### PR TITLE
feat(website/sandbox): add Run panel

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,12 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
+    # Emit Wasm imports for the JS-provided host functions the sandbox declares
+    # in `extern` blocks (`read_input`, `set_*`, …). These are resolved by the
+    # host at instantiation, never at link time; without this, `rust-lld` (since
+    # the 1.96 toolchain) rejects them as undefined symbols instead of importing
+    # them. Harmless for the wasm-bindgen-based `language-server-web`, which has
+    # no such raw imports.
+    "-Clink-arg=--import-undefined",
     # This adds __indirect_function_table to the exports which is needed for
     # the host to be able to call function pointers directly.
     "-Clink-arg=--export-table",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,14 +3729,19 @@ dependencies = [
 name = "starstream-sandbox-web"
 version = "0.0.0"
 dependencies = [
+ "cranelift-codegen 0.134.0",
  "log",
  "miette",
  "serde",
  "serde_cbor",
+ "serde_json",
+ "sha2",
  "starstream-compiler",
+ "starstream-runtime-next",
  "starstream-to-wasm",
  "termcolor",
  "wasmprinter 0.240.0",
+ "wasmtime 47.0.0",
  "wit-component",
 ]
 

--- a/starstream-sandbox-web/Cargo.toml
+++ b/starstream-sandbox-web/Cargo.toml
@@ -16,8 +16,17 @@ log = "0.4.28"
 miette.workspace = true
 serde.workspace = true
 serde_cbor = "0.11.2"
+serde_json.workspace = true
+sha2 = "0.10.9"
 starstream-compiler.workspace = true
 starstream-to-wasm.workspace = true
 termcolor = "1.4.1"
+starstream-runtime-next = { workspace = true, features = [
+    "wasmtime-custom-virtual-memory",
+] }
+wasmtime = { workspace = true }
+cranelift-codegen = { version = "0.134", default-features = false, features = [
+    "timing",
+] }
 wasmprinter = { workspace = true, features = ["component-model"] }
 wit-component.workspace = true

--- a/starstream-sandbox-web/build.rs
+++ b/starstream-sandbox-web/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Cranelift recursion (egraph, regalloc) overflows the default 1 MiB
+    // shadow stack when compiling a component in `deploy`; give it headroom.
+    if std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
+        println!("cargo::rustc-link-arg=-zstack-size=4194304");
+    }
+}

--- a/starstream-sandbox-web/src/lib.rs
+++ b/starstream-sandbox-web/src/lib.rs
@@ -1,7 +1,26 @@
-//! WebAssembly bindings for the Starstream compiler.
+//! WebAssembly bindings for the Starstream compiler and contract runtime,
+//! driven over a small C ABI by two Web Workers (`website/src/*.worker.ts`): a
+//! compile worker ([`run`]) and a run worker ([`deploy`] + [`construct`],
+//! [`call`], …).
+//!
+//! The contract runtime is `starstream-runtime-next`, driven through its *sync*
+//! APIs; values cross the JS boundary as JSON, lowered to/from
+//! [`wasmtime::component::Val`] against each function's declared type.
+mod platform;
+
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashSet};
 use std::panic;
+use std::rc::Rc;
 
 use log::error;
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+use starstream_runtime_next::{
+    Contract, EventHandler, Utxo, UtxoExport, bindings, new_wasmtime_config,
+};
+use wasmtime::AsContext as _;
+use wasmtime::component::{Type, Val, types};
 use wit_component::{ComponentEncoder, DecodedWasm};
 
 // Imports to manipulate the UI contents, provided by the JS page.
@@ -20,6 +39,88 @@ unsafe extern "C" {
     unsafe fn set_core_wasm(ptr: *const u8, len: usize);
     unsafe fn set_wit(ptr: *const u8, len: usize);
     unsafe fn set_component_wasm(ptr: *const u8, len: usize);
+
+    // JSON sinks back to the page (see the function producing each).
+    unsafe fn set_describe(ptr: *const u8, len: usize);
+    unsafe fn set_call_result(ptr: *const u8, len: usize);
+    unsafe fn set_storage(ptr: *const u8, len: usize);
+    unsafe fn set_implemented(ptr: *const u8, len: usize);
+    unsafe fn set_events(ptr: *const u8, len: usize);
+}
+
+/// A 256-bit `implements-method` hash, as four `u64` words from the guest.
+type MethodHash = (u64, u64, u64, u64);
+
+/// Cardano context observable via `starstream:std/cardano`, set from the page.
+#[derive(Clone, Copy, Default)]
+struct CardanoCtx {
+    block_height: i64,
+    current_slot: i64,
+}
+
+/// Per-instantiation store data.
+///
+/// `events` is shared with the owning [`Deployment`] so emissions from any
+/// instantiation collect in one place. `implemented` is per-instantiation: the
+/// guest constructor populates it via `implements-method`, and [`call`] gates
+/// invocations on it.
+#[derive(Clone, Default)]
+struct Ctx {
+    cardano: CardanoCtx,
+    implemented: HashSet<MethodHash>,
+    events: Rc<RefCell<Vec<Value>>>,
+}
+
+impl bindings::starstream::std::builtin::Host for Ctx {
+    fn implements_method(&mut self, hash: MethodHash) -> wasmtime::Result<()> {
+        self.implemented.insert(hash);
+        Ok(())
+    }
+}
+
+impl bindings::starstream::std::cardano::Host for Ctx {
+    fn block_height(&mut self) -> i64 {
+        self.cardano.block_height
+    }
+
+    fn current_slot(&mut self) -> i64 {
+        self.cardano.current_slot
+    }
+}
+
+impl EventHandler for Ctx {
+    fn emit_event(&mut self, instance: &str, name: &str, params: &[Val]) {
+        let args: Vec<Value> = params
+            .iter()
+            .map(|v| val_to_json(v).unwrap_or_else(Value::String))
+            .collect();
+        self.events.borrow_mut().push(json!({
+            "instance": instance,
+            "name": name,
+            "params": args,
+        }));
+    }
+}
+
+/// A live `utxo` handle: the instance plus the export it came from.
+struct Handle {
+    export: UtxoExport,
+    utxo: Utxo<Ctx>,
+}
+
+/// A deployed contract and its table of live UTXO handles.
+struct Deployment {
+    contract: Contract<Ctx>,
+    handles: BTreeMap<u32, Handle>,
+    next_id: u32,
+    cardano: CardanoCtx,
+    events: Rc<RefCell<Vec<Value>>>,
+}
+
+thread_local! {
+    /// Deployed contracts keyed by digest. Thread-local because a live [`Utxo`]
+    /// store is neither `Send` nor `Sync`; the sandbox is single-threaded.
+    static CONTRACTS: RefCell<BTreeMap<u32, Deployment>> = const { RefCell::new(BTreeMap::new()) };
 }
 
 #[derive(serde::Deserialize)]
@@ -27,28 +128,48 @@ struct Input<'a> {
     code: &'a str,
 }
 
+/// Set up output and panic context. Idempotent: the one-time global setup
+/// (logger, panic hook, Cranelift profiler) runs only on the first call, so
+/// every exported entrypoint can call it cheaply.
+fn init() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        /// Cranelift profiler that does nothing: the default one calls
+        /// `Instant::now()`, which panics on wasm32-unknown-unknown.
+        struct CraneliftProfiler;
+        impl cranelift_codegen::timing::Profiler for CraneliftProfiler {
+            fn start_pass(&self, _pass: cranelift_codegen::timing::Pass) -> Box<dyn std::any::Any> {
+                Box::new(())
+            }
+        }
+        _ = cranelift_codegen::timing::set_thread_profiler(Box::new(CraneliftProfiler));
+
+        _ = log::set_logger(&LOGGER);
+        log::set_max_level(log::LevelFilter::Trace);
+        panic::set_hook(Box::new(|info| {
+            if let Some(s) = info.payload().downcast_ref::<&str>() {
+                error!("panic! {s}");
+            } else if let Some(s) = info.payload().downcast_ref::<String>() {
+                error!("panic! {s}");
+            } else {
+                error!("panic!");
+            }
+            if let Some(loc) = info.location() {
+                error!("at {}:{}:{}", loc.file(), loc.line(), loc.column());
+            }
+        }));
+    });
+}
+
+/// Compile the CBOR [`Input`] from `read_input` to core/WIT/component.
+///
 /// # Safety
 ///
-/// Exports to do work, called by the JS page.
+/// `input_len` must equal the number of bytes the host staged for `read_input`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn run(input_len: usize) {
-    // Set up output and panic context.
-    _ = log::set_logger(&LOGGER);
-    log::set_max_level(log::LevelFilter::Trace);
-    panic::set_hook(Box::new(|info| {
-        if let Some(s) = info.payload().downcast_ref::<&str>() {
-            error!("panic! {s}");
-        } else if let Some(s) = info.payload().downcast_ref::<String>() {
-            error!("panic! {s}");
-        } else {
-            error!("panic!");
-        }
-        if let Some(loc) = info.location() {
-            error!("at {}:{}:{}", loc.file(), loc.line(), loc.column());
-        }
-    }));
+    init();
 
-    // Fetch the input.
     let mut input = vec![0; input_len];
     unsafe { read_input(input.as_mut_ptr(), input.len()) };
     let input: Input = serde_cbor::from_slice(&input).unwrap();
@@ -133,6 +254,535 @@ pub unsafe extern "C" fn run(input_len: usize) {
         }
     }
 }
