### PR TITLE
Add parser support for `token` definitions

### DIFF
--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -118,9 +118,9 @@ token_part ::=
   | fn_token_part
   | abi_impl_token_part
 
-storage_token_part ::= "storage" "{" ( token_global ( "," token_global )* ","? )? "}"
+storage_token_part ::= "storage" "{" token_global* "}"
 
-token_global ::= ("indexed")? identifier ":" type_annotation
+token_global ::= ("indexed")? "let" "mut" identifier ":" type_annotation ";"
 
 fn_token_part ::= ("mint" | "burn")? function
 
@@ -406,9 +406,10 @@ displayed in IDE hover tooltips above the type information.
   - `main fn` items within the `utxo` block act as this type's constructors
   - Can be unconditionally upcast to the root `Utxo` handle
   - Can attempt to downcast from the root `Utxo` handle (returns `Result`)
-- `token Foo` syntax declares a token type. A `token` block bundles `indexed`
-  storage fields, one or more `mint`/`burn` functions, an `impl Token { … }` block
-  (with `attach`/`detach`), and ordinary functions.
+- `token Foo` syntax declares a token type. A `token` block bundles storage
+  fields (optionally `indexed`), one or more `mint` functions, zero or more
+  `burn` functions, an `impl Token { … }` block (with `attach`/`detach`), and
+  ordinary functions.
   - **Parsing only at this time.** Token definitions are recognized by the parser
     and formatter but are not yet type-checked or compiled, and the global `Token`
     type (parallel to the root `Utxo` handle) is not yet part of the type system.

--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -45,6 +45,7 @@ definition ::=
   | struct_definition
   | enum_definition
   | utxo_definition
+  | token_definition
   | abi_definition
 
 contract_definition ::= "contract" ";"
@@ -108,6 +109,22 @@ impl_part ::=
   | fn_impl_part
 
 fn_impl_part ::= function
+
+token_definition ::=
+  "token" identifier "{" token_part* "}"
+
+token_part ::=
+  | storage_token_part
+  | fn_token_part
+  | abi_impl_token_part
+
+storage_token_part ::= "storage" "{" ( token_global ( "," token_global )* ","? )? "}"
+
+token_global ::= ("indexed")? identifier ":" type_annotation
+
+fn_token_part ::= ("mint" | "burn")? function
+
+abi_impl_token_part ::= "impl" identifier "{" impl_part* "}"
 
 abi_definition ::=
   "abi" identifier "{" abi_part* "}"
@@ -389,6 +406,12 @@ displayed in IDE hover tooltips above the type information.
   - `main fn` items within the `utxo` block act as this type's constructors
   - Can be unconditionally upcast to the root `Utxo` handle
   - Can attempt to downcast from the root `Utxo` handle (returns `Result`)
+- `token Foo` syntax declares a token type. A `token` block bundles `indexed`
+  storage fields, one or more `mint`/`burn` functions, an `impl Token { … }` block
+  (with `attach`/`detach`), and ordinary functions.
+  - **Parsing only at this time.** Token definitions are recognized by the parser
+    and formatter but are not yet type-checked or compiled, and the global `Token`
+    type (parallel to the root `Utxo` handle) is not yet part of the type system.
 
 No user-defined generics at this time.
 

--- a/starstream-compiler/src/formatter.rs
+++ b/starstream-compiler/src/formatter.rs
@@ -597,11 +597,15 @@ fn token_global_to_doc<'a>(decl: &TokenGlobal, source: &'a str) -> RcDoc<'a, ()>
         RcDoc::nil()
     };
     prefix
+        .append("let")
+        .append(RcDoc::space())
+        .append("mut")
+        .append(RcDoc::space())
         .append(identifier_to_doc(&decl.name, source))
         .append(":")
         .append(RcDoc::space())
         .append(type_annotation_to_doc(&decl.ty, source))
-        .append(RcDoc::text(","))
+        .append(RcDoc::text(";"))
 }
 
 fn abi_definition_to_doc<'a>(
@@ -1510,8 +1514,8 @@ mod tests {
             r#"
             token MyToken {
                 storage {
-                    indexed my_arbitrary_variable: u32,
-                    plain_variable: u8,
+                    indexed let mut my_arbitrary_variable: u32;
+                    let mut plain_variable: u8;
                 }
                 mint fn my_mint_fn() {}
                 burn fn my_burn_fn() {}

--- a/starstream-compiler/src/formatter.rs
+++ b/starstream-compiler/src/formatter.rs
@@ -2,7 +2,7 @@ use pretty::RcDoc;
 use starstream_types::{
     AbiDef, AbiMethodDecl, AbiPart, BinaryOp, Block, Comment, CommentMap, Definition, EventDef,
     Expr, FunctionDef, FunctionExport, FunctionParam, IfCondition, Literal, Spanned, Statement,
-    TypeAnnotation, UnaryOp, UtxoDef, UtxoGlobal, UtxoPart,
+    TokenDef, TokenGlobal, TokenPart, TypeAnnotation, UnaryOp, UtxoDef, UtxoGlobal, UtxoPart,
     ast::{
         EnumConstructorPayload, EnumDef, EnumPatternPayload, EnumVariant, EnumVariantPayload,
         Identifier, ImportDef, ImportItems, ImportNamedItem, ImportSource, MatchArm, Pattern,
@@ -139,6 +139,7 @@ fn definition_to_doc<'a>(
         Definition::Struct(definition) => struct_definition_to_doc(definition, source, comments),
         Definition::Enum(definition) => enum_definition_to_doc(definition, source, comments),
         Definition::Utxo(definition) => utxo_definition_to_doc(definition, source, comments),
+        Definition::Token(definition) => token_definition_to_doc(definition, source, comments),
         Definition::Abi(definition) => abi_definition_to_doc(definition, source, comments),
     }
 }
@@ -258,6 +259,8 @@ fn function_export_to_doc<'a>(export: &FunctionExport, _source: &'a str) -> RcDo
     match export {
         FunctionExport::Script => RcDoc::text("script"),
         FunctionExport::UtxoMain => RcDoc::text("main"),
+        FunctionExport::TokenMint => RcDoc::text("mint"),
+        FunctionExport::TokenBurn => RcDoc::text("burn"),
     }
 }
 
