### PR TITLE
build(rust): add wasm32-unknown-unknown target to toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - run: rustup target add wasm32-unknown-unknown
       - run: rustup component add clippy rustfmt
       # Enforce lockfile correctness.
       - run: cargo check --locked
@@ -33,7 +32,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - run: rustup target add wasm32-unknown-unknown
       - name: Install binaryen
         run: |
           curl -o binaryen.tar.gz --no-progress-meter -L https://github.com/WebAssembly/binaryen/releases/download/version_124/binaryen-version_124-x86_64-linux.tar.gz

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.89.0"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Add `wasm32-unknown-unknown` target to `rust-toolchain.toml` to remove the need of explicit install (rustup will automatically pick this up)