+
+// ----------------------------------------------------------------------------
+// Run tab: deploy and drive a compiled contract.
+
+fn read_input_bytes(input_len: usize) -> Vec<u8> {
+    let mut input = vec![0; input_len];
+    unsafe { read_input(input.as_mut_ptr(), input.len()) };
+    input
+}
+
+/// Flush and report the ABI events buffered during an operation.
+fn flush_events(events: &Rc<RefCell<Vec<Value>>>) {
+    let drained: Vec<Value> = std::mem::take(&mut events.borrow_mut());
+    if drained.is_empty() {
+        return;
+    }
+    let json = Value::Array(drained).to_string();
+    unsafe { set_events(json.as_ptr(), json.len()) };
+}
+
+#[derive(serde::Deserialize)]
+struct DeployInput<'a> {
+    /// Digest of `wasm`, identifying the contract.
+    digest: u32,
+    /// The component Wasm.
+    wasm: &'a [u8],
+}
+
+fn handle_deploy(input_len: usize) -> Result<(), Box<dyn std::error::Error>> {
+    let input = read_input_bytes(input_len);
+    let DeployInput { digest, wasm } = serde_cbor::from_slice(&input)?;
+
+    let engine = wasmtime::Engine::new(&new_wasmtime_config())?;
+    let contract = Contract::<Ctx>::new(&engine, wasm)?;
+    let describe = describe(&contract)?;
+
+    CONTRACTS.with_borrow_mut(|contracts| {
+        contracts.insert(
+            digest,
+            Deployment {
+                contract,
+                handles: BTreeMap::new(),
+                next_id: 0,
+                cardano: CardanoCtx::default(),
+                events: Rc::default(),
+            },
+        );
+    });
+    unsafe { set_describe(describe.as_ptr(), describe.len()) };
+    Ok(())
+}
+
+/// Deploy a contract, reporting its instances via `set_describe`. Returns 0, or
+/// -1 on failure.
+///
+/// # Safety
+///
+/// `input_len` must equal the number of bytes the host staged for `read_input`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn deploy(input_len: usize) -> i32 {
+    init();
+    match handle_deploy(input_len) {
+        Ok(()) => 0,
+        Err(error) => {
+            error!("deploy: {error}");
+            -1
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct ConstructInput {
+    /// Digest of the contract, as passed to `deploy`.
+    digest: u32,
+    /// Export name of the UTXO-owning instance.
+    instance: String,
+    /// Export name of the `[static]` constructor to call.
+    constructor: String,
+    /// One JSON value per constructor parameter.
+    args: Vec<Value>,
+}
+
+fn handle_construct(input_len: usize) -> Result<u32, Box<dyn std::error::Error>> {
+    let input = read_input_bytes(input_len);
+    let ConstructInput {
+        digest,
+        instance,
+        constructor,
+        args,
+    } = serde_json::from_slice(&input)?;
+
+    CONTRACTS.with_borrow_mut(|contracts| {
+        let dep = contracts.get_mut(&digest).ok_or("contract not found")?;
+        let export = dep.contract.get_utxo(&instance)?;
+        let ctor = dep.contract.get_utxo_constructor(&export, &constructor)?;
+        let params = convert_args(ctor.ty().params(), 0, &args)?;
+        let ctx = Ctx {
+            cardano: dep.cardano,
+            implemented: HashSet::new(),
+            events: Rc::clone(&dep.events),
+        };
+        let utxo = dep.contract.create_utxo(
+            wasmtime::Store::new(dep.contract.engine(), ctx),
+            &ctor,
+            &params,
+        )?;
+        let id = dep.next_id;
+        dep.next_id += 1;
+        dep.handles.insert(id, Handle { export, utxo });
+        flush_events(&dep.events);
+        Ok(id)
+    })
+}
+
+/// Mint a UTXO via a `[static]` constructor. Returns the new handle id, or -1
+/// on failure.
+///
+/// # Safety
+///
+/// `input_len` must equal the number of bytes the host staged for `read_input`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn construct(input_len: usize) -> i32 {
+    init();
+    match handle_construct(input_len) {
+        Ok(id) => id as i32,
+        Err(error) => {
+            error!("construct: {error}");
+            -1
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct CallInput {
+    /// Digest of the contract, as passed to `deploy`.
+    digest: u32,
+    /// Number of the UTXO handle to call, as returned by `construct`. The handle
+    /// already carries its instance export, so no instance name is needed.
+    handle: u32,
+    /// Export name of the `[method]` to invoke.
+    method: String,
+    /// One JSON value per method parameter (excluding the `self` receiver).
+    args: Vec<Value>,
+}
+
+fn handle_call(input_len: usize) -> Result<(), Box<dyn std::error::Error>> {
+    let input = read_input_bytes(input_len);
+    let CallInput {
+        digest,
+        handle,
+        method,
+        args,
+    } = serde_json::from_slice(&input)?;
+
+    CONTRACTS.with_borrow_mut(|contracts| {
+        let Deployment {
+            contract,
+            handles,
+            events,
+            ..
+        } = contracts.get_mut(&digest).ok_or("contract not found")?;
+        let handle = handles.get_mut(&handle).ok_or("handle not found")?;
+        let method_export = contract.get_utxo_method(&handle.export, &method)?;
+
+        // Only callable if the UTXO declared this method via `implements-method`.
+        let hash = method_hash(&method);
+        if !handle.utxo.as_context().data().implemented.contains(&hash) {
+            return Err(format!(
+                "method `{method}` is not callable: this UTXO did not declare it via `implements-method`"
+            )
+            .into());
+        }
+
+        let params = convert_args(method_export.ty().params(), 1, &args)?;
+        let mut full = Vec::with_capacity(params.len() + 1);
+        full.push(Val::Resource(handle.utxo.resource()));
+        full.extend(params);
+
+        let results = handle.utxo.call(&method_export, &full)?;
+        let results = results
+            .iter()
+            .map(val_to_json)
+            .collect::<Result<Vec<Value>, String>>()?;
+        let json = serde_json::to_string(&results)?;
+        unsafe { set_call_result(json.as_ptr(), json.len()) };
+        flush_events(events);
+        Ok(())
+    })
+}
+
+/// Invoke a `[method]` on a live UTXO handle, reporting results via
+/// `set_call_result`. Returns 0, or -1 on failure.
+///
+/// # Safety
+///
+/// `input_len` must equal the number of bytes the host staged for `read_input`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn call(input_len: usize) -> i32 {
+    init();
+    match handle_call(input_len) {
+        Ok(()) => 0,
+        Err(error) => {
+            error!("call: {error}");
+            -1
+        }
+    }
+}
+
+fn handle_storage_get(digest: u32, handle: u32) -> Result<(), Box<dyn std::error::Error>> {
+    CONTRACTS.with_borrow_mut(|contracts| {
+        let dep = contracts.get_mut(&digest).ok_or("contract not found")?;
+        let handle = dep.handles.get_mut(&handle).ok_or("handle not found")?;
+        let storage = handle
+            .export
+            .storage()
+            .cloned()
+            .ok_or("this resource has no storage")?;
+        let fields = handle.utxo.storage(&storage).get()?;
+        let obj = fields
+            .iter()
+            .map(|(name, val)| Ok((name.clone(), val_to_json(val)?)))
+            .collect::<Result<Map<String, Value>, String>>()?;
+        let json = Value::Object(obj).to_string();
+        unsafe { set_storage(json.as_ptr(), json.len()) };
+        Ok(())
+    })
+}
+
+/// Reads a live UTXO handle's `storage` record as a JSON object, reported via
+/// `set_storage`. Returns 0, or -1 on failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn storage_get(digest: u32, handle: u32) -> i32 {
+    init();
+    match handle_storage_get(digest, handle) {
+        Ok(()) => 0,
+        Err(error) => {
+            error!("storage_get: {error}");
+            -1
+        }
+    }
+}
+
+fn handle_implemented_methods(digest: u32, handle: u32) -> Result<(), Box<dyn std::error::Error>> {
+    CONTRACTS.with_borrow_mut(|contracts| {
+        let dep = contracts.get_mut(&digest).ok_or("contract not found")?;
+        let handle = dep.handles.get(&handle).ok_or("handle not found")?;
+        let declared = handle.utxo.as_context().data().implemented.clone();
+        let names: Vec<&str> = dep
+            .contract
+            .utxo_methods(&handle.export)
+            .filter_map(|(name, method)| method.ok().map(|_| name))
+            .filter(|name| declared.contains(&method_hash(name)))
+            .collect();
+        let json = serde_json::to_string(&names)?;
+        unsafe { set_implemented(json.as_ptr(), json.len()) };
+        Ok(())
+    })
+}
+
+/// Lists the method export names a live UTXO handle has declared callable via
+/// `implements-method`, reported as a JSON array via `set_implemented`. Returns
+/// 0, or -1 on failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn implemented_methods(digest: u32, handle: u32) -> i32 {
+    init();
+    match handle_implemented_methods(digest, handle) {
+        Ok(()) => 0,
+        Err(error) => {
+            error!("implemented_methods: {error}");
+            -1
+        }
+    }
+}
+
+fn handle_drop_resource(digest: u32, handle: u32) -> Result<(), Box<dyn std::error::Error>> {
+    CONTRACTS.with_borrow_mut(|contracts| {
+        let dep = contracts.get_mut(&digest).ok_or("contract not found")?;
+        let handle = dep.handles.remove(&handle).ok_or("handle not found")?;
+        handle.utxo.drop()?;
+        flush_events(&dep.events);
+        Ok(())
+    })
+}
+
+/// Drops a live UTXO handle, running the guest resource's destructor. Returns 0,
+/// or -1 on failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn drop_resource(digest: u32, handle: u32) -> i32 {
+    init();
+    match handle_drop_resource(digest, handle) {
+        Ok(()) => 0,
+        Err(error) => {
+            error!("drop_resource: {error}");
+            -1
+        }
+    }
+}
+
+/// Sets the Cardano context (`cardano#block-height` / `cardano#current-slot`)
+/// reported to guests of the deployment. Applies to UTXOs minted *after* this
+/// call. Returns 0, or -1 if the deployment is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn set_cardano(digest: u32, block_height: i64, current_slot: i64) -> i32 {
+    init();
+    CONTRACTS.with_borrow_mut(|contracts| match contracts.get_mut(&digest) {
+        Some(dep) => {
+            dep.cardano = CardanoCtx {
+                block_height,
+                current_slot,
+            };
+            0
+        }
+        None => {
+            error!("set_cardano: contract not found");
+            -1
+        }
+    })
+}
+
+// ----------------------------------------------------------------------------
+// JSON <-> component-model value plumbing.
+
+/// JSON description of the contract's instances for the page.
+///
+/// Shape: `{ instances: [{ name, resource, constructors: [func], methods:
+/// [func], storage: [{name, kind}] | null }] }`, where `func` is
+/// `{ export, label, params: [{name, kind}] }`.
+fn describe(contract: &Contract<Ctx>) -> Result<String, Box<dyn std::error::Error>> {
+    // Collect owned pairs first to release the `utxos()` borrow before re-borrowing.
+    let utxos: Vec<(String, UtxoExport)> = contract
+        .utxos()
+        .filter_map(|(name, utxo)| utxo.ok().map(|utxo| (name.to_string(), utxo)))
+        .collect();
+
+    let mut instances = Vec::with_capacity(utxos.len());
+    for (name, utxo) in &utxos {
+        let constructors: Vec<Value> = contract
+            .utxo_constructors(utxo)
+            .filter_map(|(export, ctor)| ctor.ok().map(|ctor| func_json(export, ctor.ty(), 0)))
+            .collect();
+        let methods: Vec<Value> = contract
+            .utxo_methods(utxo)
+            // Skip the leading `self` (`borrow<utxo>`); it comes from the handle.
+            .filter_map(|(export, method)| {
+                method.ok().map(|method| func_json(export, method.ty(), 1))
+            })
+            .collect();
+        let storage = utxo.storage().map(|storage| {
+            storage
+                .ty()
+                .fields()
+                .map(|field| json!({ "name": field.name, "kind": kind_str(&field.ty) }))
+                .collect::<Vec<_>>()
+        });
+        instances.push(json!({
+            "name": name,
+            "resource": "utxo",
+            "constructors": constructors,
+            "methods": methods,
+            "storage": storage,
+        }));
+    }
+    Ok(serde_json::to_string(&json!({ "instances": instances }))?)
+}
+
+/// Render a function as a describe entry, dropping the first `skip` params.
+fn func_json(export: &str, ty: &types::ComponentFunc, skip: usize) -> Value {
+    let params: Vec<Value> = ty
+        .params()
+        .skip(skip)
+        .map(|(name, ty)| json!({ "name": name, "kind": kind_str(&ty) }))
+        .collect();
+    // Export names look like `[static]utxo.new` / `[method]utxo.plus-chips`.
+    let label = export.rsplit('.').next().unwrap_or(export);
+    json!({ "export": export, "label": label, "params": params })
+}
+
+/// The `implements-method` hash for `export`: `sha256` of the method's
+/// `snake_case` source name as four little-endian `u64` words. WIT exports it
+/// `kebab-case` (`[method]utxo.plus-chips`), so undo the mangling (`-` → `_`).
+fn method_hash(export: &str) -> MethodHash {
+    let name = export
+        .rsplit('.')
+        .next()
+        .unwrap_or(export)
+        .replace('-', "_");
+    let digest = Sha256::digest(name.as_bytes());
+    let word = |i: usize| {
+        u64::from_le_bytes(
+            digest[i * 8..i * 8 + 8]
+                .try_into()
+                .expect("a sha256 digest is 32 bytes"),
+        )
+    };
+    (word(0), word(1), word(2), word(3))
+}
+
+/// A JS-friendly tag for a type; non-scalars map to `"json"` (raw JSON box).
+fn kind_str(ty: &Type) -> &'static str {
+    match ty {
+        Type::Bool => "bool",
+        Type::S8 => "s8",
+        Type::U8 => "u8",
+        Type::S16 => "s16",
+        Type::U16 => "u16",
+        Type::S32 => "s32",
+        Type::U32 => "u32",
+        Type::S64 => "s64",
+        Type::U64 => "u64",
+        _ => "json",
+    }
+}
+
+/// Convert positional JSON arguments to typed [`Val`]s against a function's
+/// parameter list, skipping the first `skip` parameters.
+fn convert_args<'a>(
+    params: impl Iterator<Item = (&'a str, Type)>,
+    skip: usize,
+    args: &[Value],
+) -> Result<Vec<Val>, Box<dyn std::error::Error>> {
+    let tys: Vec<Type> = params.skip(skip).map(|(_, ty)| ty).collect();
+    if tys.len() != args.len() {
+        return Err(format!("expected {} argument(s), got {}", tys.len(), args.len()).into());
+    }
+    tys.iter()
+        .zip(args)
+        .map(|(ty, arg)| json_to_val(ty, arg))
+        .collect::<Result<Vec<_>, String>>()
+        .map_err(Into::into)
+}
+
+/// Lower JSON into a [`Val`]. Integers and `bool` plus `record`/`tuple`/
+/// `option`; other types are rejected. Integer narrowing is intentionally lossy.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn json_to_val(ty: &Type, v: &Value) -> Result<Val, String> {
+    let as_i = |v: &Value| {
+        v.as_i64()
+            .or_else(|| v.as_f64().map(|f| f as i64))
+            .ok_or_else(|| format!("expected an integer, got `{v}`"))
+    };
+    let as_u = |v: &Value| {
+        v.as_u64()
+            .or_else(|| v.as_f64().map(|f| f as u64))
+            .ok_or_else(|| format!("expected an unsigned integer, got `{v}`"))
+    };
+    match ty {
+        Type::Bool => v
+            .as_bool()
+            .map(Val::Bool)
+            .ok_or_else(|| format!("expected a boolean, got `{v}`")),
+        Type::S8 => Ok(Val::S8(as_i(v)? as i8)),
+        Type::U8 => Ok(Val::U8(as_u(v)? as u8)),
+        Type::S16 => Ok(Val::S16(as_i(v)? as i16)),
+        Type::U16 => Ok(Val::U16(as_u(v)? as u16)),
+        Type::S32 => Ok(Val::S32(as_i(v)? as i32)),
+        Type::U32 => Ok(Val::U32(as_u(v)? as u32)),
+        Type::S64 => Ok(Val::S64(as_i(v)?)),
+        Type::U64 => Ok(Val::U64(as_u(v)?)),
+        Type::Record(record) => {
+            let obj = v
+                .as_object()
+                .ok_or_else(|| format!("expected an object for record, got `{v}`"))?;
+            let mut fields = Vec::new();
+            for field in record.fields() {
+                let value = obj
+                    .get(field.name)
+                    .ok_or_else(|| format!("missing record field `{}`", field.name))?;
+                fields.push((field.name.to_string(), json_to_val(&field.ty, value)?));
+            }
+            Ok(Val::Record(fields))
+        }
+        Type::Tuple(tuple) => {
+            let arr = v
+                .as_array()
+                .ok_or_else(|| format!("expected an array for tuple, got `{v}`"))?;
+            let tys: Vec<Type> = tuple.types().collect();
+            if tys.len() != arr.len() {
+                return Err(format!(
+                    "expected a {}-tuple, got {} elements",
+                    tys.len(),
+                    arr.len()
+                ));
+            }
+            tys.iter()
+                .zip(arr)
+                .map(|(ty, x)| json_to_val(ty, x))
+                .collect::<Result<Vec<_>, _>>()
+                .map(Val::Tuple)
+        }
+        Type::Option(opt) => {
+            if v.is_null() {
+                Ok(Val::Option(None))
+            } else {
+                json_to_val(&opt.ty(), v).map(|val| Val::Option(Some(Box::new(val))))
+            }
+        }
+        _ => Err("unsupported parameter type".into()),
+    }
+}
+
+/// Lift a [`Val`] into JSON for display. Mirrors [`json_to_val`]: integers,
+/// `bool`, and `record`/`tuple`/`option`; other types are rejected.
+fn val_to_json(v: &Val) -> Result<Value, String> {
+    Ok(match v {
+        Val::Bool(b) => json!(b),
+        Val::S8(n) => json!(n),
+        Val::U8(n) => json!(n),
+        Val::S16(n) => json!(n),
+        Val::U16(n) => json!(n),
+        Val::S32(n) => json!(n),
+        Val::U32(n) => json!(n),
+        Val::S64(n) => json!(n),
+        Val::U64(n) => json!(n),
+        Val::Tuple(xs) => Value::Array(xs.iter().map(val_to_json).collect::<Result<_, _>>()?),
+        Val::Record(fields) => Value::Object(
+            fields
+                .iter()
+                .map(|(k, v)| Ok((k.clone(), val_to_json(v)?)))
+                .collect::<Result<_, String>>()?,
+        ),
+        Val::Option(o) => match o.as_deref() {
+            Some(v) => val_to_json(v)?,
+            None => Value::Null,
+        },
+        other => return Err(format!("unsupported result type `{other:?}`")),
+    })
+}
+
+// ----------------------------------------------------------------------------
 
 fn print_wit(wasm: &[u8], is_core: bool) -> Result<String, Box<dyn std::error::Error>> {
     let decoded = if is_core {

--- a/starstream-sandbox-web/src/platform.rs
+++ b/starstream-sandbox-web/src/platform.rs
@@ -1,0 +1,121 @@
+//! Wasmtime "custom platform" implementation for a browser-like wasm32 host.
+//!
+//! Wasmtime doesn't recognize wasm32 as a supported OS, so with the
+//! `custom-virtual-memory` feature it calls out to a small C-ABI for its
+//! platform needs instead of using mmap/signals directly. We satisfy that ABI
+//! here, in pure Rust, backed by the global allocator.
+//!
+//! There is no real virtual memory in the sandbox, so:
+//!   * "mmap" is a page-aligned, zeroed heap allocation,
+//!   * "mprotect" is a no-op (Pulley bytecode is interpreted *data*, never
+//!     executed as native code, so W^X is irrelevant), and
+//!   * copy-on-write memory images are disabled (we return "no image").
+
+use core::ffi::c_void;
+use core::ptr;
+use core::ptr::null_mut;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use std::alloc;
+
+/// Wasmtime requires two pointers' space of TLS, addressed by slot: slot 0 is
+/// the runtime TLS pointer, slot 1 the `component-model-async` state. The
+/// browser runs this module single-threaded, so plain atomic globals are
+/// sufficient. Indexing panics (loudly, via the panic hook) if wasmtime ever
+/// passes a slot we don't know about.
+static WASMTIME_TLS: [AtomicUsize; 2] = [AtomicUsize::new(0), AtomicUsize::new(0)];
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_tls_get(slot: usize) -> *mut u8 {
+    WASMTIME_TLS[slot].load(Ordering::Relaxed) as *mut u8
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_tls_set(slot: usize, ptr: *mut u8) {
+    WASMTIME_TLS[slot].store(ptr as usize, Ordering::Relaxed);
+}
+
+/// Page size we report and align every allocation to. 64 KiB matches the Wasm
+/// page size and keeps Wasmtime's host-page-count bookkeeping consistent.
+const PAGE_SIZE: usize = 1 << 16;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_page_size() -> usize {
+    PAGE_SIZE
+}
+
+fn layout(size: usize) -> alloc::Layout {
+    // Sizes Wasmtime passes are already page-multiples; align to a page too.
+    alloc::Layout::from_size_align(size, PAGE_SIZE).expect("valid layout")
+}
+
+/// `mmap(NULL, size, ...)`: hand back a fresh, zeroed, page-aligned region.
+/// Returns 0 on success and writes the base pointer to `*ret`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_mmap_new(
+    size: usize,
+    _prot_flags: u32,
+    ret: *mut *mut u8,
+) -> i32 {
+    if size == 0 {
+        // Never paired with a munmap; a dangling aligned pointer is fine.
+        unsafe { *ret = PAGE_SIZE as *mut u8 };
+        return 0;
+    }
+    let ptr = unsafe { alloc::alloc_zeroed(layout(size)) };
+    if ptr.is_null() {
+        return 1;
+    }
+    unsafe { *ret = ptr };
+    0
+}
+
+/// `mmap(addr, size, ... MAP_FIXED)`: replace a sub-range with blank (zeroed)
+/// memory in place. We don't reallocate, just clear the bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_mmap_remap(addr: *mut u8, size: usize, _prot_flags: u32) -> i32 {
+    unsafe { ptr::write_bytes(addr, 0, size) };
+    0
+}
+
+/// `munmap(ptr, size)`: free a region previously returned by `wasmtime_mmap_new`.
+/// Wasmtime frees with the same `size` it mapped, so the layout matches.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_munmap(ptr: *mut u8, size: usize) -> i32 {
+    if size != 0 {
+        unsafe { alloc::dealloc(ptr, layout(size)) };
+    }
+    0
+}
+
+/// `mprotect`: no-op — there is no protection to change in the sandbox.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_mprotect(_ptr: *mut u8, _size: usize, _prot_flags: u32) -> i32 {
+    0
+}
+
+// --- Copy-on-write memory images: disabled. The symbols must still exist to
+// link; returning a NULL image tells Wasmtime "no image available" and it
+// falls back to plain allocation + copy.
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_memory_image_new(
+    _ptr: *const u8,
+    _len: usize,
+    ret: *mut *mut c_void,
+) -> i32 {
+    unsafe { *ret = null_mut() };
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_memory_image_map_at(
+    _image: *mut c_void,
+    _addr: *mut u8,
+    _len: usize,
+) -> i32 {
+    1
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_memory_image_free(_image: *mut c_void) {}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -207,3 +207,174 @@
 .log-table__body {
   white-space: pre-wrap;
 }
+
+/* ---- Run tab: deploy / construct / invoke surface ---------------------- */
+
+.run-subhead {
+  display: block;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0.75rem 0 0.35rem;
+}
+
+/* The Cardano context form next to the deployment selector. */
+.run-cardano {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  padding: 0.5rem 1rem 0.75rem;
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  margin: 0;
+}
+.run-cardano > legend {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ifm-color-emphasis-600);
+  padding: 0 0.4rem;
+}
+.run-cardano label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-700);
+}
+.run-cardano input {
+  width: 9rem;
+}
+
+/* One exported instance owning a `utxo` resource. */
+.run-instance {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  padding: 1rem 1.25rem 1.25rem;
+  margin-top: 1.5rem;
+}
+.run-instance__title {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 0;
+  font-family: var(--ifm-font-family-monospace);
+}
+.run-badge {
+  align-self: center;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ifm-color-emphasis-0, #fff);
+  background: var(--ifm-color-primary);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+}
+
+/* A callable function: constructor or method. */
+.run-func {
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  margin: 0.4rem 0;
+}
+.run-func__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+.run-func__name {
+  font-family: var(--ifm-font-family-monospace);
+  font-weight: 600;
+}
+.run-func__hint {
+  margin-top: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-600);
+}
+.run-func__error {
+  margin-top: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--ifm-color-danger);
+  white-space: pre-wrap;
+}
+
+/* One live UTXO handle. */
+.run-utxo {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  margin: 0.5rem 0;
+}
+.run-utxo__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.run-utxo__title {
+  font-family: var(--ifm-font-family-monospace);
+  font-weight: 600;
+  color: var(--ifm-color-info);
+}
+.run-utxo__section {
+  margin-top: 0.5rem;
+}
+.run-utxo__storage {
+  margin: 0;
+}
+
+/* A UTXO's events & return-values log. */
+.run-log {
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  max-height: 16rem;
+  overflow: auto;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.8rem;
+}
+.run-log__empty {
+  color: var(--ifm-color-emphasis-600);
+  font-style: italic;
+  font-size: 0.85rem;
+}
+.run-log__item {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  padding: 0.15rem 0;
+  word-break: break-word;
+}
+.run-log__tag {
+  flex: none;
+  width: 3.2rem;
+  color: var(--ifm-color-emphasis-600);
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+}
+.run-log__event .run-log__tag {
+  color: var(--ifm-color-primary);
+}
+.run-log__ok .run-log__tag {
+  color: var(--ifm-color-success);
+}
+.run-log__err .run-log__tag {
+  color: var(--ifm-color-danger);
+}
+.run-log__sig {
+  flex: none;
+  font-weight: 600;
+}
+.run-log__detail {
+  color: var(--ifm-color-emphasis-700);
+  white-space: pre-wrap;
+}
+.run-log__err .run-log__detail {
+  color: var(--ifm-color-danger);
+}