@@ -536,6 +539,65 @@ fn utxo_global_to_doc<'a>(decl: &UtxoGlobal, source: &'a str) -> RcDoc<'a, ()> {
         .append(RcDoc::space())
         .append(type_annotation_to_doc(&decl.ty, source))
         .append(RcDoc::text(";"))
+}
+
+fn token_definition_to_doc<'a>(
+    definition: &TokenDef,
+    source: &'a str,
+    comments: &CommentMap,
+) -> RcDoc<'a, ()> {
+    RcDoc::text("token")
+        .append(RcDoc::space())
+        .append(identifier_to_doc(&definition.name, source))
+        .append(RcDoc::space())
+        .append("{")
+        .append(
+            RcDoc::line()
+                .append(RcDoc::intersperse(
+                    definition
+                        .parts
+                        .iter()
+                        .map(|x| token_part_to_doc(x, source, comments)),
+                    RcDoc::line(),
+                ))
+                .nest(INDENT),
+        )
+        .append(RcDoc::line())
+        .append("}")
+}
+
+fn token_part_to_doc<'a>(part: &TokenPart, source: &'a str, comments: &CommentMap) -> RcDoc<'a, ()> {
+    match part {
+        TokenPart::Storage(vars) => RcDoc::text("storage")
+            .append(RcDoc::space())
+            .append("{")
+            .append(
+                RcDoc::line()
+                    .append(RcDoc::intersperse(
+                        vars.iter().map(|x| token_global_to_doc(x, source)),
+                        RcDoc::line(),
+                    ))
+                    .nest(INDENT),
+            )
+            .append(RcDoc::line())
+            .append("}"),
+        TokenPart::Function(function) => function_to_doc(function, source, comments),
+        TokenPart::AbiImpl { abi, parts } => abi_impl_to_doc(abi, parts, source, comments),
+    }
+}
+
+fn token_global_to_doc<'a>(decl: &TokenGlobal, source: &'a str) -> RcDoc<'a, ()> {
+    let prefix = if decl.indexed {
+        RcDoc::text("indexed").append(RcDoc::space())
+    } else {
+        RcDoc::nil()
+    };
+    prefix
+        .append(identifier_to_doc(&decl.name, source))
+        .append(":")
+        .append(RcDoc::space())
+        .append(type_annotation_to_doc(&decl.ty, source))
+        .append(RcDoc::text(","))
 }
 
 fn abi_definition_to_doc<'a>(
@@ -1434,6 +1496,27 @@ mod tests {
             r#"
             #!/usr/bin/env starstream
             fn main() {}
+            "#,
+        );
+    }
+
+    #[test]
+    fn token_definition() {
+        assert_format_snapshot!(
+            r#"
+            token MyToken {
+                storage {
+                    indexed my_arbitrary_variable: u32,
+                    plain_variable: u8,
+                }
+                mint fn my_mint_fn() {}
+                burn fn my_burn_fn() {}
+                impl Token {
+                    fn attach(to: Utxo) {}
+                    fn detach(source: Utxo) {}
+                }
+                fn helper() {}
+            }
             "#,
         );
     }

--- a/starstream-compiler/src/formatter.rs
+++ b/starstream-compiler/src/formatter.rs
@@ -566,7 +566,11 @@ fn token_definition_to_doc<'a>(
         .append("}")
 }
 
-fn token_part_to_doc<'a>(part: &TokenPart, source: &'a str, comments: &CommentMap) -> RcDoc<'a, ()> {
+fn token_part_to_doc<'a>(
+    part: &TokenPart,
+    source: &'a str,
+    comments: &CommentMap,
+) -> RcDoc<'a, ()> {
     match part {
         TokenPart::Storage(vars) => RcDoc::text("storage")
             .append(RcDoc::space())

--- a/starstream-compiler/src/parser/definition/mod.rs
+++ b/starstream-compiler/src/parser/definition/mod.rs
@@ -11,6 +11,7 @@ mod enum_def;
 mod function;
 mod import;
 mod struct_def;
+mod token;
 mod utxo;
 
 pub use abi::parser as abi;
@@ -19,6 +20,7 @@ pub use enum_def::parser as enum_def;
 pub use function::function_with_export;
 pub use import::parser as import;
 pub use struct_def::parser as struct_def;
+pub use token::token;
 pub use utxo::utxo;
 
 pub fn parser<'a>() -> impl Parser<'a, &'a str, Definition, Extra<'a>> {
@@ -30,7 +32,8 @@ pub fn parser<'a>() -> impl Parser<'a, &'a str, Definition, Extra<'a>> {
         function_with_export(block.clone()).map(Definition::Function),
         struct_def().map(Definition::Struct),
         enum_def().map(Definition::Enum),
-        utxo(block).map(Definition::Utxo),
+        utxo(block.clone()).map(Definition::Utxo),
+        token(block).map(Definition::Token),
         abi().map(Definition::Abi),
     ))
 }

