### PR TITLE
address clippy warnings

### DIFF
--- a/ark-poseidon2/src/constants.rs
+++ b/ark-poseidon2/src/constants.rs
@@ -155,6 +155,7 @@ impl RoundConstants<F, 8, 4, 22> {
 }
 
 impl RoundConstants<F, 12, 4, 22> {
+    #[must_use]
     pub fn new_goldilocks_12_constants() -> Self {
         // TODO: hardcoded seed
         let mut rng = ChaCha20Rng::seed_from_u64(77);

--- a/ark-poseidon2/src/lib.rs
+++ b/ark-poseidon2/src/lib.rs
@@ -234,8 +234,8 @@ mod tests {
         // At least one output should be non-zero (very likely with our placeholder linear layers)
         assert!(output_values.iter().any(|&val| val != F::from(0u64)));
 
-        println!("Input: {:?}", input_values);
-        println!("Output: {:?}", output_values);
+        println!("Input: {input_values:?}");
+        println!("Output: {output_values:?}");
         println!("Constraint system satisfied: {}", cs.is_satisfied()?);
         println!("Number of constraints: {}", cs.num_constraints());
 
@@ -298,8 +298,8 @@ mod tests {
             F::from(10410794385812429044_u64),
         ];
 
-        println!("Input: {:?}", input_values);
-        println!("Output: {:?}", output_values);
+        println!("Input: {input_values:?}");
+        println!("Output: {output_values:?}");
         println!("Constraint system satisfied: {}", cs.is_satisfied()?);
         println!("Number of constraints: {}", cs.num_constraints());
 

--- a/starstream-cli/src/build.rs
+++ b/starstream-cli/src/build.rs
@@ -186,8 +186,8 @@ fn write_outputs(
     let mut depfile_contents = Vec::new();
     if write_rule(
         &mut depfile_contents,
-        fs_tracker.outputs.iter().map(|s| s.as_path()),
-        fs_tracker.dependencies.iter().map(|s| s.as_path()),
+        fs_tracker.outputs.iter().map(PathBuf::as_path),
+        fs_tracker.dependencies.iter().map(PathBuf::as_path),
     )
     .is_ok()
     {

--- a/starstream-cli/src/explain.rs
+++ b/starstream-cli/src/explain.rs
@@ -25,13 +25,12 @@ impl Explain {
                 }
             }
             Err(miette::Error::msg(format!(
-                "{} is not a valid diagnostic code",
-                diagnostic_code,
+                "{diagnostic_code} is not a valid diagnostic code",
             )))
         } else {
             let mut names = ErrorCode::iter().map(|ec| ec.name).collect::<Vec<_>>();
             names.extend(WarningCode::iter().map(|wc| wc.name));
-            names.sort();
+            names.sort_unstable();
             for name in names {
                 println!("{name}");
             }

--- a/starstream-cli/src/format.rs
+++ b/starstream-cli/src/format.rs
@@ -81,10 +81,10 @@ fn unformatted_files(files: Vec<String>) -> miette::Result<Vec<Unformatted>> {
 
         if path.is_dir() {
             for path in starstream_files_excluding_gitignore(&path) {
-                format_file(&mut problem_files, path)?
+                format_file(&mut problem_files, path)?;
             }
         } else {
-            format_file(&mut problem_files, path)?
+            format_file(&mut problem_files, path)?;
         }
     }
 

--- a/starstream-cli/src/lib.rs
+++ b/starstream-cli/src/lib.rs
@@ -66,13 +66,12 @@ pub fn starstream_files_excluding_gitignore(dir: &Path) -> impl Iterator<Item = 
         .require_git(false)
         .build()
         .filter_map(Result::ok)
-        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .filter(|e| e.file_type().is_some_and(|t| t.is_file()))
         .map(ignore::DirEntry::into_path)
         .filter(move |d| is_starstream_path(d))
 }
 
 fn is_starstream_path(path: &Path) -> bool {
     path.extension()
-        .map(|e| e == starstream_compiler::FILE_EXTENSION)
-        .unwrap_or_default()
+        .is_some_and(|e| e == starstream_compiler::FILE_EXTENSION)
 }

--- a/starstream-cli/src/wasm.rs
+++ b/starstream-cli/src/wasm.rs
@@ -171,8 +171,8 @@ impl Wasm {
             let mut depfile_contents = Vec::new();
             write_rule(
                 &mut depfile_contents,
-                fs.outputs.iter().map(|s| s.as_path()),
-                fs.dependencies.iter().map(|s| s.as_path()),
+                fs.outputs.iter().map(PathBuf::as_path),
+                fs.dependencies.iter().map(PathBuf::as_path),
             )
             .expect("Error writing depfile");
             fs.write(&depfile, &depfile_contents)

--- a/starstream-interpreter/src/lib.rs
+++ b/starstream-interpreter/src/lib.rs
@@ -350,6 +350,7 @@ impl From<bool> for Value {
 }
 
 impl Value {
+    #[must_use]
     pub fn to_bool(&self) -> bool {
         match *self {
             Value::Boolean(v) => v,

--- a/starstream-language-server/src/capabilities.rs
+++ b/starstream-language-server/src/capabilities.rs
@@ -1,4 +1,7 @@
-use tower_lsp_server::lsp_types::*;
+use tower_lsp_server::lsp_types::{
+    ClientCapabilities, HoverProviderCapability, OneOf, ServerCapabilities,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+};
 
 pub fn capabilities(_: ClientCapabilities) -> ServerCapabilities {
     ServerCapabilities {

--- a/starstream-language-server/src/diagnostics.rs
+++ b/starstream-language-server/src/diagnostics.rs
@@ -33,7 +33,7 @@ where
 
     let labels: Vec<LabeledSpan> = diagnostic
         .labels()
-        .map(|iter| iter.collect())
+        .map(Iterator::collect)
         .unwrap_or_default();
 
     let mut range = Range::default();
@@ -49,7 +49,7 @@ where
 
     for label in labels.iter().skip(1) {
         let related_range = source_span_to_range(rope, label.inner());
-        let related_message = label.label().map(|s| s.to_string()).unwrap_or_default();
+        let related_message = label.label().map(ToString::to_string).unwrap_or_default();
 
         related_information.push(DiagnosticRelatedInformation {
             message: related_message,
@@ -68,7 +68,7 @@ where
             .or(Some(DiagnosticSeverity::ERROR)),
         code: diagnostic
             .code()
-            .map(|code| NumberOrString::String(format!("star-{}", code))),
+            .map(|code| NumberOrString::String(format!("star-{code}"))),
         code_description: diagnostic.url().and_then(|url| {
             url.to_string()
                 .parse()

--- a/starstream-language-server/src/document.rs
+++ b/starstream-language-server/src/document.rs
@@ -1,8 +1,10 @@
 //! State tracking for an open text document.
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use ropey::Rope;
 use tower_lsp_server::lsp_types::{
@@ -100,7 +102,7 @@ impl DocumentState {
         uri: &Uri,
         text: &str,
         version: Option<i32>,
-        workspace_folders: &[std::path::PathBuf],
+        workspace_folders: &[PathBuf],
     ) -> Self {
         let mut state = Self {
             rope: Rope::from_str(text),
@@ -144,7 +146,7 @@ impl DocumentState {
         uri: &Uri,
         text: &str,
         version: Option<i32>,
-        workspace_folders: &[std::path::PathBuf],
+        workspace_folders: &[PathBuf],
     ) {
         self.rope = Rope::from_str(text);
 
@@ -189,7 +191,7 @@ impl DocumentState {
         ))
     }
 
-    fn reanalyse(&mut self, uri: &Uri, text: &str, workspace_folders: &[std::path::PathBuf]) {
+    fn reanalyse(&mut self, uri: &Uri, text: &str, workspace_folders: &[PathBuf]) {
         self.diagnostics.clear();
         self.program = None;
         self.typed = None;
@@ -285,12 +287,12 @@ impl DocumentState {
         &mut self,
         uri: &Uri,
         text: &str,
-        workspace_folders: &[std::path::PathBuf],
+        workspace_folders: &[PathBuf],
     ) -> bool {
         let Some(file_path) = uri_to_file_path(uri) else {
             return false;
         };
-        let Ok(canonical_file) = std::fs::canonicalize(&file_path) else {
+        let Ok(canonical_file) = fs::canonicalize(&file_path) else {
             return false;
         };
 
@@ -301,27 +303,26 @@ impl DocumentState {
         // contract, an imported helper, or a loose orphan. Either way the
         // graph knows about it.
         let mut fs = starstream_types::FileSystem::new();
-        let graph =
-            match starstream_compiler::module_graph::load_workspace(&workspace_root, &mut fs) {
-                Ok(g) => g,
-                Err(_) => {
-                    // If the workspace scan blew up (e.g. cross-contract import
-                    // somewhere we don't own), still try to give *this* file
-                    // diagnostics by rooting a single-file graph at it.
-                    let mut local_fs = starstream_types::FileSystem::new();
-                    let Ok(local_graph) = starstream_compiler::module_graph::load_from_entry(
-                        &canonical_file,
-                        &mut local_fs,
-                    ) else {
-                        return false;
-                    };
-                    let module_id = local_graph
-                        .find_by_path(&canonical_file)
-                        .expect("entry module is always in its own graph");
-                    self.run_graph_typecheck(uri, text, &local_graph, module_id);
-                    return true;
-                }
+        let graph = if let Ok(g) =
+            starstream_compiler::module_graph::load_workspace(&workspace_root, &mut fs)
+        {
+            g
+        } else {
+            // If the workspace scan blew up (e.g. cross-contract import
+            // somewhere we don't own), still try to give *this* file
+            // diagnostics by rooting a single-file graph at it.
+            let mut local_fs = starstream_types::FileSystem::new();
+            let Ok(local_graph) =
+                starstream_compiler::module_graph::load_from_entry(&canonical_file, &mut local_fs)
+            else {
+                return false;
             };
+            let module_id = local_graph
+                .find_by_path(&canonical_file)
+                .expect("entry module is always in its own graph");
+            self.run_graph_typecheck(uri, text, &local_graph, module_id);
+            return true;
+        };
 
         if let Some(module_id) = graph.find_by_path(&canonical_file) {
             self.run_graph_typecheck(uri, text, &graph, module_id);
@@ -419,7 +420,7 @@ impl DocumentState {
     }
 
     /// Format the cached AST. Returns `None` if parsing failed.
-    pub fn format(&self) -> Result<Option<String>, std::fmt::Error> {
+    pub fn format(&self) -> Result<Option<String>, fmt::Error> {
         let program = match self.program() {
             Some(program) => program,
             None => return Ok(None),
@@ -610,21 +611,21 @@ impl DocumentState {
         match definition {
             TypedDefinition::Import(import) => self.collect_import(import),
             TypedDefinition::Function(function) => {
-                self.collect_function(function, scopes, doc.clone())
+                self.collect_function(function, scopes, doc.clone());
             }
             TypedDefinition::Struct(definition) => {
                 let untyped_struct = untyped.and_then(|u| match &u.node {
                     untyped_ast::Definition::Struct(s) => Some(s),
                     _ => None,
                 });
-                self.collect_struct(definition, untyped_struct, source, doc.clone())
+                self.collect_struct(definition, untyped_struct, source, doc.clone());
             }
             TypedDefinition::Enum(definition) => {
                 let untyped_enum = untyped.and_then(|u| match &u.node {
                     untyped_ast::Definition::Enum(e) => Some(e),
                     _ => None,
                 });
-                self.collect_enum(definition, untyped_enum, source, doc.clone())
+                self.collect_enum(definition, untyped_enum, source, doc.clone());
             }
             TypedDefinition::Utxo(definition) => self.collect_utxo(definition, scopes),
             TypedDefinition::Abi(definition) => {
@@ -632,7 +633,7 @@ impl DocumentState {
                     untyped_ast::Definition::Abi(a) => Some(a),
                     _ => None,
                 });
-                self.collect_abi(definition, untyped_abi, source, doc.clone())
+                self.collect_abi(definition, untyped_abi, source, doc.clone());
             }
             TypedDefinition::Contract => {
                 // `contract;` is a pure marker — no symbols, no hover info.
@@ -1395,7 +1396,7 @@ impl DocumentState {
                                 })
                             });
                         if let Some(types) = types {
-                            for (pattern, ty) in patterns.iter().zip(types.into_iter()) {
+                            for (pattern, ty) in patterns.iter().zip(types) {
                                 self.collect_pattern(pattern, scopes, Some(ty));
                             }
                         } else {
@@ -1588,7 +1589,7 @@ impl DocumentState {
             .cloned()
     }
 
-    /// Find the struct name for a given type by checking the struct_type_index.
+    /// Find the struct name for a given type by checking the `struct_type_index`.
     fn find_struct_name_for_type(&self, ty: &Type) -> Option<String> {
         if !matches!(ty, Type::Record(_)) {
             return None;
@@ -1823,7 +1824,7 @@ impl DocumentState {
                 .struct_types
                 .get(name)
                 .or_else(|| self.enum_types.get(name))
-                .map(|ty| ty.to_string()),
+                .map(ToString::to_string),
         }
     }
 
@@ -2074,7 +2075,7 @@ impl DocumentState {
                             Some(
                                 types
                                     .iter()
-                                    .map(|ty| ty.to_string())
+                                    .map(ToString::to_string)
                                     .collect::<Vec<_>>()
                                     .join(", "),
                             )
@@ -2157,7 +2158,7 @@ impl DocumentState {
                 TypedUtxoPart::AbiImpl { abi, span, parts } => {
                     let impl_children = parts
                         .iter()
-                        .flat_map(|function| self.function_symbol(function))
+                        .filter_map(|function| self.function_symbol(function))
                         .collect::<Vec<_>>();
                     children.push(DocumentSymbol {
                         name: abi.to_compact_string(),
@@ -2208,7 +2209,7 @@ impl DocumentState {
                             .collect::<Vec<_>>()
                             .join(", ");
 
-                        let detail = Some(format!("({})", params));
+                        let detail = Some(format!("({params})"));
 
                         #[allow(deprecated)]
                         let child = DocumentSymbol {
@@ -2338,7 +2339,7 @@ fn format_enum_variant_hover_from_info(
             } else {
                 let payload = types
                     .iter()
-                    .map(|ty| ty.to_compact_string())
+                    .map(starstream_types::Type::to_compact_string)
                     .collect::<Vec<_>>()
                     .join(", ");
                 format!("{enum_name}::{variant_name}({payload})")
@@ -2436,13 +2437,13 @@ struct StructTypeEntry {
 /// Convert an LSP `Uri` (`file:///abs/path/to/foo.star`) to a `PathBuf`.
 /// Returns `None` for non-file URIs (e.g. `untitled:`, `vscode-vfs:`) or if
 /// the URI can't be percent-decoded.
-pub fn uri_to_file_path(uri: &Uri) -> Option<std::path::PathBuf> {
+pub fn uri_to_file_path(uri: &Uri) -> Option<PathBuf> {
     let s = uri.as_str();
     let raw = s.strip_prefix("file://")?;
     // On Windows VS Code emits `file:///C:/...`; on Unix it's `file:///abs/...`.
     // After stripping `file://`, both look like `/...` (Unix) or `/C:/...` (Win).
     let decoded = percent_decode(raw);
-    Some(std::path::PathBuf::from(decoded))
+    Some(PathBuf::from(decoded))
 }
 
 /// Minimal percent-decoder. The LSP only sends URIs the editor produced, so
@@ -2452,12 +2453,13 @@ fn percent_decode(s: &str) -> String {
     let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let (Some(h), Some(l)) = (hex_digit(bytes[i + 1]), hex_digit(bytes[i + 2])) {
-                out.push((h << 4) | l);
-                i += 3;
-                continue;
-            }
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let (Some(h), Some(l)) = (hex_digit(bytes[i + 1]), hex_digit(bytes[i + 2]))
+        {
+            out.push((h << 4) | l);
+            i += 3;
+            continue;
         }
         out.push(bytes[i]);
         i += 1;
@@ -2483,19 +2485,15 @@ fn hex_digit(b: u8) -> Option<u8> {
 ///
 /// If no announced folder contains the file (or the editor announced
 /// none), fall back to the file's parent directory.
-fn workspace_root_for(
-    file_path: &std::path::Path,
-    workspace_folders: &[std::path::PathBuf],
-) -> std::path::PathBuf {
-    let mut best: Option<&std::path::Path> = None;
+fn workspace_root_for(file_path: &Path, workspace_folders: &[PathBuf]) -> PathBuf {
+    let mut best: Option<&Path> = None;
     for folder in workspace_folders {
-        let candidate = std::fs::canonicalize(folder).unwrap_or_else(|_| folder.clone());
+        let candidate = fs::canonicalize(folder).unwrap_or_else(|_| folder.clone());
         if file_path.starts_with(&candidate) {
             // Prefer the deepest containing folder.
-            if best
-                .map(|cur| candidate.as_path().components().count() > cur.components().count())
-                .unwrap_or(true)
-            {
+            if best.is_none_or(|cur| {
+                candidate.as_path().components().count() > cur.components().count()
+            }) {
                 // Storing as PathBuf via unsafe gymnastics is overkill;
                 // re-derive at the end.
                 let _ = best.replace(folder.as_path());
@@ -2503,11 +2501,10 @@ fn workspace_root_for(
         }
     }
     if let Some(found) = best {
-        return std::fs::canonicalize(found).unwrap_or_else(|_| found.to_path_buf());
+        return fs::canonicalize(found).unwrap_or_else(|_| found.to_path_buf());
     }
 
     file_path
         .parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf)
 }

--- a/starstream-language-server/src/lib.rs
+++ b/starstream-language-server/src/lib.rs
@@ -12,7 +12,14 @@ use std::sync::RwLock;
 use tower_lsp_server::{
     Client, ClientSocket, LanguageServer, LspService,
     jsonrpc::{self, Error, Result},
-    lsp_types::*,
+    lsp_types::{
+        DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+        DidSaveTextDocumentParams, DocumentFormattingParams, DocumentSymbolParams,
+        DocumentSymbolResponse, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
+        InitializeParams, InitializeResult, InitializedParams, Location, MessageType, Position,
+        Range, ReferenceParams, RenameParams, TextDocumentPositionParams, TextEdit, Uri,
+        WorkspaceEdit, WorkspaceFolder,
+    },
 };
 
 // At the moment LSP version == CLI version, but for completeness's sake:
@@ -38,7 +45,7 @@ struct TextDocumentItem<'a> {
 }
 
 impl Server {
-    /// Create a new [LspService] configured for the Starstream language server.
+    /// Create a new [`LspService`] configured for the Starstream language server.
     pub fn new() -> (LspService<Self>, ClientSocket) {
         // Any custom methods can be set here.
         LspService::new(Self::with_client)
@@ -177,7 +184,7 @@ impl LanguageServer for Server {
             text: text.as_str(),
             version: Some(version),
         })
-        .await
+        .await;
     }
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {

--- a/starstream-sandbox-web/src/lib.rs
+++ b/starstream-sandbox-web/src/lib.rs
@@ -95,7 +95,7 @@ pub unsafe extern "C" fn run(input_len: usize) {
     // WITify core version if we can.
     match print_wit(&wasm, true) {
         Ok(wit) => unsafe { set_wit(wit.as_ptr(), wit.len()) },
-        Err(error) => error!("print_wit(core): {}", error),
+        Err(error) => error!("print_wit(core): {error}"),
     }
 
     // Componentize.
@@ -106,13 +106,13 @@ pub unsafe extern "C" fn run(input_len: usize) {
             // WITify component version (it'll be more compact).
             match print_wit(&wasm, false) {
                 Ok(wit) => unsafe { set_wit(wit.as_ptr(), wit.len()) },
-                Err(error) => error!("print_wit(component): {}", error),
+                Err(error) => error!("print_wit(component): {error}"),
             }
 
             wasm
         }
         Err(error) => {
-            error!("componentize: {}", error);
+            error!("componentize: {error}");
             wasm
         }
     };
@@ -156,7 +156,7 @@ fn componentize(wasm: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
 // ----------------------------------------------------------------------------
 
 fn write_report(report: &miette::Report) {
-    error!("{}", report);
+    error!("{report}");
 }
 
 // ----------------------------------------------------------------------------
@@ -179,7 +179,7 @@ impl log::Log for Logger {
                 record.target().len(),
                 body.as_ptr(),
                 body.len(),
-            )
+            );
         };
     }
 

--- a/starstream-to-wasm/src/component_abi.rs
+++ b/starstream-to-wasm/src/component_abi.rs
@@ -1,14 +1,14 @@
 #![allow(dead_code)]
 //! Component model canonical ABI implementation.
 //!
-//! Spec: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
+//! Spec: <https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md>
 #![allow(unused_variables)]
 
 use std::rc::Rc;
 
 use wasm_encoder::{InstructionSink, MemArg};
 
-/// Despecialized component value type. Like [wasm_encoder::ComponentValType].
+/// Despecialized component value type. Like [`wasm_encoder::ComponentValType`].
 #[derive(Hash, PartialEq, Eq, Debug)]
 pub enum ComponentAbiType {
     Bool,
@@ -113,9 +113,9 @@ impl ComponentAbiType {
     }
 
     pub fn discriminant_type(n: usize) -> ComponentAbiType {
-        if n <= usize::from(u8::MAX) {
+        if u8::try_from(n).is_ok() {
             ComponentAbiType::U8
-        } else if n <= usize::from(u16::MAX) {
+        } else if u16::try_from(n).is_ok() {
             ComponentAbiType::U16
         } else if let Ok(m) = usize::try_from(u32::MAX)
             && n <= m

--- a/starstream-to-wasm/src/decision_tree.rs
+++ b/starstream-to-wasm/src/decision_tree.rs
@@ -98,7 +98,7 @@ pub struct Matrix {
     pub rows: Vec<Row>,
 }
 
-/// A binding extracted from a Leaf node: (arm_index, name, column_index).
+/// A binding extracted from a Leaf node: (`arm_index`, `name`, `column_index`).
 #[derive(Clone, Debug)]
 pub struct LeafBinding {
     pub action: usize,
@@ -176,12 +176,12 @@ pub fn compile(matrix: &Matrix, col_types: &[Type]) -> DecisionTree {
         })
         .collect();
 
-    let default = if !complete {
+    let default = if complete {
+        None
+    } else {
         let def_matrix = default_matrix(matrix, i);
         let def_col_types = default_col_types(col_types, i);
         Some(Box::new(compile(&def_matrix, &def_col_types)))
-    } else {
-        None
     };
 
     DecisionTree::Switch {

--- a/starstream-to-wasm/src/encoder.rs
+++ b/starstream-to-wasm/src/encoder.rs
@@ -120,7 +120,7 @@ impl<T: TypeRegistry> TypeBuilder<T> {
     }
 }
 
-/// Abstraction over [ComponentType] and [InstanceType].
+/// Abstraction over [`ComponentType`] and [`InstanceType`].
 #[allow(dead_code)]
 pub trait TypeRegistry {
     fn ty(&mut self) -> ComponentTypeEncoder<'_>;

--- a/starstream-to-wasm/src/ir.rs
+++ b/starstream-to-wasm/src/ir.rs
@@ -145,7 +145,7 @@ impl ControlFlowGraph {
         _ = writeln!(gv, "digraph {{");
         _ = writeln!(gv, "start [shape=box] [style=rounded];");
         _ = writeln!(gv, "start -> 0;");
-        for bb in self.resumes.iter() {
+        for bb in &self.resumes {
             _ = writeln!(gv, "yield_{bb} -> resume_{bb} [style=dotted];");
             _ = writeln!(gv, "resume_{bb} [shape=box] [style=rounded];");
             _ = writeln!(gv, "resume_{bb} -> {bb};");
@@ -155,7 +155,7 @@ impl ControlFlowGraph {
                 gv,
                 "{} [label=\"{}\"] [shape=box];",
                 i,
-                block.disassemble().to_string().replace("\n", "\\l")
+                block.disassemble().to_string().replace('\n', "\\l")
             );
             match block.out {
                 Out::None => {}
@@ -202,7 +202,7 @@ impl ControlFlowGraph {
             writeln!(fmt, "flowchart TB")?;
             writeln!(fmt, "start([start])")?;
             writeln!(fmt, "start --> 0")?;
-            for bb in self.resumes.iter() {
+            for bb in &self.resumes {
                 writeln!(fmt, "yield_{bb} -.-> resume_{bb}")?;
                 writeln!(fmt, "resume_{bb}([resume {bb}])")?;
                 writeln!(fmt, "resume_{bb} --> {bb}")?;
@@ -234,12 +234,12 @@ impl BasicBlock {
             match self.in_type {
                 None | Some(BlockType::Empty) => {}
                 Some(other) => {
-                    writeln!(fmt, "=> {:?}", other)?;
+                    writeln!(fmt, "=> {other:?}")?;
                 }
             }
             let br = wasmparser::BinaryReader::new(&self.instructions, 0);
             let or = wasmparser::OperatorsReader::new(br);
-            for result in or.into_iter() {
+            for result in or {
                 let op = result.unwrap();
                 writeln!(fmt, "{op:?}")?;
             }

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -3,9 +3,24 @@ use std::{borrow::Cow, collections::HashMap, rc::Rc};
 
 use miette::{Diagnostic, LabeledSpan};
 use sha2::Digest;
-use starstream_types::*;
+use starstream_types::{
+    BinaryOp, EffectKind, EnumType, EnumVariantKind, FunctionExport, Identifier, IntWidth, Literal,
+    RecordFieldType, RecordType, Span, Spanned, Type, TypedAbiDef, TypedAbiPart, TypedBlock,
+    TypedDefinition, TypedEnumConstructorPayload, TypedEnumDef, TypedEnumPatternPayload, TypedExpr,
+    TypedExprKind, TypedFunctionDef, TypedFunctionParam, TypedIfCondition, TypedImportDef,
+    TypedImportItems, TypedImportSource, TypedMatchArm, TypedPattern, TypedProgram, TypedStatement,
+    TypedStructDef, TypedStructField, TypedStructLiteralField, TypedUtxoDef, TypedUtxoPart,
+    UnaryOp,
+};
 use thiserror::Error;
-use wasm_encoder::*;
+use wasm_encoder::{
+    BlockType, CodeSection, Component, ComponentExportKind, ComponentExportSection,
+    ComponentSection, ComponentType, ComponentTypeRef, ComponentTypeSection, ComponentValType,
+    ConstExpr, CustomSection, DataSection, Encode, EntityType, ExportKind, ExportSection, FuncType,
+    Function, FunctionSection, GlobalSection, GlobalType, Ieee32, Ieee64, ImportSection,
+    InstanceType, InstructionSink, MemorySection, MemoryType, Module, Section, TypeBounds,
+    TypeSection, ValType,
+};
 
 use crate::component_abi::{ComponentAbiType, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS};
 use crate::decision_tree::{Ctor, DecisionTree, Matrix, Pat, Row};
@@ -51,7 +66,7 @@ mod stackifier;
 pub struct CompileOptions {
     /// Change to `false` to wrap instead of error on arithmetic overflow.
     pub check_overflows: bool,
-    /// Change to `true` to populate [CompileResult::mermaid].
+    /// Change to `true` to populate [`CompileResult::mermaid`].
     pub output_mermaid: bool,
 }
 
@@ -63,7 +78,7 @@ pub struct CompileResult {
     pub wasm: Option<Vec<u8>>,
     /// The WIT custom section bytes.
     pub binary_wit: Option<Vec<u8>>,
-    /// List of (name, flowchart) pairs. Requires [CompileOptions::output_mermaid].
+    /// List of (name, flowchart) pairs. Requires [`CompileOptions::output_mermaid`].
     pub mermaid: Vec<(String, String)>,
 }
 
@@ -76,6 +91,7 @@ pub struct CompileError {
 }
 
 /// Compile a Starstream program to a Wasm module with default options.
+#[must_use]
 pub fn compile(program: &TypedProgram) -> CompileResult {
     CompileOptions::default().compile(program)
 }
@@ -89,6 +105,7 @@ pub fn compile(program: &TypedProgram) -> CompileResult {
 /// becomes an exported transaction root, whether it's declared in the entry
 /// itself or in one of its helpers — if you wrote `script fn`, it gets
 /// exported.
+#[must_use]
 pub fn compile_contract(
     graph: &starstream_compiler::TypedModuleGraph,
     entry: starstream_compiler::ModuleId,
@@ -106,6 +123,7 @@ impl Default for CompileOptions {
 }
 
 impl CompileOptions {
+    #[must_use]
     pub fn compile(self, program: &TypedProgram) -> CompileResult {
         let mut compiler = Compiler::default();
         compiler.options = self;
@@ -113,6 +131,7 @@ impl CompileOptions {
         compiler.finish()
     }
 
+    #[must_use]
     pub fn compile_contract(
         self,
         graph: &starstream_compiler::TypedModuleGraph,
@@ -132,23 +151,19 @@ impl CompileOptions {
         while let Some(id) = stack.pop() {
             let module = graph.module(id);
             for def in &module.program.definitions {
-                if let TypedDefinition::Import(import) = def {
-                    if let TypedImportSource::Path {
+                if let TypedDefinition::Import(import) = def
+                    && let TypedImportSource::Path {
                         canonical: Some(canonical),
                         ..
                     } = &import.from
-                    {
-                        if let Some(target) = graph
-                            .modules
-                            .iter()
-                            .find(|m| &m.abs_path == canonical)
-                            .map(|m| m.id)
-                        {
-                            if reachable.insert(target) {
-                                stack.push(target);
-                            }
-                        }
-                    }
+                    && let Some(target) = graph
+                        .modules
+                        .iter()
+                        .find(|m| &m.abs_path == canonical)
+                        .map(|m| m.id)
+                    && reachable.insert(target)
+                {
+                    stack.push(target);
                 }
             }
         }
@@ -225,7 +240,7 @@ struct Compiler {
 }
 
 impl Compiler {
-    /// After [Compiler::visit_program], this function collates all the
+    /// After [`Compiler::visit_program`], this function collates all the
     /// in-progress sections into an actual Wasm binary module.
     fn finish(mut self) -> CompileResult {
         // TODO: any other final activity on the sections here, such as
@@ -382,7 +397,7 @@ impl Compiler {
     ) {
         if !fields.is_empty() {
             let resource_name = to_kebab_case(name.as_str());
-            let storage_name = format!("{}Storage", name);
+            let storage_name = format!("{name}Storage");
             let storage_struct = Type::Record(RecordType {
                 name: storage_name.clone(),
                 fields: fields
@@ -399,7 +414,7 @@ impl Compiler {
                 ty: storage_struct.clone(),
             });
             self.visit_function(
-                &format!("{}-get-storage", resource_name),
+                &format!("{resource_name}-get-storage"),
                 &TypedFunctionDef {
                     export: Some(FunctionExport::Script),
                     name: Identifier::anon(format!("{name}::get_storage")),
@@ -426,7 +441,7 @@ impl Compiler {
                 scope,
             );
             self.visit_function(
-                &format!("{}-set-storage", resource_name),
+                &format!("{resource_name}-set-storage"),
                 &TypedFunctionDef {
                     export: Some(FunctionExport::Script),
                     name: Identifier::anon(format!("{name}::set_storage")),
@@ -469,14 +484,13 @@ impl Compiler {
     /// Add a function signature to the `types` section if needed, and return
     /// the index of the new or existing entry.
     fn add_core_func_type(&mut self, ty: FuncType) -> u32 {
-        match self.core_func_type_cache.get(&ty) {
-            Some(&index) => index,
-            None => {
-                let index = self.types.len();
-                self.types.ty().func_type(&ty);
-                self.core_func_type_cache.insert(ty, index);
-                index
-            }
+        if let Some(&index) = self.core_func_type_cache.get(&ty) {
+            index
+        } else {
+            let index = self.types.len();
+            self.types.ty().func_type(&ty);
+            self.core_func_type_cache.insert(ty, index);
+            index
         }
     }
 
@@ -751,7 +765,7 @@ impl Compiler {
         let params = function
             .params
             .iter()
-            .flat_map(|p| {
+            .filter_map(|p| {
                 self.star_to_component_type(&p.ty)
                     .map(|t| (to_kebab_case(p.name.as_str()), t))
             })
@@ -942,7 +956,7 @@ impl Compiler {
                 let fields = record
                     .fields
                     .iter()
-                    .flat_map(|f| {
+                    .filter_map(|f| {
                         self.star_to_component_type(&f.ty)
                             .map(|ty| (f.name.as_str().to_owned(), ty))
                     })
@@ -1004,7 +1018,7 @@ impl Compiler {
                                 EnumVariantKind::Tuple(fields) => {
                                     let fields: Vec<_> = fields
                                         .iter()
-                                        .flat_map(|f| self.star_to_component_type(f))
+                                        .filter_map(|f| self.star_to_component_type(f))
                                         .collect();
                                     if fields.is_empty() {
                                         None
@@ -1015,7 +1029,7 @@ impl Compiler {
                                 EnumVariantKind::Struct(fields) => {
                                     let fields: Vec<_> = fields
                                         .iter()
-                                        .flat_map(|f| self.star_to_component_type(&f.ty))
+                                        .filter_map(|f| self.star_to_component_type(&f.ty))
                                         .collect();
                                     if fields.is_empty() {
                                         None
@@ -1269,7 +1283,7 @@ impl Compiler {
                 TypedDefinition::Contract => { /* Pure marker, no codegen. */ }
 
                 TypedDefinition::Function(func) => {
-                    self.visit_function(&to_kebab_case(func.name.as_str()), func, &())
+                    self.visit_function(&to_kebab_case(func.name.as_str()), func, &());
                 }
                 TypedDefinition::Struct(struct_) => self.visit_struct(struct_),
                 TypedDefinition::Utxo(utxo) => self.visit_utxo(utxo),
@@ -1328,7 +1342,7 @@ impl Compiler {
                     // Component import
                     let comp_params = params
                         .iter()
-                        .flat_map(|p| self.star_to_component_type(p).map(|t| ("x", t)))
+                        .filter_map(|p| self.star_to_component_type(p).map(|t| ("x", t)))
                         .collect::<Vec<_>>();
                     let comp_result = self.star_to_component_type(result);
                     let iface = self
@@ -1401,7 +1415,7 @@ impl Compiler {
                     let comp_params = event
                         .params
                         .iter()
-                        .flat_map(|p| self.star_to_component_type(&p.ty).map(|t| ("x", t)))
+                        .filter_map(|p| self.star_to_component_type(&p.ty).map(|t| ("x", t)))
                         .collect::<Vec<_>>();
                     let comp_result = None;
                     let iface = self.imported_interfaces.entry(interface).or_default();
@@ -1450,7 +1464,7 @@ impl Compiler {
             self.mermaid
                 .push((wit_name.to_string(), func.cfg.to_mermaid().to_string()));
             self.mermaid.push((
-                format!("{}_{}", wit_name, bb_orig),
+                format!("{wit_name}_{bb_orig}"),
                 stackified.to_mermaid().to_string(),
             ));
         }
@@ -1463,7 +1477,7 @@ impl Compiler {
             let stackified = stackify(&func, resume, stackifier::AsyncMode::AsyncContinuation);
             if self.options.output_mermaid {
                 self.mermaid.push((
-                    format!("{}_{}", wit_name, resume),
+                    format!("{wit_name}_{resume}"),
                     stackified.to_mermaid().to_string(),
                 ));
             }
@@ -1472,7 +1486,7 @@ impl Compiler {
         }
 
         match function.export {
-            Some(FunctionExport::Script) | Some(FunctionExport::UtxoMain) => {
+            Some(FunctionExport::Script | FunctionExport::UtxoMain) => {
                 self.export_component_fn(wit_name, function, idx, &params, &results);
             }
             None => {}
@@ -1563,7 +1577,7 @@ impl Compiler {
             for yield_id in range {
                 func.instructions().block(BlockType::Empty);
                 func.instructions().global_get(yield_global);
-                func.instructions().i32_const((yield_id + 1) as i32);
+                func.instructions().i32_const(yield_id + 1);
                 func.instructions().i32_ne();
                 func.instructions().br_if(0);
                 func.instructions()
@@ -1983,7 +1997,7 @@ impl Compiler {
                 Ok(())
             }
             TypedExprKind::Literal(Literal::Boolean(b)) => {
-                func.instructions(bb).i32_const(*b as i32);
+                func.instructions(bb).i32_const(i32::from(*b));
                 assert_eq!(expr.ty, Type::Bool);
                 Ok(())
             }
@@ -2502,7 +2516,7 @@ impl Compiler {
                     }
                     other => Err(self.push_error(
                         field.span_or(target.span),
-                        format!("field access is only valid on structs, not {:?}", other),
+                        format!("field access is only valid on structs, not {other:?}"),
                     )),
                 }
             }
@@ -2641,10 +2655,7 @@ impl Compiler {
                     }
                     TypedEnumConstructorPayload::Struct(fields) => {
                         let EnumVariantKind::Struct(struct_) = &variant_ty.kind else {
-                            panic!(
-                                "EnumConstructor struct used for non-struct variant {}",
-                                variant
-                            );
+                            panic!("EnumConstructor struct used for non-struct variant {variant}");
                         };
                         let fields = fields
                             .iter()
@@ -2893,7 +2904,7 @@ impl Compiler {
         Ok(())
     }
 
-    /// Same as visit_match_stack but drops the result.
+    /// Same as `visit_match_stack` but drops the result.
     fn visit_match_drop(
         &mut self,
         func: &mut StFunction,
@@ -2940,7 +2951,7 @@ impl Compiler {
         Ok(())
     }
 
-    /// Lower a TypedPattern into the simplified Pat for the decision tree matrix.
+    /// Lower a `TypedPattern` into the simplified Pat for the decision tree matrix.
     /// Bindings are embedded as `Pat::Wildcard { binding: Some(...) }` so that
     /// the CC algorithm's specialization automatically tracks them through columns.
     fn lower_pattern(&mut self, pattern: &TypedPattern, arm_idx: usize, ty: &Type) -> Pat {
@@ -3059,7 +3070,14 @@ impl Compiler {
                     }
                 }
 
-                if !bulk.is_empty() {
+                if bulk.is_empty() {
+                    let _ = self.visit_block_drop(
+                        func,
+                        bb,
+                        &(locals, &arm_locals),
+                        &arms[*action].body,
+                    );
+                } else {
                     let _ = self.visit_block_stack(
                         func,
                         bb,
@@ -3067,13 +3085,6 @@ impl Compiler {
                         &arms[*action].body,
                     );
                     bulk.store(func, bb);
-                } else {
-                    let _ = self.visit_block_drop(
-                        func,
-                        bb,
-                        &(locals, &arm_locals),
-                        &arms[*action].body,
-                    );
                 }
                 func.cfg.fill(*bb, Out::Next(bb_end));
             }
@@ -3406,7 +3417,7 @@ impl Compiler {
         }
     }
 
-    /// Expand col_locals for a struct match: replace the struct column with field columns.
+    /// Expand `col_locals` for a struct match: replace the struct column with field columns.
     fn expand_col_locals_for_struct(
         &mut self,
         col_locals: &[(u32, Type)],
@@ -3470,9 +3481,9 @@ impl Locals for (&dyn Locals, &HashMap<String, Var>) {
     }
 }
 
-/// A replacement for [wasm_encoder::Function] that allows adding locals gradually.
+/// A replacement for [`wasm_encoder::Function`] that allows adding locals gradually.
 ///
-/// Bytecode can be encoded to the return value of [Function::instructions].
+/// Bytecode can be encoded to the return value of [`Function::instructions`].
 #[derive(Default)]
 struct StFunction {
     params: Vec<ValType>,
@@ -3536,14 +3547,14 @@ impl FromIterator<ValType> for RleLocals {
 impl wasm_encoder::Encode for RleLocals {
     fn encode(&self, sink: &mut Vec<u8>) {
         self.0.len().encode(sink);
-        for &(count, ty) in self.0.iter() {
+        for &(count, ty) in &self.0 {
             count.encode(sink);
             ty.encode(sink);
         }
     }
 }
 
-/// Switch between 0 results, 1 result that can be a BlockType, or 2+ results that must be in locals.
+/// Switch between 0 results, 1 result that can be a `BlockType`, or 2+ results that must be in locals.
 enum BulkBlockOutput {
     BlockType(BlockType),
     Locals { start: u32, len: u32 },
@@ -3593,7 +3604,7 @@ impl BulkBlockOutput {
     }
 }
 
-/// Remove column `col` from a col_locals slice.
+/// Remove column `col` from a `col_locals` slice.
 fn remove_col(col_locals: &[(u32, Type)], col: usize) -> Vec<(u32, Type)> {
     let mut result = Vec::with_capacity(col_locals.len() - 1);
     result.extend_from_slice(&col_locals[..col]);

--- a/starstream-to-wasm/src/stackifier.rs
+++ b/starstream-to-wasm/src/stackifier.rs
@@ -57,7 +57,7 @@ pub fn stackify(func: &StFunction, entry: usize, mode: AsyncMode) -> Stackified<
     s
 }
 
-impl<'a> Stackified<'a> {
+impl Stackified<'_> {
     fn compile(&mut self) {
         let Stackified { func, entry, .. } = *self;
         func.cfg.assert_complete();
@@ -253,7 +253,7 @@ impl<'a> Stackified<'a> {
                     }
                 }
             }
-            for item in self.seq.iter() {
+            for item in &self.seq {
                 if let &SeqItem::Basic(bb) = item {
                     write!(fmt, "{}", self.func.cfg.blocks[bb].out.to_mermaid(bb))?;
                 }
@@ -301,9 +301,8 @@ impl DepthTracker {
 
 fn next_block_is(seq: &[SeqItem], next: usize) -> bool {
     for each in seq {
-        match each {
-            &SeqItem::Basic(bb) => return bb == next,
-            _ => {}
+        if let &SeqItem::Basic(bb) = each {
+            return bb == next;
         }
     }
     false

--- a/starstream-to-wasm/tests/overflow.rs
+++ b/starstream-to-wasm/tests/overflow.rs
@@ -5,7 +5,7 @@ use wasmtime::{Config, Engine, Linker, Module, Store};
 fn compile_program(source: &str) -> Vec<u8> {
     let parse_output = starstream_compiler::parse_program(source);
     let (program, errors) = parse_output.into_output_errors();
-    assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+    assert!(errors.is_empty(), "Parse errors: {errors:?}");
 
     let program = program.expect("No program parsed");
     let success = starstream_compiler::typecheck_program(
@@ -39,17 +39,17 @@ fn execute_wasm(wasm: &[u8], func_name: &str, params: &[i64]) -> Result<Vec<i64>
     let instance = linker.instantiate(&mut store, &module).unwrap();
     let func = instance
         .get_func(&mut store, func_name)
-        .unwrap_or_else(|| panic!("Function {} not found", func_name));
+        .unwrap_or_else(|| panic!("Function {func_name} not found"));
 
     let mut results = vec![wasmtime::Val::I64(0)];
     let params: Vec<wasmtime::Val> = params.iter().map(|&p| wasmtime::Val::I64(p)).collect();
 
     match func.call(&mut store, &params, &mut results) {
-        Ok(_) => {
+        Ok(()) => {
             let result: Vec<i64> = results.iter().map(|v| v.i64().unwrap()).collect();
             Ok(result)
         }
-        Err(e) => Err(format!("{}", e)),
+        Err(e) => Err(format!("{e}")),
     }
 }
 
@@ -59,11 +59,11 @@ fn execute_wasm(wasm: &[u8], func_name: &str, params: &[i64]) -> Result<Vec<i64>
 
 #[test]
 fn test_overflow_i64_max_plus_one() {
-    let source = r#"
+    let source = r"
 script fn overflow_test() -> i64 {
     9223372036854775807 + 1
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -73,11 +73,11 @@ script fn overflow_test() -> i64 {
 
 #[test]
 fn test_overflow_i64_max_plus_max() {
-    let source = r#"
+    let source = r"
 script fn overflow_test() -> i64 {
     9223372036854775807 + 9223372036854775807
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -87,11 +87,11 @@ script fn overflow_test() -> i64 {
 
 #[test]
 fn test_overflow_i64_min_minus_one() {
-    let source = r#"
+    let source = r"
 script fn overflow_test() -> i64 {
     -9223372036854775807 - 1 + -1
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -101,12 +101,12 @@ script fn overflow_test() -> i64 {
 
 #[test]
 fn test_overflow_i64_min_plus_min() {
-    let source = r#"
+    let source = r"
 script fn overflow_test() -> i64 {
     let min = -9223372036854775807 - 1;
     min + min
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -116,11 +116,11 @@ script fn overflow_test() -> i64 {
 
 #[test]
 fn test_overflow_large_positives() {
-    let source = r#"
+    let source = r"
 script fn overflow_test() -> i64 {
     5000000000000000000 + 5000000000000000000
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -130,11 +130,11 @@ script fn overflow_test() -> i64 {
 
 #[test]
 fn test_overflow_large_negatives() {
-    let source = r#"
+    let source = r"
 script fn overflow_test() -> i64 {
     -5000000000000000000 + -5000000000000000000
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -144,11 +144,11 @@ script fn overflow_test() -> i64 {
 
 #[test]
 fn test_overflow_with_parameters() {
-    let source = r#"
+    let source = r"
 script fn overflow_test(x: i64, y: i64) -> i64 {
     x + y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -166,11 +166,11 @@ script fn overflow_test(x: i64, y: i64) -> i64 {
 
 #[test]
 fn test_no_overflow_max_plus_zero() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_test() -> i64 {
     9223372036854775807 + 0
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -181,11 +181,11 @@ script fn no_overflow_test() -> i64 {
 
 #[test]
 fn test_no_overflow_min_plus_zero() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_test() -> i64 {
     -9223372036854775807 - 1 + 0
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -196,11 +196,11 @@ script fn no_overflow_test() -> i64 {
 
 #[test]
 fn test_no_overflow_max_plus_min() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_test() -> i64 {
     9223372036854775807 + (-9223372036854775807 - 1)
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -214,11 +214,11 @@ script fn no_overflow_test() -> i64 {
 
 #[test]
 fn test_no_overflow_max_minus_one() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_test() -> i64 {
     9223372036854775807 + -1
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -229,11 +229,11 @@ script fn no_overflow_test() -> i64 {
 
 #[test]
 fn test_no_overflow_min_plus_one() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_test() -> i64 {
     -9223372036854775807 - 1 + 1
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -244,11 +244,11 @@ script fn no_overflow_test() -> i64 {
 
 #[test]
 fn test_no_overflow_boundary_positive() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_test() -> i64 {
     4611686018427387903 + 4611686018427387903
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -259,11 +259,11 @@ script fn no_overflow_test() -> i64 {
 
 #[test]
 fn test_no_overflow_boundary_negative() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_test() -> i64 {
     -4611686018427387904 + -4611686018427387904
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -274,11 +274,11 @@ script fn no_overflow_test() -> i64 {
 
 #[test]
 fn test_no_overflow_mixed_signs() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_test() -> i64 {
     5000000000000000000 + -3000000000000000000
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -289,11 +289,11 @@ script fn no_overflow_test() -> i64 {
 
 #[test]
 fn test_no_overflow_zero_plus_zero() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_test() -> i64 {
     0 + 0
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -304,11 +304,11 @@ script fn no_overflow_test() -> i64 {
 
 #[test]
 fn test_no_overflow_small_positive() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_test() -> i64 {
     100 + 200
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -319,11 +319,11 @@ script fn no_overflow_test() -> i64 {
 
 #[test]
 fn test_no_overflow_small_negative() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_test() -> i64 {
     -100 + -200
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -334,11 +334,11 @@ script fn no_overflow_test() -> i64 {
 
 #[test]
 fn test_no_overflow_with_parameters() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_test(x: i64, y: i64) -> i64 {
     x + y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -364,11 +364,11 @@ script fn no_overflow_test(x: i64, y: i64) -> i64 {
 fn test_overflow_formula_positive_overflow() {
     // Tests the formula: (x ^ y) >= 0 && (sum ^ x) < 0
     // For positive overflow: both positive, sum negative
-    let source = r#"
+    let source = r"
 script fn test(x: i64, y: i64) -> i64 {
     x + y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -380,11 +380,11 @@ script fn test(x: i64, y: i64) -> i64 {
 #[test]
 fn test_overflow_formula_negative_overflow() {
     // For negative overflow: both negative, sum wraps to positive
-    let source = r#"
+    let source = r"
 script fn test(x: i64, y: i64) -> i64 {
     x + y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -396,11 +396,11 @@ script fn test(x: i64, y: i64) -> i64 {
 #[test]
 fn test_overflow_formula_different_signs_never_overflow() {
     // When signs differ, (x ^ y) < 0, so overflow check short-circuits
-    let source = r#"
+    let source = r"
 script fn test(x: i64, y: i64) -> i64 {
     x + y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -421,12 +421,12 @@ script fn test(x: i64, y: i64) -> i64 {
 
 #[test]
 fn test_overflow_sub_i64_min_minus_one() {
-    let source = r#"
+    let source = r"
 script fn overflow_sub_test() -> i64 {
     let min = -9223372036854775807 - 1;
     min - 1
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -436,12 +436,12 @@ script fn overflow_sub_test() -> i64 {
 
 #[test]
 fn test_overflow_sub_i64_min_minus_positive() {
-    let source = r#"
+    let source = r"
 script fn overflow_sub_test() -> i64 {
     let min = -9223372036854775807 - 1;
     min - 1000
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -451,11 +451,11 @@ script fn overflow_sub_test() -> i64 {
 
 #[test]
 fn test_overflow_sub_i64_max_minus_negative() {
-    let source = r#"
+    let source = r"
 script fn overflow_sub_test() -> i64 {
     9223372036854775807 - (-1)
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -465,11 +465,11 @@ script fn overflow_sub_test() -> i64 {
 
 #[test]
 fn test_overflow_sub_positive_minus_large_negative() {
-    let source = r#"
+    let source = r"
 script fn overflow_sub_test() -> i64 {
     5000000000000000000 - (-5000000000000000000)
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -479,11 +479,11 @@ script fn overflow_sub_test() -> i64 {
 
 #[test]
 fn test_overflow_sub_negative_minus_positive() {
-    let source = r#"
+    let source = r"
 script fn overflow_sub_test() -> i64 {
     -5000000000000000000 - 5000000000000000000
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -493,11 +493,11 @@ script fn overflow_sub_test() -> i64 {
 
 #[test]
 fn test_overflow_sub_with_parameters() {
-    let source = r#"
+    let source = r"
 script fn overflow_sub_test(x: i64, y: i64) -> i64 {
     x - y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -520,11 +520,11 @@ script fn overflow_sub_test(x: i64, y: i64) -> i64 {
 
 #[test]
 fn test_no_overflow_sub_max_minus_zero() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_sub_test() -> i64 {
     9223372036854775807 - 0
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -535,12 +535,12 @@ script fn no_overflow_sub_test() -> i64 {
 
 #[test]
 fn test_no_overflow_sub_min_minus_zero() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_sub_test() -> i64 {
     let min = -9223372036854775807 - 1;
     min - 0
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -551,11 +551,11 @@ script fn no_overflow_sub_test() -> i64 {
 
 #[test]
 fn test_no_overflow_sub_zero_minus_zero() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_sub_test() -> i64 {
     0 - 0
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -566,11 +566,11 @@ script fn no_overflow_sub_test() -> i64 {
 
 #[test]
 fn test_no_overflow_sub_positive_minus_positive() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_sub_test() -> i64 {
     500 - 200
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -581,11 +581,11 @@ script fn no_overflow_sub_test() -> i64 {
 
 #[test]
 fn test_no_overflow_sub_negative_minus_negative() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_sub_test() -> i64 {
     -200 - (-500)
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -596,11 +596,11 @@ script fn no_overflow_sub_test() -> i64 {
 
 #[test]
 fn test_no_overflow_sub_max_minus_positive() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_sub_test() -> i64 {
     9223372036854775807 - 1
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -611,12 +611,12 @@ script fn no_overflow_sub_test() -> i64 {
 
 #[test]
 fn test_no_overflow_sub_min_minus_negative() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_sub_test() -> i64 {
     let min = -9223372036854775807 - 1;
     min - (-1)
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -627,11 +627,11 @@ script fn no_overflow_sub_test() -> i64 {
 
 #[test]
 fn test_no_overflow_sub_max_minus_max() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_sub_test() -> i64 {
     9223372036854775807 - 9223372036854775807
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -645,12 +645,12 @@ script fn no_overflow_sub_test() -> i64 {
 
 #[test]
 fn test_no_overflow_sub_min_minus_min() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_sub_test() -> i64 {
     let min = -9223372036854775807 - 1;
     min - min
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -664,11 +664,11 @@ script fn no_overflow_sub_test() -> i64 {
 
 #[test]
 fn test_no_overflow_sub_with_parameters() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_sub_test(x: i64, y: i64) -> i64 {
     x - y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -698,11 +698,11 @@ script fn no_overflow_sub_test(x: i64, y: i64) -> i64 {
 fn test_overflow_sub_formula_positive_minus_negative() {
     // Tests the formula: (x ^ y) < 0 && (diff ^ x) < 0
     // Positive - Negative can overflow to negative
-    let source = r#"
+    let source = r"
 script fn test_sub(x: i64, y: i64) -> i64 {
     x - y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -714,11 +714,11 @@ script fn test_sub(x: i64, y: i64) -> i64 {
 #[test]
 fn test_overflow_sub_formula_negative_minus_positive() {
     // Negative - Positive can overflow to positive
-    let source = r#"
+    let source = r"
 script fn test_sub(x: i64, y: i64) -> i64 {
     x - y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -730,11 +730,11 @@ script fn test_sub(x: i64, y: i64) -> i64 {
 #[test]
 fn test_overflow_sub_formula_same_signs_never_overflow() {
     // When both operands have same sign, subtraction cannot overflow
-    let source = r#"
+    let source = r"
 script fn test_sub(x: i64, y: i64) -> i64 {
     x - y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -759,11 +759,11 @@ script fn test_sub(x: i64, y: i64) -> i64 {
 
 #[test]
 fn test_overflow_mul_i64_max_times_two() {
-    let source = r#"
+    let source = r"
 script fn overflow_mul_test() -> i64 {
     9223372036854775807 * 2
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -773,12 +773,12 @@ script fn overflow_mul_test() -> i64 {
 
 #[test]
 fn test_overflow_mul_i64_min_times_neg_one() {
-    let source = r#"
+    let source = r"
 script fn overflow_mul_test() -> i64 {
     let min = -9223372036854775807 - 1;
     min * (-1)
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -788,12 +788,12 @@ script fn overflow_mul_test() -> i64 {
 
 #[test]
 fn test_overflow_mul_neg_one_times_i64_min() {
-    let source = r#"
+    let source = r"
 script fn overflow_mul_test() -> i64 {
     let min = -9223372036854775807 - 1;
     (-1) * min
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -803,11 +803,11 @@ script fn overflow_mul_test() -> i64 {
 
 #[test]
 fn test_overflow_mul_large_positive_values() {
-    let source = r#"
+    let source = r"
 script fn overflow_mul_test() -> i64 {
     4611686018427387904 * 2
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -820,11 +820,11 @@ script fn overflow_mul_test() -> i64 {
 
 #[test]
 fn test_overflow_mul_large_negative_values() {
-    let source = r#"
+    let source = r"
 script fn overflow_mul_test() -> i64 {
     (-4611686018427387904) * 3
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -837,11 +837,11 @@ script fn overflow_mul_test() -> i64 {
 
 #[test]
 fn test_overflow_mul_positive_negative_large() {
-    let source = r#"
+    let source = r"
 script fn overflow_mul_test() -> i64 {
     4611686018427387904 * (-3)
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -854,11 +854,11 @@ script fn overflow_mul_test() -> i64 {
 
 #[test]
 fn test_overflow_mul_max_times_max() {
-    let source = r#"
+    let source = r"
 script fn overflow_mul_test() -> i64 {
     9223372036854775807 * 9223372036854775807
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -868,12 +868,12 @@ script fn overflow_mul_test() -> i64 {
 
 #[test]
 fn test_overflow_mul_min_times_two() {
-    let source = r#"
+    let source = r"
 script fn overflow_mul_test() -> i64 {
     let min = -9223372036854775807 - 1;
     min * 2
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -883,11 +883,11 @@ script fn overflow_mul_test() -> i64 {
 
 #[test]
 fn test_overflow_mul_with_parameters() {
-    let source = r#"
+    let source = r"
 script fn overflow_mul_test(x: i64, y: i64) -> i64 {
     x * y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -910,11 +910,11 @@ script fn overflow_mul_test(x: i64, y: i64) -> i64 {
 
 #[test]
 fn test_no_overflow_mul_small_values() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_mul_test() -> i64 {
     123 * 456
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -925,11 +925,11 @@ script fn no_overflow_mul_test() -> i64 {
 
 #[test]
 fn test_no_overflow_mul_zero_times_max() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_mul_test() -> i64 {
     0 * 9223372036854775807
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -940,11 +940,11 @@ script fn no_overflow_mul_test() -> i64 {
 
 #[test]
 fn test_no_overflow_mul_max_times_zero() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_mul_test() -> i64 {
     9223372036854775807 * 0
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -955,11 +955,11 @@ script fn no_overflow_mul_test() -> i64 {
 
 #[test]
 fn test_no_overflow_mul_one_times_max() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_mul_test() -> i64 {
     1 * 9223372036854775807
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -970,11 +970,11 @@ script fn no_overflow_mul_test() -> i64 {
 
 #[test]
 fn test_no_overflow_mul_max_times_one() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_mul_test() -> i64 {
     9223372036854775807 * 1
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -985,12 +985,12 @@ script fn no_overflow_mul_test() -> i64 {
 
 #[test]
 fn test_no_overflow_mul_min_times_zero() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_mul_test() -> i64 {
     let min = -9223372036854775807 - 1;
     min * 0
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -1001,12 +1001,12 @@ script fn no_overflow_mul_test() -> i64 {
 
 #[test]
 fn test_no_overflow_mul_min_times_one() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_mul_test() -> i64 {
     let min = -9223372036854775807 - 1;
     min * 1
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -1017,11 +1017,11 @@ script fn no_overflow_mul_test() -> i64 {
 
 #[test]
 fn test_no_overflow_mul_negative_one_times_positive() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_mul_test() -> i64 {
     (-1) * 1000
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -1033,11 +1033,11 @@ script fn no_overflow_mul_test() -> i64 {
 #[test]
 fn test_no_overflow_mul_boundary_sqrt_max() {
     // Use a value slightly under the overflow threshold
-    let source = r#"
+    let source = r"
 script fn no_overflow_mul_test() -> i64 {
     3037000499 * 3037000499
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -1049,11 +1049,11 @@ script fn no_overflow_mul_test() -> i64 {
 
 #[test]
 fn test_no_overflow_mul_negative_times_negative() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_mul_test() -> i64 {
     (-50) * (-100)
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -1064,11 +1064,11 @@ script fn no_overflow_mul_test() -> i64 {
 
 #[test]
 fn test_no_overflow_mul_with_parameters() {
-    let source = r#"
+    let source = r"
 script fn no_overflow_mul_test(x: i64, y: i64) -> i64 {
     x * y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -1097,11 +1097,11 @@ script fn no_overflow_mul_test(x: i64, y: i64) -> i64 {
 #[test]
 fn test_overflow_mul_formula_product_division_check() {
     // Tests that if product / y != x, then overflow occurred
-    let source = r#"
+    let source = r"
 script fn test_mul(x: i64, y: i64) -> i64 {
     x * y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -1116,11 +1116,11 @@ script fn test_mul(x: i64, y: i64) -> i64 {
 #[test]
 fn test_overflow_mul_special_case_min_times_neg_one() {
     // Special case: MIN * -1 must trap
-    let source = r#"
+    let source = r"
 script fn test_mul(x: i64, y: i64) -> i64 {
     x * y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 
@@ -1134,11 +1134,11 @@ script fn test_mul(x: i64, y: i64) -> i64 {
 #[test]
 fn test_no_overflow_mul_zero_multiplicand() {
     // When multiplying by zero, never overflow
-    let source = r#"
+    let source = r"
 script fn test_mul(x: i64, y: i64) -> i64 {
     x * y
 }
-"#;
+";
 
     let wasm = compile_program(source);
 

--- a/starstream-to-wasm/tests/snapshots.rs
+++ b/starstream-to-wasm/tests/snapshots.rs
@@ -26,7 +26,7 @@ impl<T: Print> Print for CustomPrinter<T> {
                 .print(data, &mut wasmprinter::PrintFmtWrite(&mut wat))
                 .unwrap();
             self.write_str("\n  (@custom \"component-type\"")?;
-            for line in wat.split("\n") {
+            for line in wat.split('\n') {
                 if !line.is_empty() {
                     self.write_str("\n    ")?;
                     self.write_str(line)?;
@@ -58,7 +58,7 @@ fn inputs() {
                     .expect("failed to render diagnostic");
             }
             if let Some(program) = program {
-                writeln!(output, "{:#?}\n", program).unwrap();
+                writeln!(output, "{program:#?}\n").unwrap();
 
                 let formatted_source =
                     starstream_compiler::formatter::program(&program, &source, &comments)

--- a/starstream-types/src/ast.rs
+++ b/starstream-types/src/ast.rs
@@ -18,6 +18,7 @@ pub const DUMMY_SPAN: Span = Span {
 /// Create a span from start and end offsets.
 ///
 /// This is a convenience function that avoids needing to import the chumsky Span trait.
+#[must_use]
 pub fn span(start: usize, end: usize) -> Span {
     Span::new((), start..end)
 }
@@ -81,16 +82,19 @@ impl Identifier {
     }
 
     /// Get the identifier's text.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.name
     }
 
-    /// Get the identifier's source span if available, or DUMMY_SPAN if the identifier was hardcoded.
+    /// Get the identifier's source span if available, or `DUMMY_SPAN` if the identifier was hardcoded.
+    #[must_use]
     pub fn span(&self) -> Span {
         self.span
     }
 
     /// Get the identifier's source span if available, or `default` if the identifier was hardcoded.
+    #[must_use]
     pub fn span_or(&self, default: Span) -> Span {
         if self.span == DUMMY_SPAN {
             default
@@ -100,6 +104,7 @@ impl Identifier {
     }
 
     /// Get the identifier's source span if available, or `None` if the identifier was hardcoded.
+    #[must_use]
     pub fn opt_span(&self) -> Option<Span> {
         if self.span == DUMMY_SPAN {
             None
@@ -124,6 +129,7 @@ pub struct Comment(pub Span);
 impl Comment {
     /// Extracts doc comments (lines starting with `///`) from a slice of comments.
     /// Consecutive `///` lines are joined with newlines. Returns None if no doc comments.
+    #[must_use]
     pub fn extract_doc(comments: &[Comment], source: &str) -> Option<String> {
         let doc_lines: Vec<&str> = comments
             .iter()

--- a/starstream-types/src/comments.rs
+++ b/starstream-types/src/comments.rs
@@ -13,11 +13,13 @@ pub struct CommentMap {
 
 impl CommentMap {
     /// Create an empty comment map.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Create a comment map from a list of comments (will be sorted and deduplicated).
+    #[must_use]
     pub fn from_comments(mut comments: Vec<Comment>) -> Self {
         comments.sort_by_key(|c| c.0.start);
         comments.dedup_by_key(|c| (c.0.start, c.0.end));
@@ -34,6 +36,7 @@ impl CommentMap {
     }
 
     /// Get all comments in the map.
+    #[must_use]
     pub fn all(&self) -> &[Comment] {
         &self.comments
     }
@@ -42,6 +45,7 @@ impl CommentMap {
     ///
     /// Returns comments whose span ends before `node_start` and which are
     /// not on the same line as any preceding code.
+    #[must_use]
     pub fn comments_before(&self, node_span: Span, source: &str) -> Vec<&Comment> {
         let node_start = node_span.start;
         let node_line = line_of_offset(source, node_start);
@@ -64,6 +68,7 @@ impl CommentMap {
     ///
     /// This finds comments between `prev_end` and `node_span.start`
     /// that are on their own line (not inline with previous code).
+    #[must_use]
     pub fn comments_between(
         &self,
         prev_end: usize,
@@ -104,6 +109,7 @@ impl CommentMap {
     ///
     /// Returns the first comment that starts after `node_span.end` but
     /// is on the same line as the node's end (no newline between them).
+    #[must_use]
     pub fn inline_comment_after(&self, node_span: Span, source: &str) -> Option<&Comment> {
         // Bounds check - span might be out of range for manually constructed AST
         if node_span.start > source.len() || node_span.end > source.len() {
@@ -133,6 +139,7 @@ impl CommentMap {
     ///
     /// Returns the concatenated content of consecutive `///` comments
     /// directly preceding the node (no other code between), or `None` if there are none.
+    #[must_use]
     pub fn doc_comments(&self, node_span: Span, source: &str) -> Option<String> {
         let node_start = node_span.start;
 
@@ -151,7 +158,7 @@ impl CommentMap {
         for comment in candidates {
             // Check if there's only whitespace between this comment and current_pos
             let between = &source[comment.0.end..current_pos];
-            if !between.chars().all(|c| c.is_whitespace()) {
+            if !between.chars().all(char::is_whitespace) {
                 // There's code between, stop looking
                 break;
             }

--- a/starstream-types/src/error.rs
+++ b/starstream-types/src/error.rs
@@ -51,7 +51,7 @@ impl std::fmt::Display for ErrorCode {
 inventory::collect!(ErrorCode);
 
 impl ErrorCode {
-    /// Iterate over all error codes registered with [error_code].
+    /// Iterate over all error codes registered with [`error_code`].
     pub fn iter() -> impl Iterator<Item = &'static ErrorCode> {
         inventory::iter::<ErrorCode>()
     }
@@ -73,14 +73,14 @@ impl std::fmt::Display for WarningCode {
 inventory::collect!(WarningCode);
 
 impl WarningCode {
-    /// Iterate over all warning codes registered with [warning_code].
+    /// Iterate over all warning codes registered with [`warning_code`].
     pub fn iter() -> impl Iterator<Item = &'static WarningCode> {
         inventory::iter::<WarningCode>()
     }
 }
 
 /// Create an error code, attaching its docs from the associated file in the
-/// `docs` folder and registering it with [ErrorCode::iter].
+/// `docs` folder and registering it with [`ErrorCode::iter`].
 #[macro_export]
 macro_rules! error_code {
     ($id:ident) => {{
@@ -100,7 +100,7 @@ macro_rules! error_code {
 }
 
 /// Create a warning code, attaching its docs from the associated file in the
-/// `docs` folder and registering it with [WarningCode::iter].
+/// `docs` folder and registering it with [`WarningCode::iter`].
 #[macro_export]
 macro_rules! warning_code {
     ($id:ident) => {{

--- a/starstream-types/src/filesystem.rs
+++ b/starstream-types/src/filesystem.rs
@@ -14,6 +14,7 @@ impl Default for FileSystem {
 }
 
 impl FileSystem {
+    #[must_use]
     pub fn new() -> FileSystem {
         FileSystem {
             dependencies: Vec::new(),

--- a/starstream-types/src/typed_ast.rs
+++ b/starstream-types/src/typed_ast.rs
@@ -82,13 +82,13 @@ impl std::fmt::Display for TypedImportSource {
                 package,
                 interface,
             } => {
-                write!(f, "{}:{}", namespace, package)?;
+                write!(f, "{namespace}:{package}")?;
                 if let Some(interface) = interface {
-                    write!(f, "/{}", interface)?;
+                    write!(f, "/{interface}")?;
                 }
                 Ok(())
             }
-            TypedImportSource::Path { value, .. } => write!(f, "\"{}\"", value),
+            TypedImportSource::Path { value, .. } => write!(f, "\"{value}\""),
         }
     }
 }
@@ -182,6 +182,7 @@ pub struct TypedAbiMethodDecl {
 
 impl TypedAbiMethodDecl {
     /// Get the stable hashable identity of this method type.
+    #[must_use]
     pub fn identity(&self) -> &str {
         // TODO: specify hashing for types and include real type signature here
         self.name.as_str()
@@ -386,12 +387,14 @@ pub struct TypedStructPatternField {
 }
 
 impl TypedExpr {
+    #[must_use]
     pub fn new(ty: Type, kind: TypedExprKind) -> Self {
         Self { ty, kind }
     }
 }
 
 impl TypedBlock {
+    #[must_use]
     pub fn new(
         statements: Vec<TypedStatement>,
         tail_expression: Option<Spanned<TypedExpr>>,

--- a/starstream-types/src/types.rs
+++ b/starstream-types/src/types.rs
@@ -28,6 +28,7 @@ pub enum IntWidth {
 }
 
 impl IntWidth {
+    #[must_use]
     pub fn is_signed(self) -> bool {
         matches!(
             self,
@@ -35,6 +36,7 @@ impl IntWidth {
         )
     }
 
+    #[must_use]
     pub fn bit_width(self) -> u32 {
         match self {
             IntWidth::I8 | IntWidth::U8 => 8,
@@ -44,6 +46,7 @@ impl IntWidth {
         }
     }
 
+    #[must_use]
     pub fn display_name(self) -> &'static str {
         match self {
             IntWidth::I8 => "i8",
@@ -57,37 +60,42 @@ impl IntWidth {
         }
     }
 
+    #[must_use]
     pub fn min_value(self) -> i128 {
         match self {
-            IntWidth::I8 => i8::MIN as i128,
-            IntWidth::I16 => i16::MIN as i128,
-            IntWidth::I32 => i32::MIN as i128,
-            IntWidth::I64 => i64::MIN as i128,
+            IntWidth::I8 => i128::from(i8::MIN),
+            IntWidth::I16 => i128::from(i16::MIN),
+            IntWidth::I32 => i128::from(i32::MIN),
+            IntWidth::I64 => i128::from(i64::MIN),
             IntWidth::U8 | IntWidth::U16 | IntWidth::U32 | IntWidth::U64 => 0,
         }
     }
 
+    #[must_use]
     pub fn max_value(self) -> i128 {
         match self {
-            IntWidth::I8 => i8::MAX as i128,
-            IntWidth::I16 => i16::MAX as i128,
-            IntWidth::I32 => i32::MAX as i128,
-            IntWidth::I64 => i64::MAX as i128,
-            IntWidth::U8 => u8::MAX as i128,
-            IntWidth::U16 => u16::MAX as i128,
-            IntWidth::U32 => u32::MAX as i128,
-            IntWidth::U64 => u64::MAX as i128,
+            IntWidth::I8 => i128::from(i8::MAX),
+            IntWidth::I16 => i128::from(i16::MAX),
+            IntWidth::I32 => i128::from(i32::MAX),
+            IntWidth::I64 => i128::from(i64::MAX),
+            IntWidth::U8 => i128::from(u8::MAX),
+            IntWidth::U16 => i128::from(u16::MAX),
+            IntWidth::U32 => i128::from(u32::MAX),
+            IntWidth::U64 => i128::from(u64::MAX),
         }
     }
 
+    #[must_use]
     pub fn fits(self, value: i128) -> bool {
         value >= self.min_value() && value <= self.max_value()
     }
 
+    #[must_use]
     pub fn is_64bit(self) -> bool {
         matches!(self, IntWidth::I64 | IntWidth::U64)
     }
 
+    #[must_use]
     pub fn is_sub32(self) -> bool {
         matches!(
             self,
@@ -119,6 +127,7 @@ pub struct TypeVarId(pub u32);
 
 impl TypeVarId {
     /// Render the identifier using the conventional `t0`, `t1`, … scheme.
+    #[must_use]
     pub fn as_str(&self) -> String {
         format!("t{}", self.0)
     }
@@ -134,8 +143,8 @@ pub struct TypeParam {
 /// A generic type definition with its template type and named parameters.
 #[derive(Clone, Debug)]
 pub struct GenericTypeDef {
-    /// The generic type with Type::Var for each param
-    /// (type_args set to the param vars so display works naturally).
+    /// The generic type with `Type::Var` for each param
+    /// (`type_args` set to the param vars so display works naturally).
     pub ty: Type,
     pub type_params: Vec<TypeParam>,
     pub doc: Option<String>,
@@ -143,6 +152,7 @@ pub struct GenericTypeDef {
 }
 
 impl GenericTypeDef {
+    #[must_use]
     pub fn param_name_map(&self) -> HashMap<TypeVarId, String> {
         self.type_params
             .iter()
@@ -194,18 +204,22 @@ pub enum Type {
 }
 
 impl Type {
+    #[must_use]
     pub fn unit() -> Self {
         Type::Unit
     }
 
+    #[must_use]
     pub fn bool() -> Self {
         Type::Bool
     }
 
+    #[must_use]
     pub fn int() -> Self {
         Type::Int(IntWidth::I64)
     }
 
+    #[must_use]
     pub fn int_of(w: IntWidth) -> Self {
         Type::Int(w)
     }
@@ -230,6 +244,7 @@ impl Type {
     /// Anonymous pure function type helper.
     ///
     /// Use `Type::Function { ... }` directly to set full details.
+    #[must_use]
     pub fn function(params: Vec<Type>, result: Type) -> Self {
         Type::Function {
             params,
@@ -249,16 +264,19 @@ impl fmt::Display for Type {
 }
 
 impl Type {
+    #[must_use]
     pub fn to_compact_string(&self) -> String {
         render_doc(self.to_doc_mode(TypeDocMode::Compact))
     }
 
     /// Render expanded display using named type parameters for `Type::Var`.
+    #[must_use]
     pub fn display_with_params(&self, params: &HashMap<TypeVarId, String>) -> String {
         render_doc(self.to_doc(TypeDocMode::Expanded, params))
     }
 
     /// Render compact display using named type parameters for `Type::Var`.
+    #[must_use]
     pub fn compact_display_with_params(&self, params: &HashMap<TypeVarId, String>) -> String {
         render_doc(self.to_doc(TypeDocMode::Compact, params))
     }
@@ -571,6 +589,7 @@ pub struct Scheme {
 }
 
 impl Scheme {
+    #[must_use]
     pub fn monomorphic(ty: Type) -> Self {
         Scheme {
             vars: Vec::new(),


### PR DESCRIPTION
Ran `cargo clippy --workspace --all-targets --fix -- -W clippy::pedantic`, cleaned it up a bit and commited fixes for everything except `interleaving` and `compiler`, since those are rather large.