--- a/website/src/editor.tsx
+++ b/website/src/editor.tsx
@@ -7,13 +7,39 @@ import { useEffect, useRef } from "react";
 import "./starstream.vsix";
 
 const code = `\
-struct Token {
-    amount: i64,
-    price: i64,
+abi Score {
+    fn plus_chips(chips: u64);
+    fn plus_mult(mult: u64);
+    fn mult_mult(mult_pct: u64);
+    fn finish();
+    event Finish(total: u64);
 }
 
-script fn total_value(token: Token) -> i64 {
-    token.amount * token.price
+utxo ScoreProgress {
+    storage {
+        let mut chips: u64;
+        let mut mult: u64;
+    }
+
+    main fn new() {
+        yield(Score);
+        emit Finish(chips * mult);
+    }
+
+    impl Score {
+        fn plus_chips(pub chips2: u64) {
+            chips = chips + chips2;
+        }
+        fn plus_mult(pub mult2: u64) {
+            mult = mult + mult2;
+        }
+        fn mult_mult(pub mult_pct: u64) {
+            mult = mult * mult_pct / 100;
+        }
+        fn finish() {
+            resume;
+        }
+    }
 }
 `;
 

--- a/website/src/pages/sandbox.tsx
+++ b/website/src/pages/sandbox.tsx
@@ -4,6 +4,7 @@ import {
   ComponentProps,
   CSSProperties,
   Dispatch,
+  Fragment,
   ReactNode,
   SetStateAction,
   useCallback,
@@ -16,6 +17,14 @@ import type {
   SandboxWorkerRequest,
   SandboxWorkerResponse,
 } from "../sandbox.worker";
+import type {
+  RunWorkerRequest,
+  RunWorkerResponse,
+  AbiEvent,
+  Describe,
+  DescribeFunc,
+  DescribeInstance,
+} from "../run.worker";
 import { useBlobUrl } from "../hooks";
 import type * as monaco from "monaco-editor";
 
@@ -36,6 +45,34 @@ function useSandboxWorker(onResponse: (r: SandboxWorkerResponse) => void): {
     if (!current) return;
 
     function onMessage({ data }: { data: SandboxWorkerResponse }) {
+      onResponse(data);
+    }
+    current.addEventListener("message", onMessage);
+    return () => current.removeEventListener("message", onMessage);
+  }, [onResponse]);
+
+  return {
+    request(r) {
+      worker.current?.postMessage(r);
+    },
+  };
+}
+
+function useRunWorker(onResponse: (r: RunWorkerResponse) => void): {
+  request(r: RunWorkerRequest): void;
+} {
+  const worker = useRef<Worker | null>(null);
+
+  useEffect(() => {
+    worker.current = new Worker(new URL("../run.worker", import.meta.url));
+    return () => worker.current?.terminate();
+  }, []);
+
+  useEffect(() => {
+    const current = worker.current;
+    if (!current) return;
+
+    function onMessage({ data }: { data: RunWorkerResponse }) {
       onResponse(data);
     }
     current.addEventListener("message", onMessage);
@@ -173,6 +210,562 @@ function DiagnosticsList({
   );
 }
 
+// ----------------------------------------------------------------------------
+// Run tab: deploy a compiled component, mint UTXOs by calling `[static]`
+// constructors (the only way to create one) and invoke methods on them.
+
+const INT_KINDS = new Set(["s8", "u8", "s16", "u16", "s32", "u32", "s64", "u64"]);
+
+// Parse a raw input string into the JSON value the runtime expects for `kind`.
+// Starstream's only scalar types are integers and `bool`; everything compound
+// (records, tuples, options/results and other enums) arrives as "json".
+function readArg(kind: string, raw: string): unknown {
+  if (kind === "bool") return raw === "true";
+  // Blank integer fields default to 0 rather than rejecting the submit.
+  if (INT_KINDS.has(kind)) {
+    return Number(raw.trim() === "" ? "0" : raw);
+  }
+  // "json": records, tuples, options/results and other enums, as raw JSON.
+  if (raw.trim() === "") throw new Error("missing JSON value");
+  return JSON.parse(raw);
+}
+
+// A deployed component, identified by the sha256 hex digest of its Wasm.
+interface RunDeployment {
+  digest: string;
+  describe: Describe;
+  deployedAt: Date;
+}
+
+// A live UTXO handle, minted from a deployment's constructor.
+interface RunUtxo {
+  digest: string;
+  /** Export name of the UTXO-owning instance. */
+  instance: string;
+  /** Handle number, as reported by the worker. */
+  handle: number;
+  /** Display label, e.g. `score-progress #0`. */
+  label: string;
+}
+
+// One entry in a UTXO's call log: an emitted ABI event, a method return value,
+// or a call error.
+type LogItem =
+  | { kind: "event"; instance: string; name: string; params: unknown[] }
+  | { kind: "result"; label: string; text: string }
+  | { kind: "error"; label: string; text: string };
+
+// The key a UTXO's storage / implemented-methods / log are stored under.
+function utxoKey(digest: string, handle: number): string {
+  return `${digest}#${handle}`;
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// A short, human label for an instance export id (`ns:pkg/iface@ver` → `iface`).
+function shortInstance(name: string): string {
+  const afterSlash = name.includes("/")
+    ? name.slice(name.lastIndexOf("/") + 1)
+    : name;
+  return afterSlash.split("@")[0];
+}
+
+// The trailing segment of an export name (`[method]utxo.plus-chips` →
+// `plus-chips`), used to label a call in the log.
+function exportLabel(name: string): string {
+  return name.split(".").pop() ?? name;
+}
+
+// A two-column grid that lines up the labels and inputs of the params inside.
+const FIELD_GRID: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "max-content 1fr",
+  gap: 8,
+  alignItems: "center",
+  justifyItems: "start",
+  marginTop: 8,
+};
+
+// Text inputs fill their grid cell and shrink with it on narrow layouts.
+const INPUT_STYLE: CSSProperties = {
+  width: "100%",
+  minWidth: 0,
+  boxSizing: "border-box",
+};
+
+// An input widget for one parameter, chosen by its scalar `kind`. Compound
+// types arrive as "json" and get a raw-JSON textarea.
+function KindInput({
+  kind,
+  value,
+  onChange,
+}: {
+  kind: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  if (kind === "bool") {
+    return (
+      <input
+        type="checkbox"
+        checked={value === "true"}
+        onChange={(e) => onChange(String(e.target.checked))}
+      />
+    );
+  }
+  if (kind === "json") {
+    return (
+      <textarea
+        style={{ ...INPUT_STYLE, fontFamily: "monospace", minHeight: "3rem" }}
+        placeholder="JSON value"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    );
+  }
+  // The only remaining scalar kinds are integers.
+  return (
+    <input
+      type="number"
+      step="1"
+      style={INPUT_STYLE}
+      placeholder={kind}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onFocus={(e) => e.target.select()}
+    />
+  );
+}
+
+// One callable function (constructor or method): a labelled row of parameter
+// inputs and a submit button. Calls `onSubmit` with the JSON-decoded args.
+function FuncForm({
+  func,
+  submitLabel,
+  disabled,
+  disabledReason,
+  onSubmit,
+}: {
+  func: DescribeFunc;
+  submitLabel: string;
+  disabled?: boolean;
+  disabledReason?: string;
+  onSubmit: (args: unknown[]) => void;
+}) {
+  const [args, setArgs] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string>();
+  const setArg = useCallback((name: string, value: string) => {
+    setArgs((prev) => ({ ...prev, [name]: value }));
+  }, []);
+
+  return (
+    <form
+      className="run-func"
+      onSubmit={(e) => {
+        e.preventDefault();
+        let values: unknown[];
+        try {
+          values = func.params.map((p) => readArg(p.kind, args[p.name] ?? ""));
+        } catch (err) {
+          setError(`Invalid input: ${(err as Error).message ?? err}`);
+          return;
+        }
+        setError(undefined);
+        onSubmit(values);
+      }}
+    >
+      <div className="run-func__head">
+        <span className="run-func__name">
+          <code>{func.label}</code>
+        </span>
+        <button
+          type="submit"
+          className="button button--primary button--sm"
+          disabled={disabled}
+        >
+          {submitLabel}
+        </button>
+      </div>
+      {func.params.length > 0 && (
+        <div style={FIELD_GRID}>
+          {func.params.map((p) => (
+            <Fragment key={p.name}>
+              <span>
+                {p.name}: <code>{p.kind}</code>
+              </span>
+              <KindInput
+                kind={p.kind}
+                value={args[p.name] ?? (INT_KINDS.has(p.kind) ? "0" : "")}
+                onChange={(v) => setArg(p.name, v)}
+              />
+            </Fragment>
+          ))}
+        </div>
+      )}
+      {disabled && disabledReason && (
+        <div className="run-func__hint">{disabledReason}</div>
+      )}
+      {error && <div className="run-func__error">{error}</div>}
+    </form>
+  );
+}
+
+// One entry of a UTXO's call log.
+function LogLine({ item }: { item: LogItem }) {
+  if (item.kind === "event") {
+    const args = item.params.map((p) => JSON.stringify(p)).join(", ");
+    return (
+      <div className="run-log__item run-log__event">
+        <span className="run-log__tag">event</span>
+        <span className="run-log__sig">
+          {item.instance}.{item.name}
+        </span>
+        <span className="run-log__detail">({args})</span>
+      </div>
+    );
+  }
+  return (
+    <div
+      className={`run-log__item ${
+        item.kind === "error" ? "run-log__err" : "run-log__ok"
+      }`}
+    >
+      <span className="run-log__tag">{item.kind === "error" ? "✗" : "→"}</span>
+      <span className="run-log__sig">{item.label}</span>
+      <span className="run-log__detail">{item.text}</span>
+    </div>
+  );
+}
+
+// One live UTXO: storage view, callable methods (only those declared via
+// `implements-method` are enabled), a drop button and a call log.
+function UtxoCard({
+  utxo,
+  instance,
+  storage,
+  implemented,
+  log,
+  onCall,
+  onDrop,
+}: {
+  utxo: RunUtxo;
+  instance: DescribeInstance;
+  storage: Record<string, unknown> | undefined;
+  implemented: string[] | undefined;
+  log: LogItem[];
+  onCall: (method: string, args: unknown[]) => void;
+  onDrop: () => void;
+}) {
+  const implementedSet = useMemo(
+    () => (implemented ? new Set(implemented) : null),
+    [implemented],
+  );
+
+  // Keep the log pinned to the most recent entry as calls and events arrive.
+  const logRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = logRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [log]);
+
+  return (
+    <div className="run-utxo">
+      <div className="run-utxo__head">
+        <span className="run-utxo__title">{utxo.label}</span>
+        <button
+          type="button"
+          className="button button--secondary button--sm"
+          onClick={onDrop}
+        >
+          Drop
+        </button>
+      </div>
+      {instance.storage && (
+        <div className="run-utxo__section">
+          <span className="run-subhead">Storage</span>
+          <pre className="run-utxo__storage">
+            {storage ? JSON.stringify(storage, null, 2) : "…"}
+          </pre>
+        </div>
+      )}
+      {instance.methods.length > 0 && (
+        <div className="run-utxo__section">
+          <span className="run-subhead">Methods</span>
+          {instance.methods.map((m) => {
+            // `implementedSet` is null until the implements-method list loads;
+            // keep methods disabled until then, since which are callable is
+            // still unknown.
+            const loading = implementedSet === null;
+            const enabled = implementedSet ? implementedSet.has(m.export) : false;
+            return (
+              <FuncForm
+                key={m.export}
+                func={m}
+                submitLabel="Call"
+                disabled={!enabled}
+                disabledReason={
+                  loading
+                    ? "Loading implemented methods…"
+                    : enabled
+                      ? undefined
+                      : "Not declared via implements-method — not callable."
+                }
+                onSubmit={(args) => onCall(m.export, args)}
+              />
+            );
+          })}
+        </div>
+      )}
+      <div className="run-utxo__section">
+        <span className="run-subhead">Log — events &amp; return values</span>
+        {log.length === 0 ? (
+          <div className="run-log__empty">No calls or events yet.</div>
+        ) : (
+          <div className="run-log" ref={logRef}>
+            {log.map((item, i) => (
+              <LogLine key={i} item={item} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// The Cardano context form for the selected deployment. Applies to UTXOs minted
+// *after* a change.
+function CardanoForm({
+  digest,
+  onSetCardano,
+}: {
+  digest: string;
+  onSetCardano: (
+    digest: string,
+    blockHeight: number,
+    currentSlot: number,
+  ) => void;
+}) {
+  const [blockHeight, setBlockHeight] = useState("0");
+  const [currentSlot, setCurrentSlot] = useState("0");
+
+  // Reset the fields when the selected deployment changes.
+  useEffect(() => {
+    setBlockHeight("0");
+    setCurrentSlot("0");
+  }, [digest]);
+
+  const apply = (bh: string, cs: string) =>
+    onSetCardano(digest, Number(bh || "0"), Number(cs || "0"));
+
+  return (
+    <fieldset className="run-cardano">
+      <legend>Cardano context</legend>
+      <label>
+        block height
+        <input
+          type="number"
+          step="1"
+          value={blockHeight}
+          onChange={(e) => {
+            setBlockHeight(e.target.value);
+            apply(e.target.value, currentSlot);
+          }}
+        />
+      </label>
+      <label>
+        current slot
+        <input
+          type="number"
+          step="1"
+          value={currentSlot}
+          onChange={(e) => {
+            setCurrentSlot(e.target.value);
+            apply(blockHeight, e.target.value);
+          }}
+        />
+      </label>
+    </fieldset>
+  );
+}
+
+function RunPanel({
+  canDeploy,
+  deployHint,
+  deployErrors,
+  onDeploy,
+  deployments,
+  onConstruct,
+  utxos,
+  utxoStorage,
+  utxoImplemented,
+  utxoLogs,
+  onCall,
+  onDrop,
+  onSetCardano,
+  log,
+}: {
+  canDeploy: boolean;
+  /** Why deploying is unavailable, shown next to the disabled button. */
+  deployHint: ReactNode | undefined;
+  /** Errors of the last failed deploy, shown as a warning under the button. */
+  deployErrors: string[];
+  onDeploy: () => void;
+  deployments: RunDeployment[];
+  onConstruct: (
+    digest: string,
+    instance: string,
+    constructor: string,
+    args: unknown[],
+  ) => void;
+  utxos: RunUtxo[];
+  utxoStorage: Record<string, Record<string, unknown>>;
+  utxoImplemented: Record<string, string[]>;
+  utxoLogs: Record<string, LogItem[]>;
+  onCall: (
+    digest: string,
+    handle: number,
+    method: string,
+    args: unknown[],
+  ) => void;
+  onDrop: (digest: string, handle: number) => void;
+  onSetCardano: (
+    digest: string,
+    blockHeight: number,
+    currentSlot: number,
+  ) => void;
+  /** Log lines not attributable to a UTXO (deploy/construct). */
+  log: string[];
+}) {
+  const [selectedDigest, setSelectedDigest] = useState("");
+
+  // Deployments are ordered most recent first; select the newest one whenever a
+  // deployment happens.
+  useEffect(() => {
+    setSelectedDigest(deployments[0]?.digest ?? "");
+  }, [deployments]);
+
+  const deployment = deployments.find((d) => d.digest === selectedDigest);
+
+  return (
+    <div className="padding--md" style={{ height: "100%", overflow: "auto" }}>
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <button
+          type="button"
+          className="button button--secondary"
+          disabled={!canDeploy}
+          onClick={onDeploy}
+        >
+          Deploy
+        </button>
+        {deployHint && <span>{deployHint}</span>}
+      </div>
+      {deployErrors.length > 0 && (
+        <div
+          className="alert alert--warning"
+          role="alert"
+          style={{ marginTop: 8 }}
+        >
+          <strong>Deployment failed.</strong>
+          <pre style={{ margin: "8px 0 0", whiteSpace: "pre-wrap" }}>
+            {deployErrors.join("\n")}
+          </pre>
+        </div>
+      )}
+      {deployments.length > 0 && (
+        <div
+          style={{
+            marginTop: 16,
+            display: "flex",
+            gap: 16,
+            alignItems: "flex-end",
+            flexWrap: "wrap",
+          }}
+        >
+          <label>
+            Deployment{" "}
+            <select
+              value={selectedDigest}
+              onChange={(e) => setSelectedDigest(e.target.value)}
+            >
+              {deployments.map((d) => (
+                <option key={d.digest} value={d.digest}>
+                  {d.digest.slice(0, 16)}… — deployed at{" "}
+                  {d.deployedAt.toLocaleTimeString()}
+                </option>
+              ))}
+            </select>
+          </label>
+          {selectedDigest && (
+            <CardanoForm digest={selectedDigest} onSetCardano={onSetCardano} />
+          )}
+        </div>
+      )}
+      {deployment && deployment.describe.instances.length === 0 && (
+        <p style={{ marginTop: 16 }}>No UTXO defined.</p>
+      )}
+      {deployment?.describe.instances.map((instance) => {
+        const live = utxos.filter(
+          (u) => u.digest === selectedDigest && u.instance === instance.name,
+        );
+        return (
+          <div key={instance.name} className="run-instance">
+            <h3 className="run-instance__title">
+              <span className="run-badge">{instance.resource}</span>{" "}
+              <code>{shortInstance(instance.name)}</code>
+            </h3>
+            <div className="run-construct">
+              <span className="run-subhead">Construct</span>
+              {instance.constructors.length === 0 ? (
+                <p>This resource exposes no constructors.</p>
+              ) : (
+                instance.constructors.map((c) => (
+                  <FuncForm
+                    key={c.export}
+                    func={c}
+                    submitLabel="Create UTXO"
+                    onSubmit={(args) =>
+                      onConstruct(selectedDigest, instance.name, c.export, args)
+                    }
+                  />
+                ))
+              )}
+            </div>
+            <div className="run-live">
+              <span className="run-subhead">Live UTXOs</span>
+              {live.length === 0 ? (
+                <div className="run-log__empty">
+                  None yet — call a constructor above to mint one.
+                </div>
+              ) : (
+                live.map((u) => (
+                  <UtxoCard
+                    key={u.handle}
+                    utxo={u}
+                    instance={instance}
+                    storage={utxoStorage[utxoKey(u.digest, u.handle)]}
+                    implemented={utxoImplemented[utxoKey(u.digest, u.handle)]}
+                    log={utxoLogs[utxoKey(u.digest, u.handle)] ?? []}
+                    onCall={(method, args) =>
+                      onCall(u.digest, u.handle, method, args)
+                    }
+                    onDrop={() => onDrop(u.digest, u.handle)}
+                  />
+                ))
+              )}
+            </div>
+          </div>
+        );
+      })}
+      {log.length > 0 && <pre style={{ marginTop: 16 }}>{log.join("\n")}</pre>}
+    </div>
+  );
+}
+
 export function Sandbox() {
   const [inputTab, setInputTab] = useState("Editor");
   const [outputTab, setOutputTab] = useState("About");
@@ -229,6 +822,282 @@ export function Sandbox() {
       response satisfies never;
     }
   });
+
+  const [deployments, setDeployments] = useState<RunDeployment[]>([]);
+  const [utxos, setUtxos] = useState<RunUtxo[]>([]);
+  // Per-UTXO storage, implemented methods and call log, keyed by `utxoKey`.
+  const [utxoStorage, setUtxoStorage] = useState<
+    Record<string, Record<string, unknown>>
+  >({});
+  const [utxoImplemented, setUtxoImplemented] = useState<
+    Record<string, string[]>
+  >({});
+  const [utxoLogs, setUtxoLogs] = useState<Record<string, LogItem[]>>({});
+  const [runLog, setRunLog] = useState<string[]>([]);
+
+  // Monotonic per-(deployment, instance) counter for UTXO labels, kept across drops.
+  const utxoCounters = useRef<Map<string, number>>(new Map());
+
+  const appendUtxoLog = useCallback((key: string, item: LogItem) => {
+    setUtxoLogs((prev) => ({ ...prev, [key]: [...(prev[key] ?? []), item] }));
+  }, []);
+
+  // The digest of the current compiler output, identifying its deployment.
+  const [componentDigest, setComponentDigest] = useState<string>();
+  useEffect(() => {
+    setComponentDigest(undefined);
+    if (!componentWasm) return;
+    let cancelled = false;
+    sha256Hex(componentWasm).then((digest) => {
+      if (!cancelled) setComponentDigest(digest);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [componentWasm]);
+
+  // The digest last deployed; Deploy is disabled until the Wasm digest changes.
+  const [lastDeployedDigest, setLastDeployedDigest] = useState<string>();
+
+  // Errors of the last failed deploy, shown next to the Deploy button.
+  const [deployErrors, setDeployErrors] = useState<string[]>([]);
+  useEffect(() => {
+    setDeployErrors([]);
+  }, [componentWasm]);
+
+  // The in-flight deploy, to attribute its error logs to the deploy warning.
+  const pendingDeploy = useRef<string | undefined>(undefined);
+
+  // The in-flight method call, to attribute its logs/result to its UTXO.
+  const pendingCall = useRef<
+    { key: string; digest: string; handle: number; label: string } | undefined
+  >(undefined);
+
+  const run_request_id = useRef(0);
+  const runWorker = useRunWorker((response) => {
+    if (response.type == "idle") {
+      // The request fully completed (its result responses, if any, arrived
+      // before this). Stop attributing later logs to it, so a subsequent
+      // operation that doesn't reset the refs (e.g. setCardano) can't be
+      // mis-attributed to this one.
+      pendingCall.current = undefined;
+      pendingDeploy.current = undefined;
+    } else if (response.type == "log") {
+      const level = ["", "Error", "Warn", "Info", "Debug", "Trace"][
+        response.level
+      ];
+      console.log(level, `[${response.target}]`, response.body);
+      // Surface errors and warnings, attributed to the UTXO being called if
+      // there is one, else to the deploy warning or the panel-level log.
+      if (response.level <= 2) {
+        const entry = `${level}: ${response.body}`;
+        const pending = pendingCall.current;
+        if (pending) {
+          appendUtxoLog(pending.key, {
+            kind: "error",
+            label: pending.label,
+            text: entry,
+          });
+        } else if (pendingDeploy.current !== undefined) {
+          setDeployErrors((prev) => [...prev, entry]);
+        } else {
+          setRunLog((prev) => [...prev, entry]);
+        }
+      }
+    } else if (response.type == "deployed") {
+      pendingDeploy.current = undefined;
+      const { digest, describe } = response;
+      const deployment = { digest, describe, deployedAt: new Date() };
+      // Most recent deployment first; a re-deploy moves its digest up front.
+      setDeployments((prev) => [
+        deployment,
+        ...prev.filter((d) => d.digest !== digest),
+      ]);
+    } else if (response.type == "deploy_failed") {
+      pendingDeploy.current = undefined;
+      // The cause arrived as "log" responses; ensure the warning shows anyway.
+      setDeployErrors((prev) => (prev.length > 0 ? prev : ["Unknown error."]));
+      // Re-enable the Deploy button that onDeploy optimistically disabled.
+      setLastDeployedDigest((prev) =>
+        prev === response.digest ? undefined : prev,
+      );
+    } else if (response.type == "constructed") {
+      const { digest, instance, handle, events } = response;
+      const counterKey = `${digest}|${instance}`;
+      const n = utxoCounters.current.get(counterKey) ?? 0;
+      utxoCounters.current.set(counterKey, n + 1);
+      const label = `${shortInstance(instance)} #${n}`;
+      const key = utxoKey(digest, handle);
+      setUtxos((prev) => [...prev, { digest, instance, handle, label }]);
+      setUtxoLogs((prev) => ({
+        ...prev,
+        [key]: [
+          { kind: "result", label: "constructed", text: "(minted)" },
+          ...events.map(
+            (e: AbiEvent): LogItem => ({
+              kind: "event",
+              instance: e.instance,
+              name: e.name,
+              params: e.params,
+            }),
+          ),
+        ],
+      }));
+      // Fetch the new UTXO's initial storage and its callable methods.
+      runWorker.request({
+        request_id: ++run_request_id.current,
+        type: "storageGet",
+        digest,
+        handle,
+      });
+      runWorker.request({
+        request_id: ++run_request_id.current,
+        type: "implementedMethods",
+        digest,
+        handle,
+      });
+    } else if (response.type == "construct_failed") {
+      // The cause arrived as "log" responses (attributed to the panel log).
+    } else if (response.type == "called") {
+      const pending = pendingCall.current;
+      if (pending) {
+        const text =
+          response.results.length > 0
+            ? JSON.stringify(response.results)
+            : "(no return value)";
+        const items: LogItem[] = [
+          { kind: "result", label: pending.label, text },
+          ...response.events.map(
+            (e: AbiEvent): LogItem => ({
+              kind: "event",
+              instance: e.instance,
+              name: e.name,
+              params: e.params,
+            }),
+          ),
+        ];
+        setUtxoLogs((prev) => ({
+          ...prev,
+          [pending.key]: [...(prev[pending.key] ?? []), ...items],
+        }));
+        // The call may have mutated storage — refresh the view.
+        runWorker.request({
+          request_id: ++run_request_id.current,
+          type: "storageGet",
+          digest: pending.digest,
+          handle: pending.handle,
+        });
+      }
+    } else if (response.type == "storage") {
+      const key = utxoKey(response.digest, response.handle);
+      setUtxoStorage((prev) => ({ ...prev, [key]: response.storage }));
+    } else if (response.type == "implemented") {
+      const key = utxoKey(response.digest, response.handle);
+      setUtxoImplemented((prev) => ({ ...prev, [key]: response.methods }));
+    } else if (response.type == "dropped") {
+      const { digest, handle } = response;
+      const key = utxoKey(digest, handle);
+      setUtxos((prev) =>
+        prev.filter((u) => !(u.digest === digest && u.handle === handle)),
+      );
+      const remove = <T,>(rec: Record<string, T>) => {
+        if (!(key in rec)) return rec;
+        const next = { ...rec };
+        delete next[key];
+        return next;
+      };
+      setUtxoStorage(remove);
+      setUtxoImplemented(remove);
+      setUtxoLogs(remove);
+    } else {
+      response satisfies never;
+    }
+  });
+
+  const onDeploy = useCallback(() => {
+    if (!componentWasm || !componentDigest) return;
+    setLastDeployedDigest(componentDigest);
+    pendingCall.current = undefined;
+    pendingDeploy.current = componentDigest;
+    setDeployErrors([]);
+    setRunLog([]);
+    runWorker.request({
+      request_id: ++run_request_id.current,
+      type: "deploy",
+      digest: componentDigest,
+      component: componentWasm,
+    });
+  }, [componentWasm, componentDigest]);
+
+  const onConstruct = useCallback(
+    (digest: string, instance: string, ctor: string, args: unknown[]) => {
+      pendingCall.current = undefined;
+      pendingDeploy.current = undefined;
+      setRunLog([]);
+      runWorker.request({
+        request_id: ++run_request_id.current,
+        type: "construct",
+        digest,
+        instance,
+        ctor,
+        args,
+      });
+    },
+    [],
+  );
+
+  const onCall = useCallback(
+    (digest: string, handle: number, method: string, args: unknown[]) => {
+      const key = utxoKey(digest, handle);
+      const label = `${exportLabel(method)}(${args
+        .map((a) => JSON.stringify(a))
+        .join(", ")})`;
+      pendingCall.current = { key, digest, handle, label };
+      pendingDeploy.current = undefined;
+      runWorker.request({
+        request_id: ++run_request_id.current,
+        type: "call",
+        digest,
+        handle,
+        method,
+        args,
+      });
+    },
+    [],
+  );
+
+  const onDrop = useCallback((digest: string, handle: number) => {
+    pendingCall.current = undefined;
+    pendingDeploy.current = undefined;
+    runWorker.request({
+      request_id: ++run_request_id.current,
+      type: "drop",
+      digest,
+      handle,
+    });
+  }, []);
+
+  const onSetCardano = useCallback(
+    (digest: string, blockHeight: number, currentSlot: number) => {
+      runWorker.request({
+        request_id: ++run_request_id.current,
+        type: "setCardano",
+        digest,
+        blockHeight,
+        currentSlot,
+      });
+    },
+    [],
+  );
+
+  // Whether the current output is deployed, and whether a deploy is in flight.
+  const deployed =
+    componentDigest !== undefined &&
+    deployments.some((d) => d.digest === componentDigest);
+  const deploying =
+    !deployed &&
+    componentDigest !== undefined &&
+    componentDigest === lastDeployedDigest;
 
   const onTextChanged = useCallback((code: string) => {
     worker.request({ request_id: ++request_id.current, code });
@@ -303,6 +1172,10 @@ export function Sandbox() {
                     </li>
                     <li>
                       Downloads: Buttons for downloading the compiler outputs.
+                    </li>
+                    <li>
+                      Run: Deploy the compiled component, mint UTXOs by calling a
+                      constructor, and invoke methods on them.
                     </li>
                   </ul>
                   <p>Keyboard shortcuts:</p>
@@ -395,6 +1268,42 @@ export function Sandbox() {
                     <p>Compile the code to see download options.</p>
                   )}
                 </div>
+              ),
+            },
+            {
+              key: "Run",
+              body: (
+                <RunPanel
+                  canDeploy={
+                    !deployed && !deploying && componentDigest !== undefined
+                  }
+                  deployHint={
+                    !componentWasm ? (
+                      "Compile the code to deploy it."
+                    ) : deploying ? (
+                      "Deploying…"
+                    ) : deployed ? (
+                      <>
+                        Contract deployed as{" "}
+                        <code style={{ overflowWrap: "anywhere" }}>
+                          {componentDigest}
+                        </code>
+                      </>
+                    ) : undefined
+                  }
+                  deployErrors={deployErrors}
+                  onDeploy={onDeploy}
+                  deployments={deployments}
+                  onConstruct={onConstruct}
+                  utxos={utxos}
+                  utxoStorage={utxoStorage}
+                  utxoImplemented={utxoImplemented}
+                  utxoLogs={utxoLogs}
+                  onCall={onCall}
+                  onDrop={onDrop}
+                  onSetCardano={onSetCardano}
+                  log={runLog}
+                />
               ),
             },
           ]}

--- a/website/src/run.worker.ts
+++ b/website/src/run.worker.ts
@@ -1,0 +1,400 @@
+// WebWorker hosting the sandbox "Run" environment. Unlike the compile worker,
+// it keeps one Wasm instance alive so the wasmtime engine and deployed
+// contracts persist across messages.
+//
+// Protocol (see `starstream-sandbox-web/src/lib.rs`): deploy a component, mint
+// UTXOs via `[static]` constructors, then invoke `[method]`s on live handles.
+
+import starstreamSandboxWasm from "file-loader!../starstream_sandbox_web.wasm";
+import { encode } from "cbor2";
+
+// ----------------------------------------------------------------------------
+// The contract description produced by `describe` in
+// `starstream-sandbox-web/src/lib.rs`.
+
+/** A scalar type name (`u64`, `bool`, …) or `"json"` (entered as raw JSON). */
+export type Kind = string;
+
+export interface DescribeParam {
+  name: string;
+  kind: Kind;
+}
+
+/** A constructor or method; `export` is the WIT name, `label` its tail. */
+export interface DescribeFunc {
+  export: string;
+  label: string;
+  params: DescribeParam[];
+}
+
+export interface DescribeInstance {
+  name: string;
+  resource: string;
+  constructors: DescribeFunc[];
+  methods: DescribeFunc[];
+  /** The `storage` record's fields, or `null` if the resource has none. */
+  storage: DescribeParam[] | null;
+}
+
+export interface Describe {
+  instances: DescribeInstance[];
+}
+
+export interface AbiEvent {
+  instance: string;
+  name: string;
+  params: unknown[];
+}
+// ----------------------------------------------------------------------------
+
+export type RunWorkerRequest = {
+  request_id: number;
+} & (
+  | {
+      type: "deploy";
+      /** Sha256 hex digest of `component`, identifying the deployment. */
+      digest: string;
+      component: Uint8Array;
+    }
+  | {
+      type: "construct";
+      digest: string;
+      instance: string;
+      ctor: string;
+      args: unknown[];
+    }
+  | {
+      type: "call";
+      digest: string;
+      handle: number;
+      method: string;
+      /** One JSON value per parameter, excluding the `self` receiver. */
+      args: unknown[];
+    }
+  | {
+      type: "storageGet";
+      digest: string;
+      handle: number;
+    }
+  | {
+      type: "implementedMethods";
+      digest: string;
+      handle: number;
+    }
+  | {
+      type: "drop";
+      digest: string;
+      handle: number;
+    }
+  | {
+      type: "setCardano";
+      digest: string;
+      blockHeight: number;
+      currentSlot: number;
+    }
+);
+
+export type RunWorkerResponse = {
+  request_id: number;
+} & (
+  | {
+      type: "idle";
+    }
+  | {
+      type: "log";
+      level: number;
+      target: string;
+      body: string;
+    }
+  | {
+      type: "deployed";
+      digest: string;
+      describe: Describe;
+    }
+  | {
+      type: "deploy_failed";
+      digest: string;
+    }
+  | {
+      type: "constructed";
+      digest: string;
+      instance: string;
+      handle: number;
+      events: AbiEvent[];
+    }
+  | {
+      type: "construct_failed";
+      digest: string;
+      instance: string;
+    }
+  | {
+      type: "called";
+      results: unknown[];
+      events: AbiEvent[];
+    }
+  | {
+      type: "storage";
+      digest: string;
+      handle: number;
+      storage: Record<string, unknown>;
+    }
+  | {
+      type: "implemented";
+      digest: string;
+      handle: number;
+      methods: string[];
+    }
+  | {
+      type: "dropped";
+      digest: string;
+      handle: number;
+    }
+);
+
+// ----------------------------------------------------------------------------
+// These interfaces should match `starstream-sandbox-web/src/lib.rs`.
+interface SandboxWasmImports extends WebAssembly.ModuleImports {
+  read_input(ptr: number, len: number): void;
+
+  sandbox_log(
+    level: number,
+    target: number,
+    target_len: number,
+    body: number,
+    body_len: number,
+  ): void;
+  set_wat(ptr: number, len: number): void;
+  set_core_wasm(ptr: number, len: number): void;
+  set_wit(ptr: number, len: number): void;
+  set_component_wasm(ptr: number, len: number): void;
+
+  set_describe(ptr: number, len: number): void;
+  set_call_result(ptr: number, len: number): void;
+  set_storage(ptr: number, len: number): void;
+  set_implemented(ptr: number, len: number): void;
+  set_events(ptr: number, len: number): void;
+}
+
+interface SandboxWasmExports {
+  memory: WebAssembly.Memory;
+  deploy(input_len: number): number;
+  construct(input_len: number): number;
+  call(input_len: number): number;
+  storage_get(digest: number, handle: number): number;
+  implemented_methods(digest: number, handle: number): number;
+  drop_resource(digest: number, handle: number): number;
+  set_cardano(digest: number, block_height: bigint, current_slot: bigint): number;
+}
+// ----------------------------------------------------------------------------
+
+// State the Wasm imports below read and write; set per incoming message.
+let input = new Uint8Array();
+let request_id = 0;
+let describeJson: Describe | undefined;
+let callResult: unknown[] | undefined;
+let storageJson: Record<string, unknown> | undefined;
+let implementedJson: string[] | undefined;
+let eventsJson: AbiEvent[] = [];
+
+// The numeric digest each contract is known by to the Wasm, keyed by the
+// sha256 hex digest computed by the page.
+const digestNumbers = new Map<string, number>();
+
+let wasm: SandboxWasmExports;
+let wasmPromise: Promise<SandboxWasmExports> | null = null;
+function getWasmInstance(): Promise<SandboxWasmExports> {
+  wasmPromise ??= WebAssembly.instantiateStreaming(
+    fetch(starstreamSandboxWasm),
+    {
+      env: {
+        read_input(ptr, len) {
+          new Uint8Array(wasm.memory.buffer, ptr, len).set(input);
+        },
+        sandbox_log(level, target, target_len, body, body_len) {
+          send({
+            request_id,
+            type: "log",
+            level,
+            target: utf8(target, target_len),
+            body: utf8(body, body_len),
+          });
+        },
+        set_wat() {},
+        set_core_wasm() {},
+        set_wit() {},
+        set_component_wasm() {},
+        set_describe(ptr, len) {
+          describeJson = JSON.parse(utf8(ptr, len)) as Describe;
+        },
+        set_call_result(ptr, len) {
+          callResult = JSON.parse(utf8(ptr, len)) as unknown[];
+        },
+        set_storage(ptr, len) {
+          storageJson = JSON.parse(utf8(ptr, len)) as Record<string, unknown>;
+        },
+        set_implemented(ptr, len) {
+          implementedJson = JSON.parse(utf8(ptr, len)) as string[];
+        },
+        set_events(ptr, len) {
+          eventsJson = JSON.parse(utf8(ptr, len)) as AbiEvent[];
+        },
+      } satisfies SandboxWasmImports,
+    },
+  ).then(({ instance }) => {
+    wasm = instance.exports as unknown as SandboxWasmExports;
+    return wasm;
+  });
+  return wasmPromise;
+}
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+function utf8(ptr: number, len: number): string {
+  return decoder.decode(new Uint8Array(wasm.memory.buffer, ptr, len));
+}
+
+function send(r: RunWorkerResponse, opts?: WindowPostMessageOptions) {
+  self.postMessage(r, opts);
+}
+
+// Look up the numeric digest the Wasm knows a deployment by, throwing if it was
+// never deployed in this worker.
+function digestNumber(digest: string): number {
+  const n = digestNumbers.get(digest);
+  if (n === undefined) {
+    throw new Error(`no contract deployed with digest ${digest}`);
+  }
+  return n;
+}
+
+self.onmessage = async function ({ data }: { data: RunWorkerRequest }) {
+  // Capture locally and only publish to the global once instantiation has
+  // settled: messages arriving while `getWasmInstance()` is in-flight must not
+  // overwrite the id of the request currently being served. The body below is
+  // synchronous from here on, so the global stays correct for its duration.
+  const wasm = await getWasmInstance();
+  request_id = data.request_id;
+  try {
+    if (data.type === "deploy") {
+      // Assign the digest a number; re-deploying the same digest reuses it.
+      let digest = digestNumbers.get(data.digest);
+      if (digest === undefined) {
+        digest = digestNumbers.size;
+        digestNumbers.set(data.digest, digest);
+      }
+      // CBOR-encoded `DeployInput`.
+      input = encode({ digest, wasm: data.component });
+      describeJson = undefined;
+      if (wasm.deploy(input.length) >= 0 && describeJson) {
+        send({
+          request_id,
+          type: "deployed",
+          digest: data.digest,
+          describe: describeJson,
+        });
+      } else {
+        // The error itself was already reported as a "log" response.
+        send({ request_id, type: "deploy_failed", digest: data.digest });
+      }
+    } else if (data.type === "construct") {
+      const digest = digestNumber(data.digest);
+      // JSON-encoded `ConstructInput`.
+      input = encoder.encode(
+        JSON.stringify({
+          digest,
+          instance: data.instance,
+          constructor: data.ctor,
+          args: data.args,
+        }),
+      );
+      eventsJson = [];
+      const handle = wasm.construct(input.length);
+      if (handle >= 0) {
+        send({
+          request_id,
+          type: "constructed",
+          digest: data.digest,
+          instance: data.instance,
+          handle,
+          events: eventsJson,
+        });
+      } else {
+        send({
+          request_id,
+          type: "construct_failed",
+          digest: data.digest,
+          instance: data.instance,
+        });
+      }
+    } else if (data.type === "call") {
+      const digest = digestNumber(data.digest);
+      // JSON-encoded `CallInput`.
+      input = encoder.encode(
+        JSON.stringify({
+          digest,
+          handle: data.handle,
+          method: data.method,
+          args: data.args,
+        }),
+      );
+      callResult = undefined;
+      eventsJson = [];
+      if (wasm.call(input.length) >= 0) {
+        send({
+          request_id,
+          type: "called",
+          results: callResult ?? [],
+          events: eventsJson,
+        });
+      }
+    } else if (data.type === "storageGet") {
+      const digest = digestNumber(data.digest);
+      storageJson = undefined;
+      if (wasm.storage_get(digest, data.handle) >= 0 && storageJson) {
+        send({
+          request_id,
+          type: "storage",
+          digest: data.digest,
+          handle: data.handle,
+          storage: storageJson,
+        });
+      }
+    } else if (data.type === "implementedMethods") {
+      const digest = digestNumber(data.digest);
+      implementedJson = undefined;
+      if (wasm.implemented_methods(digest, data.handle) >= 0 && implementedJson) {
+        send({
+          request_id,
+          type: "implemented",
+          digest: data.digest,
+          handle: data.handle,
+          methods: implementedJson,
+        });
+      }
+    } else if (data.type === "drop") {
+      const digest = digestNumber(data.digest);
+      if (wasm.drop_resource(digest, data.handle) >= 0) {
+        send({ request_id, type: "dropped", digest: data.digest, handle: data.handle });
+      }
+    } else if (data.type === "setCardano") {
+      const digest = digestNumber(data.digest);
+      wasm.set_cardano(
+        digest,
+        BigInt(Math.trunc(data.blockHeight)),
+        BigInt(Math.trunc(data.currentSlot)),
+      );
+    } else {
+      data satisfies never;
+    }
+  } catch (crash) {
+    send({
+      request_id,
+      type: "log",
+      level: 1,
+      target: "run",
+      body: String(crash),
+    });
+  }
+  send({ request_id, type: "idle" });
+};

--- a/website/src/sandbox.worker.ts
+++ b/website/src/sandbox.worker.ts
@@ -56,6 +56,12 @@ interface SandboxWasmImports extends WebAssembly.ModuleImports {
   set_core_wasm(ptr: number, len: number): void;
   set_wit(ptr: number, len: number): void;
   set_component_wasm(ptr: number, len: number): void;
+
+  set_describe(ptr: number, len: number): void;
+  set_call_result(ptr: number, len: number): void;
+  set_storage(ptr: number, len: number): void;
+  set_implemented(ptr: number, len: number): void;
+  set_events(ptr: number, len: number): void;
 }
 
 interface SandboxWasmExports {
@@ -139,6 +145,13 @@ self.onmessage = async function ({ data }: { data: SandboxWorkerRequest }) {
         bytes: new Uint8Array(wasm.memory.buffer, ptr, len),
       });
     },
+    // Only called by the Run tab's exports (`deploy`/`construct`/`call`/…),
+    // which the run worker handles.
+    set_describe() {},
+    set_call_result() {},
+    set_storage() {},
+    set_implemented() {},
+    set_events() {},
   });
   try {
     wasm.run(input.length);


### PR DESCRIPTION
Add a basic "Run" panel to the sandbox, which allows "deploying" the contract and then "creating" multiple instances of UTXOs out of them for calling individual exports. This is just the first sketch, which will likely change significantly going forward.

- Everything is added to the existing Wasm module for simplicity, but splitting these would probably make sense as a follow-up
- This PR is almost entirely generated by an LLM, mostly verified by using the sandbox UI. I have lightly reviewed the Rust code and I did not review JS/frontend.

Recording of the UI available here: https://www.youtube.com/watch?v=CcCSNLWJmnY

~Blocked on #150~