--- a/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_empty.snap
+++ b/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_empty.snap
@@ -1,0 +1,11 @@
+---
+source: starstream-compiler/src/parser/definition/token.rs
+description: "Code:\n\ntoken MyToken {}"
+---
+TokenDef {
+    name: Identifier {
+        name: "MyToken",
+        span: 6..13,
+    },
+    parts: [],
+}

--- a/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_full.snap
+++ b/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_full.snap
@@ -1,0 +1,148 @@
+---
+source: starstream-compiler/src/parser/definition/token.rs
+description: "Code:\n\ntoken MyToken {\n    storage {\n        indexed my_arbitrary_variable: u32,\n    }\n    mint fn my_mint_fn() {}\n    burn fn my_burn_fn() {}\n    impl Token {\n        fn attach(to: Utxo) {}\n        fn detach(source: Utxo) {}\n    }\n    fn helper() {}\n}\n"
+---
+TokenDef {
+    name: Identifier {
+        name: "MyToken",
+        span: 6..13,
+    },
+    parts: [
+        Storage(
+            [
+                TokenGlobal {
+                    indexed: true,
+                    name: Identifier {
+                        name: "my_arbitrary_variable",
+                        span: 46..67,
+                    },
+                    ty: TypeAnnotation {
+                        name: Identifier {
+                            name: "u32",
+                            span: 69..72,
+                        },
+                        generics: [],
+                    },
+                },
+            ],
+        ),
+        Function(
+            FunctionDef {
+                export: Some(
+                    TokenMint,
+                ),
+                name: Identifier {
+                    name: "my_mint_fn",
+                    span: 92..102,
+                },
+                params: [],
+                return_type: None,
+                body: Block {
+                    statements: [],
+                    tail_expression: None,
+                    span: 105..112,
+                },
+            },
+        ),
+        Function(
+            FunctionDef {
+                export: Some(
+                    TokenBurn,
+                ),
+                name: Identifier {
+                    name: "my_burn_fn",
+                    span: 120..130,
+                },
+                params: [],
+                return_type: None,
+                body: Block {
+                    statements: [],
+                    tail_expression: None,
+                    span: 133..140,
+                },
+            },
+        ),
+        AbiImpl {
+            abi: Identifier {
+                name: "Token",
+                span: 145..150,
+            },
+            parts: [
+                FunctionDef {
+                    export: None,
+                    name: Identifier {
+                        name: "attach",
+                        span: 164..170,
+                    },
+                    params: [
+                        FunctionParam {
+                            public: false,
+                            name: Identifier {
+                                name: "to",
+                                span: 171..173,
+                            },
+                            ty: TypeAnnotation {
+                                name: Identifier {
+                                    name: "Utxo",
+                                    span: 175..179,
+                                },
+                                generics: [],
+                            },
+                        },
+                    ],
+                    return_type: None,
+                    body: Block {
+                        statements: [],
+                        tail_expression: None,
+                        span: 181..192,
+                    },
+                },
+                FunctionDef {
+                    export: None,
+                    name: Identifier {
+                        name: "detach",
+                        span: 195..201,
+                    },
+                    params: [
+                        FunctionParam {
+                            public: false,
+                            name: Identifier {
+                                name: "source",
+                                span: 202..208,
+                            },
+                            ty: TypeAnnotation {
+                                name: Identifier {
+                                    name: "Utxo",
+                                    span: 210..214,
+                                },
+                                generics: [],
+                            },
+                        },
+                    ],
+                    return_type: None,
+                    body: Block {
+                        statements: [],
+                        tail_expression: None,
+                        span: 216..223,
+                    },
+                },
+            ],
+        },
+        Function(
+            FunctionDef {
+                export: None,
+                name: Identifier {
+                    name: "helper",
+                    span: 232..238,
+                },
+                params: [],
+                return_type: None,
+                body: Block {
+                    statements: [],
+                    tail_expression: None,
+                    span: 241..244,
+                },
+            },
+        ),
+    ],
+}

--- a/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_full.snap
+++ b/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_full.snap
@@ -1,6 +1,6 @@
 ---
 source: starstream-compiler/src/parser/definition/token.rs
-description: "Code:\n\ntoken MyToken {\n    storage {\n        indexed my_arbitrary_variable: u32,\n    }\n    mint fn my_mint_fn() {}\n    burn fn my_burn_fn() {}\n    impl Token {\n        fn attach(to: Utxo) {}\n        fn detach(source: Utxo) {}\n    }\n    fn helper() {}\n}\n"
+description: "Code:\n\ntoken MyToken {\n    storage {\n        indexed let mut my_arbitrary_variable: u32;\n    }\n    mint fn my_mint_fn() {}\n    burn fn my_burn_fn() {}\n    impl Token {\n        fn attach(to: Utxo) {}\n        fn detach(source: Utxo) {}\n    }\n    fn helper() {}\n}\n"
 ---
 TokenDef {
     name: Identifier {
@@ -14,12 +14,12 @@ TokenDef {
                     indexed: true,
                     name: Identifier {
                         name: "my_arbitrary_variable",
-                        span: 46..67,
+                        span: 54..75,
                     },
                     ty: TypeAnnotation {
                         name: Identifier {
                             name: "u32",
-                            span: 69..72,
+                            span: 77..80,
                         },
                         generics: [],
                     },
@@ -33,14 +33,14 @@ TokenDef {
                 ),
                 name: Identifier {
                     name: "my_mint_fn",
-                    span: 92..102,
+                    span: 100..110,
                 },
                 params: [],
                 return_type: None,
                 body: Block {
                     statements: [],
                     tail_expression: None,
-                    span: 105..112,
+                    span: 113..120,
                 },
             },
         ),
@@ -51,40 +51,40 @@ TokenDef {
                 ),
                 name: Identifier {
                     name: "my_burn_fn",
-                    span: 120..130,
+                    span: 128..138,
                 },
                 params: [],
                 return_type: None,
                 body: Block {
                     statements: [],
                     tail_expression: None,
-                    span: 133..140,
+                    span: 141..148,
                 },
             },
         ),
         AbiImpl {
             abi: Identifier {
                 name: "Token",
-                span: 145..150,
+                span: 153..158,
             },
             parts: [
                 FunctionDef {
                     export: None,
                     name: Identifier {
                         name: "attach",
-                        span: 164..170,
+                        span: 172..178,
                     },
                     params: [
                         FunctionParam {
                             public: false,
                             name: Identifier {
                                 name: "to",
-                                span: 171..173,
+                                span: 179..181,
                             },
                             ty: TypeAnnotation {
                                 name: Identifier {
                                     name: "Utxo",
-                                    span: 175..179,
+                                    span: 183..187,
                                 },
                                 generics: [],
                             },
@@ -94,26 +94,26 @@ TokenDef {
                     body: Block {
                         statements: [],
                         tail_expression: None,
-                        span: 181..192,
+                        span: 189..200,
                     },
                 },
                 FunctionDef {
                     export: None,
                     name: Identifier {
                         name: "detach",
-                        span: 195..201,
+                        span: 203..209,
                     },
                     params: [
                         FunctionParam {
                             public: false,
                             name: Identifier {
                                 name: "source",
-                                span: 202..208,
+                                span: 210..216,
                             },
                             ty: TypeAnnotation {
                                 name: Identifier {
                                     name: "Utxo",
-                                    span: 210..214,
+                                    span: 218..222,
                                 },
                                 generics: [],
                             },
@@ -123,7 +123,7 @@ TokenDef {
                     body: Block {
                         statements: [],
                         tail_expression: None,
-                        span: 216..223,
+                        span: 224..231,
                     },
                 },
             ],
@@ -133,14 +133,14 @@ TokenDef {
                 export: None,
                 name: Identifier {
                     name: "helper",
-                    span: 232..238,
+                    span: 240..246,
                 },
                 params: [],
                 return_type: None,
                 body: Block {
                     statements: [],
                     tail_expression: None,
-                    span: 241..244,
+                    span: 249..252,
                 },
             },
         ),

--- a/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_with_impl.snap
+++ b/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_with_impl.snap
@@ -1,0 +1,78 @@
+---
+source: starstream-compiler/src/parser/definition/token.rs
+description: "Code:\n\ntoken MyToken {\n    impl Token {\n        fn attach(to: Utxo) {}\n        fn detach(source: Utxo) {}\n    }\n}\n"
+---
+TokenDef {
+    name: Identifier {
+        name: "MyToken",
+        span: 6..13,
+    },
+    parts: [
+        AbiImpl {
+            abi: Identifier {
+                name: "Token",
+                span: 25..30,
+            },
+            parts: [
+                FunctionDef {
+                    export: None,
+                    name: Identifier {
+                        name: "attach",
+                        span: 44..50,
+                    },
+                    params: [
+                        FunctionParam {
+                            public: false,
+                            name: Identifier {
+                                name: "to",
+                                span: 51..53,
+                            },
+                            ty: TypeAnnotation {
+                                name: Identifier {
+                                    name: "Utxo",
+                                    span: 55..59,
+                                },
+                                generics: [],
+                            },
+                        },
+                    ],
+                    return_type: None,
+                    body: Block {
+                        statements: [],
+                        tail_expression: None,
+                        span: 61..72,
+                    },
+                },
+                FunctionDef {
+                    export: None,
+                    name: Identifier {
+                        name: "detach",
+                        span: 75..81,
+                    },
+                    params: [
+                        FunctionParam {
+                            public: false,
+                            name: Identifier {
+                                name: "source",
+                                span: 82..88,
+                            },
+                            ty: TypeAnnotation {
+                                name: Identifier {
+                                    name: "Utxo",
+                                    span: 90..94,
+                                },
+                                generics: [],
+                            },
+                        },
+                    ],
+                    return_type: None,
+                    body: Block {
+                        statements: [],
+                        tail_expression: None,
+                        span: 96..103,
+                    },
+                },
+            ],
+        },
+    ],
+}

--- a/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_with_indexed_storage.snap
+++ b/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_with_indexed_storage.snap
@@ -1,0 +1,44 @@
+---
+source: starstream-compiler/src/parser/definition/token.rs
+description: "Code:\n\ntoken MyToken {\n    storage {\n        indexed my_arbitrary_variable: u32,\n        plain_variable: u8,\n    }\n}\n"
+---
+TokenDef {
+    name: Identifier {
+        name: "MyToken",
+        span: 6..13,
+    },
+    parts: [
+        Storage(
+            [
+                TokenGlobal {
+                    indexed: true,
+                    name: Identifier {
+                        name: "my_arbitrary_variable",
+                        span: 46..67,
+                    },
+                    ty: TypeAnnotation {
+                        name: Identifier {
+                            name: "u32",
+                            span: 69..72,
+                        },
+                        generics: [],
+                    },
+                },
+                TokenGlobal {
+                    indexed: false,
+                    name: Identifier {
+                        name: "plain_variable",
+                        span: 82..96,
+                    },
+                    ty: TypeAnnotation {
+                        name: Identifier {
+                            name: "u8",
+                            span: 98..100,
+                        },
+                        generics: [],
+                    },
+                },
+            ],
+        ),
+    ],
+}

--- a/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_with_indexed_storage.snap
+++ b/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_with_indexed_storage.snap
@@ -1,6 +1,6 @@
 ---
 source: starstream-compiler/src/parser/definition/token.rs
-description: "Code:\n\ntoken MyToken {\n    storage {\n        indexed my_arbitrary_variable: u32,\n        plain_variable: u8,\n    }\n}\n"
+description: "Code:\n\ntoken MyToken {\n    storage {\n        indexed let mut my_arbitrary_variable: u32;\n        let mut plain_variable: u8;\n    }\n}\n"
 ---
 TokenDef {
     name: Identifier {
@@ -14,12 +14,12 @@ TokenDef {
                     indexed: true,
                     name: Identifier {
                         name: "my_arbitrary_variable",
-                        span: 46..67,
+                        span: 54..75,
                     },
                     ty: TypeAnnotation {
                         name: Identifier {
                             name: "u32",
-                            span: 69..72,
+                            span: 77..80,
                         },
                         generics: [],
                     },
@@ -28,12 +28,12 @@ TokenDef {
                     indexed: false,
                     name: Identifier {
                         name: "plain_variable",
-                        span: 82..96,
+                        span: 98..112,
                     },
                     ty: TypeAnnotation {
                         name: Identifier {
                             name: "u8",
-                            span: 98..100,
+                            span: 114..116,
                         },
                         generics: [],
                     },

--- a/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_with_mint_burn.snap
+++ b/starstream-compiler/src/parser/definition/snapshots/starstream_compiler__parser__definition__token__tests__token_with_mint_burn.snap
@@ -1,0 +1,48 @@
+---
+source: starstream-compiler/src/parser/definition/token.rs
+description: "Code:\n\ntoken MyToken {\n    mint fn my_mint_fn() {}\n    burn fn my_burn_fn() {}\n}\n"
+---
+TokenDef {
+    name: Identifier {
+        name: "MyToken",
+        span: 6..13,
+    },
+    parts: [
+        Function(
+            FunctionDef {
+                export: Some(
+                    TokenMint,
+                ),
+                name: Identifier {
+                    name: "my_mint_fn",
+                    span: 28..38,
+                },
+                params: [],
+                return_type: None,
+                body: Block {
+                    statements: [],
+                    tail_expression: None,
+                    span: 41..48,
+                },
+            },
+        ),
+        Function(
+            FunctionDef {
+                export: Some(
+                    TokenBurn,
+                ),
+                name: Identifier {
+                    name: "my_burn_fn",
+                    span: 56..66,
+                },
+                params: [],
+                return_type: None,
+                body: Block {
+                    statements: [],
+                    tail_expression: None,
+                    span: 69..72,
+                },
+            },
+        ),
+    ],
+}

--- a/starstream-compiler/src/parser/definition/token.rs
+++ b/starstream-compiler/src/parser/definition/token.rs
@@ -1,7 +1,5 @@
 use chumsky::prelude::*;
-use starstream_types::{
-    Block, FunctionDef, FunctionExport, TokenDef, TokenGlobal, TokenPart,
-};
+use starstream_types::{Block, FunctionDef, FunctionExport, TokenDef, TokenGlobal, TokenPart};
 
 use crate::parser::{
     context::Extra,

--- a/starstream-compiler/src/parser/definition/token.rs
+++ b/starstream-compiler/src/parser/definition/token.rs
@@ -1,0 +1,166 @@
+use chumsky::prelude::*;
+use starstream_types::{
+    Block, FunctionDef, FunctionExport, TokenDef, TokenGlobal, TokenPart,
+};
+
+use crate::parser::{
+    context::Extra,
+    definition::function::function,
+    primitives::{self, identifier},
+    type_annotation,
+};
+
+pub fn token<'a>(
+    block: impl Parser<'a, &'a str, Block, Extra<'a>> + Clone,
+) -> impl Parser<'a, &'a str, TokenDef, Extra<'a>> {
+    let token_global = just("indexed")
+        .padded()
+        .or_not()
+        .then(primitives::identifier())
+        .then(just(":").ignore_then(type_annotation::parser()))
+        .map(|((indexed, name), ty)| TokenGlobal {
+            indexed: indexed.is_some(),
+            name,
+            ty,
+        });
+
+    let storage_part = token_global
+        .separated_by(just(',').padded())
+        .allow_trailing()
+        .collect::<Vec<_>>()
+        .delimited_by(
+            just("storage").padded().then(just('{')).padded(),
+            just('}').padded(),
+        )
+        .map(TokenPart::Storage);
+
+    let fn_part = choice((
+        just("mint").to(FunctionExport::TokenMint),
+        just("burn").to(FunctionExport::TokenBurn),
+    ))
+    .padded()
+    .or_not()
+    .then(function(block.clone()))
+    .map(|(modifier, def)| {
+        TokenPart::Function(
+            FunctionDef {
+                export: modifier,
+                ..def
+            }
+            .into(),
+        )
+    });
+
+    let abi_impl_part = just("impl")
+        .padded()
+        .ignore_then(identifier())
+        .padded()
+        .then(
+            function(block)
+                .repeated()
+                .collect::<Vec<_>>()
+                .delimited_by(just('{').padded(), just('}').padded()),
+        )
+        .map(|(abi, parts)| TokenPart::AbiImpl { abi, parts });
+
+    let part = choice((storage_part, fn_part, abi_impl_part));
+
+    just("token")
+        .padded()
+        .ignore_then(primitives::identifier())
+        .then(
+            part.repeated()
+                .collect::<Vec<_>>()
+                .delimited_by(just('{').padded(), just('}').padded()),
+        )
+        .map(|(name, parts)| TokenDef { name, parts })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+
+    macro_rules! assert_token_snapshot {
+        ($code:expr) => {{
+            let (_, block, _) = $crate::parser::recursives();
+            let parsed = token(block)
+                .parse(indoc! { $code })
+                .into_result()
+                .expect("token should parse");
+
+            insta::with_settings!({
+                description => format!("Code:\n\n{}", indoc! { $code }),
+                omit_expression => true,
+                prepend_module_to_snapshot => true,
+            }, {
+                insta::assert_debug_snapshot!(parsed);
+            });
+        }};
+    }
+
+    #[test]
+    fn token_empty() {
+        assert_token_snapshot!("token MyToken {}");
+    }
+
+    #[test]
+    fn token_with_indexed_storage() {
+        assert_token_snapshot!(
+            r#"
+            token MyToken {
+                storage {
+                    indexed my_arbitrary_variable: u32,
+                    plain_variable: u8,
+                }
+            }
+            "#
+        );
+    }
+
+    #[test]
+    fn token_with_mint_burn() {
+        assert_token_snapshot!(
+            r#"
+            token MyToken {
+                mint fn my_mint_fn() {}
+                burn fn my_burn_fn() {}
+            }
+            "#
+        );
+    }
+
+    #[test]
+    fn token_with_impl() {
+        assert_token_snapshot!(
+            r#"
+            token MyToken {
+                impl Token {
+                    fn attach(to: Utxo) {}
+                    fn detach(source: Utxo) {}
+                }
+            }
+            "#
+        );
+    }
+
+    #[test]
+    fn token_full() {
+        assert_token_snapshot!(
+            r#"
+            token MyToken {
+                storage {
+                    indexed my_arbitrary_variable: u32,
+                }
+                mint fn my_mint_fn() {}
+                burn fn my_burn_fn() {}
+                impl Token {
+                    fn attach(to: Utxo) {}
+                    fn detach(source: Utxo) {}
+                }
+                fn helper() {}
+            }
+            "#
+        );
+    }
+}

--- a/starstream-compiler/src/parser/definition/token.rs
+++ b/starstream-compiler/src/parser/definition/token.rs
@@ -14,8 +14,10 @@ pub fn token<'a>(
     let token_global = just("indexed")
         .padded()
         .or_not()
+        .then_ignore(just("let").padded().then(just("mut")).padded())
         .then(primitives::identifier())
         .then(just(":").ignore_then(type_annotation::parser()))
+        .then_ignore(just(';').padded())
         .map(|((indexed, name), ty)| TokenGlobal {
             indexed: indexed.is_some(),
             name,
@@ -23,8 +25,7 @@ pub fn token<'a>(
         });
 
     let storage_part = token_global
-        .separated_by(just(',').padded())
-        .allow_trailing()
+        .repeated()
         .collect::<Vec<_>>()
         .delimited_by(
             just("storage").padded().then(just('{')).padded(),
@@ -108,8 +109,8 @@ mod tests {
             r#"
             token MyToken {
                 storage {
-                    indexed my_arbitrary_variable: u32,
-                    plain_variable: u8,
+                    indexed let mut my_arbitrary_variable: u32;
+                    let mut plain_variable: u8;
                 }
             }
             "#
@@ -148,7 +149,7 @@ mod tests {
             r#"
             token MyToken {
                 storage {
-                    indexed my_arbitrary_variable: u32,
+                    indexed let mut my_arbitrary_variable: u32;
                 }
                 mint fn my_mint_fn() {}
                 burn fn my_burn_fn() {}

--- a/starstream-compiler/src/snapshots/starstream_compiler__formatter__tests__token_definition.snap
+++ b/starstream-compiler/src/snapshots/starstream_compiler__formatter__tests__token_definition.snap
@@ -1,11 +1,11 @@
 ---
 source: starstream-compiler/src/formatter.rs
-description: "Code:\n\ntoken MyToken {\n    storage {\n        indexed my_arbitrary_variable: u32,\n        plain_variable: u8,\n    }\n    mint fn my_mint_fn() {}\n    burn fn my_burn_fn() {}\n    impl Token {\n        fn attach(to: Utxo) {}\n        fn detach(source: Utxo) {}\n    }\n    fn helper() {}\n}\n"
+description: "Code:\n\ntoken MyToken {\n    storage {\n        indexed let mut my_arbitrary_variable: u32;\n        let mut plain_variable: u8;\n    }\n    mint fn my_mint_fn() {}\n    burn fn my_burn_fn() {}\n    impl Token {\n        fn attach(to: Utxo) {}\n        fn detach(source: Utxo) {}\n    }\n    fn helper() {}\n}\n"
 ---
 token MyToken {
     storage {
-        indexed my_arbitrary_variable: u32,
-        plain_variable: u8,
+        indexed let mut my_arbitrary_variable: u32;
+        let mut plain_variable: u8;
     }
     mint fn my_mint_fn() { }
     burn fn my_burn_fn() { }

--- a/starstream-compiler/src/snapshots/starstream_compiler__formatter__tests__token_definition.snap
+++ b/starstream-compiler/src/snapshots/starstream_compiler__formatter__tests__token_definition.snap
@@ -1,0 +1,17 @@
+---
+source: starstream-compiler/src/formatter.rs
+description: "Code:\n\ntoken MyToken {\n    storage {\n        indexed my_arbitrary_variable: u32,\n        plain_variable: u8,\n    }\n    mint fn my_mint_fn() {}\n    burn fn my_burn_fn() {}\n    impl Token {\n        fn attach(to: Utxo) {}\n        fn detach(source: Utxo) {}\n    }\n    fn helper() {}\n}\n"
+---
+token MyToken {
+    storage {
+        indexed my_arbitrary_variable: u32,
+        plain_variable: u8,
+    }
+    mint fn my_mint_fn() { }
+    burn fn my_burn_fn() { }
+    impl Token {
+        fn attach(to: Utxo) { }
+        fn detach(source: Utxo) { }
+    }
+    fn helper() { }
+}

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -8,8 +8,8 @@ use std::{
 
 use starstream_types::{
     Abi, AbiDef, AbiPart, DUMMY_SPAN, EffectKind, EventDef, GenericTypeDef, IfCondition, IntWidth,
-    Scheme, Span, Spanned, Type, TypeParam, TypeVarId, TypedUtxoDef, TypedUtxoGlobal,
-    TypedUtxoPart, UtxoDef, UtxoGlobal, UtxoPart,
+    Scheme, Span, Spanned, Type, TypeParam, TypeVarId, TypedTokenDef, TypedUtxoDef,
+    TypedUtxoGlobal, TypedUtxoPart, UtxoDef, UtxoGlobal, UtxoPart,
     ast::{
         BinaryOp, Block, Definition, EnumConstructorPayload, EnumDef, EnumPatternPayload,
         EnumVariantPayload, Expr, FunctionDef, Identifier, ImportDef, ImportItems, ImportSource,
@@ -676,6 +676,8 @@ fn collect_exports(typed_definitions: &[TypedDefinition]) -> ModuleExports {
             TypedDefinition::Utxo(u) => {
                 exports.types.insert(u.name.name.clone());
             }
+            // `token` is parse-only for now: no exported type yet.
+            TypedDefinition::Token(_) => {}
             TypedDefinition::Import(_) => {}
             TypedDefinition::Contract => {}
         }
@@ -963,6 +965,9 @@ impl Inferencer {
                 Definition::Enum(def) => self.register_enum(def)?,
                 Definition::Function(_) => {}
                 Definition::Utxo(def) => self.register_utxo(def)?,
+                // `token` definitions are parse-only for now: no type is
+                // registered yet (the global `Token` type is a follow-up).
+                Definition::Token(_) => {}
                 Definition::Abi(def) => self.register_abi(def)?,
             }
         }
@@ -2167,6 +2172,16 @@ impl Inferencer {
                 let (utxo, trace) = self.infer_utxo(env, def)?;
 
                 Ok((TypedDefinition::Utxo(utxo), trace))
+            }
+            Definition::Token(def) => {
+                // Parse-only for now: lower to a shallow marker without
+                // type-checking the body. Semantics land in a follow-up.
+                let typed = TypedTokenDef {
+                    name: def.name.clone(),
+                    span: def.name.span(),
+                };
+
+                Ok((TypedDefinition::Token(typed), InferenceTree::default()))
             }
             Definition::Abi(def) => {
                 let typed = self.build_typed_abi(def)?;
@@ -4658,6 +4673,7 @@ impl Inferencer {
             | TypedDefinition::Struct(_)
             | TypedDefinition::Enum(_)
             | TypedDefinition::Abi(_)
+            | TypedDefinition::Token(_)
             | TypedDefinition::Contract => {}
         }
     }

--- a/starstream-language-server/src/document.rs
+++ b/starstream-language-server/src/document.rs
@@ -627,6 +627,9 @@ impl DocumentState {
                 self.collect_enum(definition, untyped_enum, source, doc.clone())
             }
             TypedDefinition::Utxo(definition) => self.collect_utxo(definition, scopes),
+            TypedDefinition::Token(_) => {
+                // `token` is parse-only for now: no symbols/hover yet.
+            }
             TypedDefinition::Abi(definition) => {
                 let untyped_abi = untyped.and_then(|u| match &u.node {
                     untyped_ast::Definition::Abi(a) => Some(a),
@@ -1711,6 +1714,9 @@ impl DocumentState {
                         }
                     }
                 }
+                untyped_ast::Definition::Token(_) => {
+                    // `token` is parse-only for now: no annotations collected yet.
+                }
                 untyped_ast::Definition::Import(_) => {
                     // Imports don't have type annotations to collect
                 }
@@ -1991,7 +1997,9 @@ impl DocumentState {
             .definitions
             .iter()
             .filter_map(|definition| match definition {
-                TypedDefinition::Import(_) | TypedDefinition::Contract => None,
+                TypedDefinition::Import(_)
+                | TypedDefinition::Token(_)
+                | TypedDefinition::Contract => None,
                 TypedDefinition::Function(function) => self.function_symbol(function),
                 TypedDefinition::Struct(definition) => self.struct_symbol(definition),
                 TypedDefinition::Enum(definition) => self.enum_symbol(definition),

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -1283,6 +1283,7 @@ impl Compiler {
                 TypedDefinition::Import(_) => { /* Handled above. */ }
                 TypedDefinition::Abi(_) => { /* Handled above. */ }
                 TypedDefinition::Contract => { /* Pure marker, no codegen. */ }
+                TypedDefinition::Token(_) => { /* Token codegen not yet supported. */ }
 
                 TypedDefinition::Function(func) => {
                     self.visit_function(&to_kebab_case(func.name.as_str()), func, &())
@@ -1494,6 +1495,8 @@ impl Compiler {
             Some(FunctionExport::Script) | Some(FunctionExport::UtxoMain) => {
                 self.export_component_fn(wit_name, function, idx, &params, &results);
             }
+            // Token mint/burn functions are parse-only for now; no codegen.
+            Some(FunctionExport::TokenMint) | Some(FunctionExport::TokenBurn) => {}
             None => {}
         }
     }

--- a/starstream-types/src/ast.rs
+++ b/starstream-types/src/ast.rs
@@ -165,6 +165,7 @@ pub enum Definition {
     Struct(StructDef),
     Enum(EnumDef),
     Utxo(UtxoDef),
+    Token(TokenDef),
     Abi(AbiDef),
     /// `contract;` — marks the file as a contract entry point. May appear
     /// anywhere at the top level; the formatter moves it to the top. The
@@ -238,6 +239,10 @@ pub enum FunctionExport {
     Script,
     /// `utxo { main fn }`
     UtxoMain,
+    /// `token { mint fn }`
+    TokenMint,
+    /// `token { burn fn }`
+    TokenBurn,
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq)]
@@ -307,6 +312,31 @@ pub type AbiImplPart = FunctionDef;
 
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct UtxoGlobal {
+    pub name: Identifier,
+    pub ty: TypeAnnotation,
+}
+
+/// `token` definition.
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct TokenDef {
+    pub name: Identifier,
+    pub parts: Vec<TokenPart>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub enum TokenPart {
+    Storage(Vec<TokenGlobal>),
+    Function(Box<FunctionDef>),
+    AbiImpl {
+        abi: Identifier,
+        parts: Vec<AbiImplPart>,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct TokenGlobal {
+    /// Whether the field carries the `indexed` modifier.
+    pub indexed: bool,
     pub name: Identifier,
     pub ty: TypeAnnotation,
 }

--- a/starstream-types/src/typed_ast.rs
+++ b/starstream-types/src/typed_ast.rs
@@ -30,6 +30,7 @@ pub enum TypedDefinition {
     Struct(TypedStructDef),
     Enum(TypedEnumDef),
     Utxo(TypedUtxoDef),
+    Token(TypedTokenDef),
     Abi(TypedAbiDef),
     /// `contract;` marker carried through from the AST.
     Contract,
@@ -158,6 +159,15 @@ pub enum TypedUtxoPart {
 pub struct TypedUtxoGlobal {
     pub name: Identifier,
     pub ty: Type,
+}
+
+/// Shallow typed marker for a `token` definition. Token bodies are not yet
+/// type-checked; this carries just the name/span so the definition survives
+/// lowering. Fleshed out alongside the global `Token` type in a follow-up.
+#[derive(Clone, Debug)]
+pub struct TypedTokenDef {
+    pub name: Identifier,
+    pub span: Span,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Adds a new top-level `token` definition, structurally parallel to the existing `utxo` definition. A `token` block bundles `indexed` storage fields, one or more `mint`/`burn` functions, an `impl Token { ... }` block, and ordinary functions:

```starstream
token MyToken {
    storage {
        indexed my_arbitrary_variable: u32,
        plain_variable: u8,
    }
    mint fn my_mint_fn() {}
    burn fn my_burn_fn() {}
    impl Token {
        fn attach(to: Utxo) {}
        fn detach(source: Utxo) {}
    }
    fn helper() {}
}
```

This first pass is **parsing only**. The parser and formatter fully support `token` blocks; typecheck, codegen, and the language server carry inert "not yet supported" arms so the workspace still compiles. Semantic checking, codegen, and the global `Token` type (parallel to the root `Utxo` handle) are explicit follow-ups.

## Changes

- **AST** (`starstream-types/src/ast.rs`): `Definition::Token`, `TokenDef` / `TokenPart` / `TokenGlobal { indexed: bool }`, and `FunctionExport::{TokenMint, TokenBurn}`. Shallow typed marker `TypedDefinition::Token(TypedTokenDef)` in `typed_ast.rs`.
- **Parser** (new `starstream-compiler/src/parser/definition/token.rs`): mirrors `utxo.rs`. `indexed` is an optional per-field modifier; storage fields are comma-separated with an optional trailing comma; `mint`/`burn` map to the new function exports. Wired into the top-level `choice()`.
- **Formatter**: full round-trip support (`token_definition_to_doc` and helpers, `mint`/`burn` rendering).
- **Downstream stubs**: typecheck (`infer.rs`), codegen (`starstream-to-wasm`), and LSP (`document.rs`) get inert arms for the new variants.
- **Spec** (`docs/language-spec.md`): added the `token_definition` grammar and a `token Foo` entry noting it is parse-only for now.

### Keywords

`token` / `mint` / `burn` / `indexed` are **contextual** keywords (recognized inline at the parser level), consistent with how `utxo` / `storage` / `main` / `impl` already work — so they are **not** added to the reserved word list.

## Tests

Five parser snapshot tests (empty / indexed storage / mint+burn / impl / full) plus one formatter round-trip test. All 233 compiler tests pass, along with the `starstream-types`, `starstream-to-wasm`, and `starstream-language-server` suites.

## Notes

- The original spec example used `fn detach(from: Utxo)`, but `from` is a reserved keyword, so the tests use `source`. Worth deciding later whether `from` should be usable as a parameter name.
- The tree-sitter grammar and VSCode language config (called out in the spec's grammar NOTE) are not updated here — left for a follow-up.