### PR TITLE
Type-check `token` definitions

### DIFF
--- a/docs/errors/E0052.md
+++ b/docs/errors/E0052.md
@@ -1,0 +1,29 @@
+# E0052: Token missing `mint fn`
+
+A `token` definition must declare at least one `mint fn`. Without one, the token
+can never be created, so it would be useless.
+
+## Example (error)
+
+```starstream
+token MyToken {
+    impl Token {
+        fn attach(to: Utxo) {}
+        fn detach(source: Utxo) {}
+    }
+}
+```
+
+## Fix
+
+Add at least one `mint fn`:
+
+```starstream
+token MyToken {
+    mint fn mint() {}
+    impl Token {
+        fn attach(to: Utxo) {}
+        fn detach(source: Utxo) {}
+    }
+}
+```

--- a/docs/errors/E0053.md
+++ b/docs/errors/E0053.md
@@ -1,0 +1,26 @@
+# E0053: Token missing `impl Token` block
+
+Every `token` definition must contain exactly one `impl Token { ... }` block
+implementing the built-in `Token` interface (`attach` and `detach`).
+
+## Example (error)
+
+```starstream
+token MyToken {
+    mint fn mint() {}
+}
+```
+
+## Fix
+
+Add the `impl Token` block:
+
+```starstream
+token MyToken {
+    mint fn mint() {}
+    impl Token {
+        fn attach(to: Utxo) {}
+        fn detach(source: Utxo) {}
+    }
+}
+```

--- a/docs/errors/E0054.md
+++ b/docs/errors/E0054.md
@@ -1,0 +1,34 @@
+# E0054: Token has multiple `impl Token` blocks
+
+A `token` definition may contain only one `impl Token { ... }` block. The
+built-in `Token` interface must be implemented exactly once.
+
+## Example (error)
+
+```starstream
+token MyToken {
+    mint fn mint() {}
+    impl Token {
+        fn attach(to: Utxo) {}
+        fn detach(source: Utxo) {}
+    }
+    impl Token {
+        fn attach(to: Utxo) {}
+        fn detach(source: Utxo) {}
+    }
+}
+```
+
+## Fix
+
+Keep a single `impl Token` block:
+
+```starstream
+token MyToken {
+    mint fn mint() {}
+    impl Token {
+        fn attach(to: Utxo) {}
+        fn detach(source: Utxo) {}
+    }
+}
+```

--- a/docs/errors/E0055.md
+++ b/docs/errors/E0055.md
@@ -1,0 +1,23 @@
+# E0055: Reserved ABI name
+
+`Token` is a built-in ABI provided by the compiler (it declares `attach` and
+`detach` for `token` definitions). User code may not declare an `abi` with that
+name.
+
+## Example (error)
+
+```starstream
+abi Token {
+    fn attach(to: Utxo);
+}
+```
+
+## Fix
+
+Choose a different ABI name:
+
+```starstream
+abi MyTokenAbi {
+    fn attach(to: Utxo);
+}
+```

--- a/starstream-compiler/src/docs.rs
+++ b/starstream-compiler/src/docs.rs
@@ -96,6 +96,14 @@ impl From<&Type> for TypeRef {
                 name: name.to_owned(),
                 kind: TypeKind::Resource,
             },
+            Type::TokenAny => TypeRef::Resource {
+                name: "Token".to_owned(),
+                kind: TypeKind::Resource,
+            },
+            Type::TokenNamed(name) => TypeRef::Resource {
+                name: name.to_owned(),
+                kind: TypeKind::Resource,
+            },
             Type::AbiNarrow(abi) => TypeRef::Resource {
                 name: abi.name.to_string(),
                 kind: TypeKind::Resource,

--- a/starstream-compiler/src/typecheck/env.rs
+++ b/starstream-compiler/src/typecheck/env.rs
@@ -135,6 +135,8 @@ fn free_type_vars_type(ty: &Type, out: &mut HashSet<TypeVarId>) {
         | Type::Unit
         | Type::UtxoAny
         | Type::UtxoNamed(_)
+        | Type::TokenAny
+        | Type::TokenNamed(_)
         | Type::AbiNarrow(_) => {}
     }
 }

--- a/starstream-compiler/src/typecheck/errors.rs
+++ b/starstream-compiler/src/typecheck/errors.rs
@@ -743,7 +743,10 @@ impl fmt::Display for TypeErrorKind {
                 write!(f, "token `{name}` must have at least one `mint fn`")
             }
             TypeErrorKind::TokenMissingImpl { name } => {
-                write!(f, "token `{name}` must have an `impl Token {{ ... }}` block")
+                write!(
+                    f,
+                    "token `{name}` must have an `impl Token {{ ... }}` block"
+                )
             }
             TypeErrorKind::TokenDuplicateImpl { name } => {
                 write!(

--- a/starstream-compiler/src/typecheck/errors.rs
+++ b/starstream-compiler/src/typecheck/errors.rs
@@ -297,6 +297,22 @@ pub enum TypeErrorKind {
     },
     /// `yield` appears outside Utxo `main fn`.
     YieldOutsideMainFn,
+    /// A `token` definition has no `mint fn`.
+    TokenMissingMintFn {
+        name: String,
+    },
+    /// A `token` definition has no `impl Token { ... }` block.
+    TokenMissingImpl {
+        name: String,
+    },
+    /// A `token` definition has more than one `impl Token { ... }` block.
+    TokenDuplicateImpl {
+        name: String,
+    },
+    /// User code tried to declare an `abi` with a reserved built-in name (e.g. `Token`).
+    ReservedAbiName {
+        name: String,
+    },
 }
 
 impl TypeErrorKind {
@@ -354,6 +370,10 @@ impl TypeErrorKind {
             TypeErrorKind::LinearMethodCallViolation { .. } => error_code!(E0049),
             TypeErrorKind::UnknownPathExport { .. } => error_code!(E0050),
             TypeErrorKind::YieldOutsideMainFn => error_code!(E0051),
+            TypeErrorKind::TokenMissingMintFn { .. } => error_code!(E0052),
+            TypeErrorKind::TokenMissingImpl { .. } => error_code!(E0053),
+            TypeErrorKind::TokenDuplicateImpl { .. } => error_code!(E0054),
+            TypeErrorKind::ReservedAbiName { .. } => error_code!(E0055),
         }
     }
 }
@@ -718,6 +738,21 @@ impl fmt::Display for TypeErrorKind {
             }
             TypeErrorKind::YieldOutsideMainFn => {
                 write!(f, "`yield` can only be used inside a `main fn`")
+            }
+            TypeErrorKind::TokenMissingMintFn { name } => {
+                write!(f, "token `{name}` must have at least one `mint fn`")
+            }
+            TypeErrorKind::TokenMissingImpl { name } => {
+                write!(f, "token `{name}` must have an `impl Token {{ ... }}` block")
+            }
+            TypeErrorKind::TokenDuplicateImpl { name } => {
+                write!(
+                    f,
+                    "token `{name}` may have only one `impl Token {{ ... }}` block"
+                )
+            }
+            TypeErrorKind::ReservedAbiName { name } => {
+                write!(f, "`{name}` is a built-in ABI and cannot be redeclared")
             }
         }
     }

--- a/starstream-compiler/src/typecheck/exhaustiveness.rs
+++ b/starstream-compiler/src/typecheck/exhaustiveness.rs
@@ -81,7 +81,11 @@ impl CtorSet {
             // We represent this as an empty constructor set.
             Type::Int(_) | Type::Unit | Type::Var(_) => Some(Self::infinite()),
             Type::Function { .. } | Type::Tuple(_) => Some(Self::infinite()),
-            Type::UtxoAny | Type::UtxoNamed(_) | Type::AbiNarrow(_) => Some(Self::infinite()),
+            Type::UtxoAny
+            | Type::UtxoNamed(_)
+            | Type::TokenAny
+            | Type::TokenNamed(_)
+            | Type::AbiNarrow(_) => Some(Self::infinite()),
         }
     }
 

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -1727,7 +1727,9 @@ impl Inferencer {
         let token_impl_count = def
             .parts
             .iter()
-            .filter(|part| matches!(part, TokenPart::AbiImpl { abi, .. } if abi.as_str() == "Token"))
+            .filter(
+                |part| matches!(part, TokenPart::AbiImpl { abi, .. } if abi.as_str() == "Token"),
+            )
             .count();
 
         if mint_count == 0 {
@@ -1824,9 +1826,7 @@ impl Inferencer {
                 parts,
                 ty: Type::TokenNamed(def.name.to_string()),
             },
-            self.make_trace("T-Token", None, Some(def.name.to_string()), None, || {
-                traces
-            }),
+            self.make_trace("T-Token", None, Some(def.name.to_string()), None, || traces),
         ))
     }
 

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -8,8 +8,9 @@ use std::{
 
 use starstream_types::{
     Abi, AbiDef, AbiPart, DUMMY_SPAN, EffectKind, EventDef, GenericTypeDef, IfCondition, IntWidth,
-    Scheme, Span, Spanned, Type, TypeParam, TypeVarId, TypedTokenDef, TypedUtxoDef,
-    TypedUtxoGlobal, TypedUtxoPart, UtxoDef, UtxoGlobal, UtxoPart,
+    Scheme, Span, Spanned, TokenDef, TokenGlobal, TokenPart, Type, TypeParam, TypeVarId,
+    TypedTokenDef, TypedTokenGlobal, TypedTokenPart, TypedUtxoDef, TypedUtxoGlobal, TypedUtxoPart,
+    UtxoDef, UtxoGlobal, UtxoPart,
     ast::{
         BinaryOp, Block, Definition, EnumConstructorPayload, EnumDef, EnumPatternPayload,
         EnumVariantPayload, Expr, FunctionDef, Identifier, ImportDef, ImportItems, ImportSource,
@@ -676,8 +677,9 @@ fn collect_exports(typed_definitions: &[TypedDefinition]) -> ModuleExports {
             TypedDefinition::Utxo(u) => {
                 exports.types.insert(u.name.name.clone());
             }
-            // `token` is parse-only for now: no exported type yet.
-            TypedDefinition::Token(_) => {}
+            TypedDefinition::Token(t) => {
+                exports.types.insert(t.name.name.clone());
+            }
             TypedDefinition::Import(_) => {}
             TypedDefinition::Contract => {}
         }
@@ -830,7 +832,32 @@ impl Inferencer {
             has_yields: false,
         };
         inferencer.register_prelude_types();
+        inferencer.register_builtin_token_abi();
         inferencer
+    }
+
+    /// Register the built-in `Token` ABI that every `token` definition's
+    /// `impl Token { ... }` block is checked against. It declares
+    /// `attach(Utxo) -> ()` and `detach(Utxo) -> ()`. User code may not
+    /// redeclare `abi Token` (guarded in `register_abi`).
+    fn register_builtin_token_abi(&mut self) {
+        let method = |name: &str| TypedAbiMethodDecl {
+            name: Identifier::new(name, DUMMY_SPAN),
+            params: vec![TypedFunctionParam {
+                public: false,
+                name: Identifier::new("utxo", DUMMY_SPAN),
+                ty: Type::UtxoAny,
+            }],
+            return_type: Type::Unit,
+            span: DUMMY_SPAN,
+        };
+        self.abis.insert(
+            "Token".to_owned(),
+            Abi {
+                name: Identifier::new("Token", DUMMY_SPAN),
+                methods: vec![method("attach"), method("detach")],
+            },
+        );
     }
 
     /// Register builtin prelude types (`Option<T>`, `Result<T, E>`).
@@ -965,9 +992,7 @@ impl Inferencer {
                 Definition::Enum(def) => self.register_enum(def)?,
                 Definition::Function(_) => {}
                 Definition::Utxo(def) => self.register_utxo(def)?,
-                // `token` definitions are parse-only for now: no type is
-                // registered yet (the global `Token` type is a follow-up).
-                Definition::Token(_) => {}
+                Definition::Token(def) => self.register_token(def)?,
                 Definition::Abi(def) => self.register_abi(def)?,
             }
         }
@@ -1136,6 +1161,15 @@ impl Inferencer {
     }
 
     fn register_abi(&mut self, def: &AbiDef) -> Result<(), TypeError> {
+        if def.name.name == "Token" {
+            return Err(TypeError::new(
+                TypeErrorKind::ReservedAbiName {
+                    name: def.name.name.clone(),
+                },
+                def.name.span(),
+            ));
+        }
+
         let mut methods = Vec::new();
         for part in &def.parts {
             match part {
@@ -1352,6 +1386,22 @@ impl Inferencer {
 
     fn register_utxo(&mut self, def: &UtxoDef) -> Result<(), TypeError> {
         let ty = Type::UtxoNamed(def.name.to_string());
+        self.types.insert(
+            def.name.to_string(),
+            TypeEntry {
+                ty,
+                kind: TypeEntryKind::Handle,
+                span: def.name.span(),
+                type_params: vec![],
+                doc: None,
+                variant_docs: HashMap::new(),
+            },
+        );
+        Ok(())
+    }
+
+    fn register_token(&mut self, def: &TokenDef) -> Result<(), TypeError> {
+        let ty = Type::TokenNamed(def.name.to_string());
         self.types.insert(
             def.name.to_string(),
             TypeEntry {
@@ -1652,6 +1702,155 @@ impl Inferencer {
             },
             self.make_trace("T-Utxo", None, Some(def.name.to_string()), None, || traces),
         ))
+    }
+
+    fn infer_token(
+        &mut self,
+        env: &mut TypeEnv,
+        def: &TokenDef,
+    ) -> Result<(TypedTokenDef, InferenceTree), TypeError> {
+        // Structural pre-pass: validate the shape (at least one `mint fn`,
+        // exactly one `impl Token`) before inferring any bodies, so these
+        // token-specific diagnostics take precedence over body-level errors
+        // such as the duplicate-function clash from two `impl Token` blocks.
+        let mint_count = def
+            .parts
+            .iter()
+            .filter(|part| {
+                matches!(
+                    part,
+                    TokenPart::Function(f)
+                        if f.export == Some(starstream_types::FunctionExport::TokenMint)
+                )
+            })
+            .count();
+        let token_impl_count = def
+            .parts
+            .iter()
+            .filter(|part| matches!(part, TokenPart::AbiImpl { abi, .. } if abi.as_str() == "Token"))
+            .count();
+
+        if mint_count == 0 {
+            return Err(TypeError::new(
+                TypeErrorKind::TokenMissingMintFn {
+                    name: def.name.to_string(),
+                },
+                def.name.span(),
+            ));
+        }
+        match token_impl_count {
+            0 => {
+                return Err(TypeError::new(
+                    TypeErrorKind::TokenMissingImpl {
+                        name: def.name.to_string(),
+                    },
+                    def.name.span(),
+                ));
+            }
+            1 => {}
+            _ => {
+                return Err(TypeError::new(
+                    TypeErrorKind::TokenDuplicateImpl {
+                        name: def.name.to_string(),
+                    },
+                    def.name.span(),
+                ));
+            }
+        }
+
+        env.push_scope();
+
+        let mut parts = Vec::with_capacity(def.parts.len());
+        let mut traces = Vec::with_capacity(def.parts.len());
+
+        for part in &def.parts {
+            parts.push(match part {
+                TokenPart::Storage(vars) => TypedTokenPart::Storage(
+                    vars.iter()
+                        .map(|var| self.infer_token_global(env, var))
+                        .collect::<Result<Vec<_>, _>>()?,
+                ),
+                TokenPart::Function(function) => {
+                    // `mint fn`s implicitly return unit — the caller-facing
+                    // result (a handle to the minted token) is supplied by the
+                    // runtime, so an explicit return type is rejected.
+                    if function.export == Some(starstream_types::FunctionExport::TokenMint)
+                        && function.return_type.is_some()
+                    {
+                        return Err(TypeError::new(
+                            TypeErrorKind::ReturnTypeNotAllowed,
+                            function.name.span(),
+                        ));
+                    }
+                    let (func, trace) = self.infer_function(env, function)?;
+                    traces.push(trace);
+                    TypedTokenPart::Function(func.into())
+                }
+                TokenPart::AbiImpl { abi, parts } => {
+                    let span = abi.span();
+
+                    let parts = parts
+                        .iter()
+                        .map(|function| {
+                            let (func, trace) = self.infer_function(env, function)?;
+                            traces.push(trace);
+                            Ok(func)
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+
+                    // Assert that the signature sets match. `Token` resolves to
+                    // the built-in ABI; other names must be user-declared ABIs.
+                    let Some(abi_info) = self.abis.get(abi.as_str()) else {
+                        return Err(TypeError::new(
+                            TypeErrorKind::UnknownAbi {
+                                name: abi.to_string(),
+                            },
+                            span,
+                        ));
+                    };
+                    self.check_abi_impl(abi, abi_info, &parts)?;
+
+                    let abi = Type::AbiNarrow(abi_info.clone());
+                    TypedTokenPart::AbiImpl { abi, span, parts }
+                }
+            });
+        }
+
+        env.pop_scope();
+
+        Ok((
+            TypedTokenDef {
+                name: def.name.clone(),
+                parts,
+                ty: Type::TokenNamed(def.name.to_string()),
+            },
+            self.make_trace("T-Token", None, Some(def.name.to_string()), None, || {
+                traces
+            }),
+        ))
+    }
+
+    fn infer_token_global(
+        &mut self,
+        env: &mut TypeEnv,
+        var: &TokenGlobal,
+    ) -> Result<TypedTokenGlobal, TypeError> {
+        let ty = self.type_from_annotation(&var.ty)?;
+        env.insert(
+            var.name.name.clone(),
+            Binding {
+                decl_span: var.name.span(),
+                mutable: true,
+                scheme: Scheme::monomorphic(ty.clone()),
+                class: BindingClass::Storage,
+                visibility: BindingVisibility::Public,
+            },
+        );
+        Ok(TypedTokenGlobal {
+            indexed: var.indexed,
+            name: var.name.clone(),
+            ty,
+        })
     }
 
     fn check_abi_impl(
@@ -2174,14 +2373,9 @@ impl Inferencer {
                 Ok((TypedDefinition::Utxo(utxo), trace))
             }
             Definition::Token(def) => {
-                // Parse-only for now: lower to a shallow marker without
-                // type-checking the body. Semantics land in a follow-up.
-                let typed = TypedTokenDef {
-                    name: def.name.clone(),
-                    span: def.name.span(),
-                };
+                let (token, trace) = self.infer_token(env, def)?;
 
-                Ok((TypedDefinition::Token(typed), InferenceTree::default()))
+                Ok((TypedDefinition::Token(token), trace))
             }
             Definition::Abi(def) => {
                 let typed = self.build_typed_abi(def)?;
@@ -4336,6 +4530,7 @@ impl Inferencer {
             "()" => Ok(Type::unit()),
             "_" => Ok(self.fresh_var()),
             "Utxo" => Ok(Type::UtxoAny),
+            "Token" => Ok(Type::TokenAny),
             other => match self.types.get(other) {
                 Some(entry) if !entry.type_params.is_empty() => Err(TypeError::new(
                     TypeErrorKind::WrongGenericArity {
@@ -4674,6 +4869,8 @@ impl Inferencer {
             Type::Unit => Type::Unit,
             Type::UtxoAny => Type::UtxoAny,
             Type::UtxoNamed(id) => Type::UtxoNamed(id.clone()),
+            Type::TokenAny => Type::TokenAny,
+            Type::TokenNamed(id) => Type::TokenNamed(id.clone()),
             Type::AbiNarrow(name) => Type::AbiNarrow(name.clone()),
         }
     }
@@ -4689,12 +4886,38 @@ impl Inferencer {
         match definition {
             TypedDefinition::Function(function) => self.apply_function(function),
             TypedDefinition::Utxo(utxo) => self.apply_utxo(utxo),
+            TypedDefinition::Token(token) => self.apply_token(token),
             TypedDefinition::Import(_)
             | TypedDefinition::Struct(_)
             | TypedDefinition::Enum(_)
             | TypedDefinition::Abi(_)
-            | TypedDefinition::Token(_)
             | TypedDefinition::Contract => {}
+        }
+    }
+
+    fn apply_token(&self, token: &mut TypedTokenDef) {
+        token.ty = self.apply(&token.ty);
+        for part in &mut token.parts {
+            match part {
+                TypedTokenPart::Storage(vars) => {
+                    for var in vars {
+                        var.ty = self.apply(&var.ty);
+                    }
+                }
+                TypedTokenPart::Function(func) => {
+                    self.apply_function(func);
+                }
+                TypedTokenPart::AbiImpl {
+                    abi,
+                    span: _,
+                    parts,
+                } => {
+                    *abi = self.apply(abi);
+                    for part in parts {
+                        self.apply_function(part);
+                    }
+                }
+            }
         }
     }
 
@@ -5586,6 +5809,8 @@ fn substitute_type(ty: &Type, mapping: &HashMap<TypeVarId, Type>) -> Type {
         Type::Unit => Type::Unit,
         Type::UtxoAny => Type::UtxoAny,
         Type::UtxoNamed(id) => Type::UtxoNamed(id.clone()),
+        Type::TokenAny => Type::TokenAny,
+        Type::TokenNamed(id) => Type::TokenNamed(id.clone()),
         Type::AbiNarrow(name) => Type::AbiNarrow(name.clone()),
     }
 }
@@ -5628,6 +5853,8 @@ fn occurs_in(var: TypeVarId, ty: &Type, subst: &HashMap<TypeVarId, Type>) -> boo
         | Type::Unit
         | Type::UtxoAny
         | Type::UtxoNamed(_)
+        | Type::TokenAny
+        | Type::TokenNamed(_)
         | Type::AbiNarrow(_) => false,
     }
 }
@@ -5683,6 +5910,8 @@ fn collect_free_type_vars(ty: &Type, set: &mut HashSet<TypeVarId>) {
         | Type::Unit
         | Type::UtxoAny
         | Type::UtxoNamed(_)
+        | Type::TokenAny
+        | Type::TokenNamed(_)
         | Type::AbiNarrow(_) => {}
     }
 }

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_attach_wrong_signature_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_attach_wrong_signature_error.snap
@@ -1,0 +1,19 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\ntoken MyToken {\n    mint fn mint() {}\n\n    impl Token {\n        fn attach(to: i64) {}\n        fn detach(source: Utxo) {}\n    }\n}\n"
+---
+E0031 (https://starstream.nightstream.dev/errors/E0031)
+
+  x argument 0 has type `i64` but `Utxo` was expected
+   ,-[test.star:1:1]
+ 1 | token MyToken {
+   : ^
+   : `-- parameter expects `Utxo`
+ 2 |     mint fn mint() {}
+   `----
+   ,-[test.star:5:19]
+ 4 |     impl Token {
+ 5 |         fn attach(to: i64) {}
+   :                   ^^
+ 6 |         fn detach(source: Utxo) {}
+   `----

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_duplicate_impl_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_duplicate_impl_error.snap
@@ -1,0 +1,12 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\ntoken MyToken {\n    mint fn mint() {}\n\n    impl Token {\n        fn attach(to: Utxo) {}\n        fn detach(source: Utxo) {}\n    }\n\n    impl Token {\n        fn attach(to: Utxo) {}\n        fn detach(source: Utxo) {}\n    }\n}\n"
+---
+E0054 (https://starstream.nightstream.dev/errors/E0054)
+
+  x token `MyToken` may have only one `impl Token { ... }` block
+   ,-[test.star:1:7]
+ 1 | token MyToken {
+   :       ^^^^^^^
+ 2 |     mint fn mint() {}
+   `----

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_mint_return_type_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_mint_return_type_error.snap
@@ -1,0 +1,13 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\ntoken MyToken {\n    mint fn mint() -> u32 {\n        0\n    }\n\n    impl Token {\n        fn attach(to: Utxo) {}\n        fn detach(source: Utxo) {}\n    }\n}\n"
+---
+E0043 (https://starstream.nightstream.dev/errors/E0043)
+
+  x return type not allowed on this function
+   ,-[test.star:2:13]
+ 1 | token MyToken {
+ 2 |     mint fn mint() -> u32 {
+   :             ^^^^
+ 3 |         0
+   `----

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_missing_impl_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_missing_impl_error.snap
@@ -1,0 +1,12 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\ntoken MyToken {\n    mint fn mint() {}\n}\n"
+---
+E0053 (https://starstream.nightstream.dev/errors/E0053)
+
+  x token `MyToken` must have an `impl Token { ... }` block
+   ,-[test.star:1:7]
+ 1 | token MyToken {
+   :       ^^^^^^^
+ 2 |     mint fn mint() {}
+   `----

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_missing_mint_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_missing_mint_error.snap
@@ -1,0 +1,12 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\ntoken MyToken {\n    impl Token {\n        fn attach(to: Utxo) {}\n        fn detach(source: Utxo) {}\n    }\n}\n"
+---
+E0052 (https://starstream.nightstream.dev/errors/E0052)
+
+  x token `MyToken` must have at least one `mint fn`
+   ,-[test.star:1:7]
+ 1 | token MyToken {
+   :       ^^^^^^^
+ 2 |     impl Token {
+   `----

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_reserved_abi_name_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_reserved_abi_name_error.snap
@@ -1,0 +1,12 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\nabi Token {\n    fn attach(to: Utxo);\n}\n"
+---
+E0055 (https://starstream.nightstream.dev/errors/E0055)
+
+  x `Token` is a built-in ABI and cannot be redeclared
+   ,-[test.star:1:5]
+ 1 | abi Token {
+   :     ^^^^^
+ 2 |     fn attach(to: Utxo);
+   `----

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_valid.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__token_valid.snap
@@ -1,0 +1,16 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\ntoken MyToken {\n    storage {\n        indexed let mut supply: u32;\n        let mut owner: u64;\n    }\n\n    mint fn mint() {\n        supply = 1;\n    }\n\n    burn fn burn() {\n        supply = 0;\n    }\n\n    impl Token {\n        fn attach(to: Utxo) {}\n        fn detach(source: Utxo) {}\n    }\n\n    fn helper() {}\n}\n"
+---
+T-Token: MyToken => 
+  T-Fn: mint => ()
+    T-Assign: {mint: fn() -> (), owner: u64, supply: u32} ⊢ supply = 1; ⇒ u32
+      T-Int: {mint: fn() -> (), owner: u64, supply: u32} ⊢ 1 ⇒ i64
+      Unify-Var: i64 ~ u32 => {u32/t3}
+  T-Fn: burn => ()
+    T-Assign: {burn: fn() -> (), mint: fn() -> (), owner: u64, supply: u32} ⊢ supply = 0; ⇒ u32
+      T-Int: {burn: fn() -> (), mint: fn() -> (), owner: u64, supply: u32} ⊢ 0 ⇒ i64
+      Unify-Var: i64 ~ u32 => {u32/t4}
+  T-Fn: attach => ()
+  T-Fn: detach => ()
+  T-Fn: helper => ()

--- a/starstream-compiler/src/typecheck/tests.rs
+++ b/starstream-compiler/src/typecheck/tests.rs
@@ -1559,3 +1559,123 @@ fn if_is_linear_violation_error() {
         "#
     );
 }
+
+#[test]
+fn token_valid() {
+    assert_typecheck_snapshot!(
+        r#"
+        token MyToken {
+            storage {
+                indexed let mut supply: u32;
+                let mut owner: u64;
+            }
+
+            mint fn mint() {
+                supply = 1;
+            }
+
+            burn fn burn() {
+                supply = 0;
+            }
+
+            impl Token {
+                fn attach(to: Utxo) {}
+                fn detach(source: Utxo) {}
+            }
+
+            fn helper() {}
+        }
+        "#
+    );
+}
+
+#[test]
+fn token_missing_mint_error() {
+    assert_typecheck_snapshot!(
+        r#"
+        token MyToken {
+            impl Token {
+                fn attach(to: Utxo) {}
+                fn detach(source: Utxo) {}
+            }
+        }
+        "#
+    );
+}
+
+#[test]
+fn token_missing_impl_error() {
+    assert_typecheck_snapshot!(
+        r#"
+        token MyToken {
+            mint fn mint() {}
+        }
+        "#
+    );
+}
+
+#[test]
+fn token_duplicate_impl_error() {
+    assert_typecheck_snapshot!(
+        r#"
+        token MyToken {
+            mint fn mint() {}
+
+            impl Token {
+                fn attach(to: Utxo) {}
+                fn detach(source: Utxo) {}
+            }
+
+            impl Token {
+                fn attach(to: Utxo) {}
+                fn detach(source: Utxo) {}
+            }
+        }
+        "#
+    );
+}
+
+#[test]
+fn token_attach_wrong_signature_error() {
+    assert_typecheck_snapshot!(
+        r#"
+        token MyToken {
+            mint fn mint() {}
+
+            impl Token {
+                fn attach(to: i64) {}
+                fn detach(source: Utxo) {}
+            }
+        }
+        "#
+    );
+}
+
+#[test]
+fn token_mint_return_type_error() {
+    assert_typecheck_snapshot!(
+        r#"
+        token MyToken {
+            mint fn mint() -> u32 {
+                0
+            }
+
+            impl Token {
+                fn attach(to: Utxo) {}
+                fn detach(source: Utxo) {}
+            }
+        }
+        "#
+    );
+}
+
+#[test]
+fn token_reserved_abi_name_error() {
+    assert_typecheck_snapshot!(
+        r#"
+        abi Token {
+            fn attach(to: Utxo);
+        }
+        "#
+    );
+}

--- a/starstream-language-server/src/document.rs
+++ b/starstream-language-server/src/document.rs
@@ -892,7 +892,11 @@ impl DocumentState {
         }
     }
 
-    fn collect_token(&mut self, definition: &TypedTokenDef, scopes: &mut Vec<HashMap<String, Span>>) {
+    fn collect_token(
+        &mut self,
+        definition: &TypedTokenDef,
+        scopes: &mut Vec<HashMap<String, Span>>,
+    ) {
         for part in &definition.parts {
             match part {
                 TypedTokenPart::Storage(vars) => {

--- a/starstream-language-server/src/document.rs
+++ b/starstream-language-server/src/document.rs
@@ -19,8 +19,8 @@ use starstream_compiler::{
     typecheck::{TypeError, TypeWarning, TypecheckOptions, TypecheckSuccess},
 };
 use starstream_types::{
-    CommentMap, DUMMY_SPAN, FunctionDef, GenericTypeDef, Span, Spanned, TypeVarId, TypedUtxoDef,
-    TypedUtxoPart,
+    CommentMap, DUMMY_SPAN, FunctionDef, GenericTypeDef, Span, Spanned, TypeVarId, TypedTokenDef,
+    TypedTokenPart, TypedUtxoDef, TypedUtxoPart,
     ast::{self as untyped_ast, Program, TypeAnnotation},
     typed_ast::{
         TypedAbiDef, TypedAbiPart, TypedBlock, TypedDefinition, TypedEnumConstructorPayload,
@@ -628,9 +628,7 @@ impl DocumentState {
                 self.collect_enum(definition, untyped_enum, source, doc.clone());
             }
             TypedDefinition::Utxo(definition) => self.collect_utxo(definition, scopes),
-            TypedDefinition::Token(_) => {
-                // `token` is parse-only for now: no symbols/hover yet.
-            }
+            TypedDefinition::Token(definition) => self.collect_token(definition, scopes),
             TypedDefinition::Abi(definition) => {
                 let untyped_abi = untyped.and_then(|u| match &u.node {
                     untyped_ast::Definition::Abi(a) => Some(a),
@@ -882,6 +880,38 @@ impl DocumentState {
                     self.collect_function(function, scopes, None);
                 }
                 TypedUtxoPart::AbiImpl {
+                    abi: _,
+                    span: _,
+                    parts,
+                } => {
+                    for part in parts {
+                        self.collect_function(part, scopes, None);
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_token(&mut self, definition: &TypedTokenDef, scopes: &mut Vec<HashMap<String, Span>>) {
+        for part in &definition.parts {
+            match part {
+                TypedTokenPart::Storage(vars) => {
+                    let global = scopes.first_mut().unwrap();
+                    for var in vars {
+                        if let Some(span) = var.name.opt_span() {
+                            global.insert(var.name.name.clone(), span);
+                            self.definition_entries.push(DefinitionEntry {
+                                usage: span,
+                                target: span,
+                            });
+                            self.add_hover_span(span, &var.ty);
+                        }
+                    }
+                }
+                TypedTokenPart::Function(function) => {
+                    self.collect_function(function, scopes, None);
+                }
+                TypedTokenPart::AbiImpl {
                     abi: _,
                     span: _,
                     parts,
@@ -1716,8 +1746,24 @@ impl DocumentState {
                         }
                     }
                 }
-                untyped_ast::Definition::Token(_) => {
-                    // `token` is parse-only for now: no annotations collected yet.
+                untyped_ast::Definition::Token(definition) => {
+                    for part in &definition.parts {
+                        match part {
+                            untyped_ast::TokenPart::Storage(vars) => {
+                                for var in vars {
+                                    self.collect_type_annotation_node(&var.ty);
+                                }
+                            }
+                            untyped_ast::TokenPart::Function(function) => {
+                                self.collect_type_annotation_function(function);
+                            }
+                            untyped_ast::TokenPart::AbiImpl { abi: _, parts } => {
+                                for part in parts {
+                                    self.collect_type_annotation_function(part);
+                                }
+                            }
+                        }
+                    }
                 }
                 untyped_ast::Definition::Import(_) => {
                     // Imports don't have type annotations to collect
@@ -2000,13 +2046,12 @@ impl DocumentState {
             .definitions
             .iter()
             .filter_map(|definition| match definition {
-                TypedDefinition::Import(_)
-                | TypedDefinition::Token(_)
-                | TypedDefinition::Contract => None,
+                TypedDefinition::Import(_) | TypedDefinition::Contract => None,
                 TypedDefinition::Function(function) => self.function_symbol(function),
                 TypedDefinition::Struct(definition) => self.struct_symbol(definition),
                 TypedDefinition::Enum(definition) => self.enum_symbol(definition),
                 TypedDefinition::Utxo(definition) => self.utxo_symbol(definition),
+                TypedDefinition::Token(definition) => self.token_symbol(definition),
                 TypedDefinition::Abi(definition) => self.abi_symbol(definition),
             })
             .collect()
@@ -2167,6 +2212,71 @@ impl DocumentState {
                     let impl_children = parts
                         .iter()
                         .filter_map(|function| self.function_symbol(function))
+                        .collect::<Vec<_>>();
+                    children.push(DocumentSymbol {
+                        name: abi.to_compact_string(),
+                        detail: Some(abi.to_string()),
+                        kind: SymbolKind::INTERFACE,
+                        tags: None,
+                        #[allow(deprecated)]
+                        deprecated: None,
+                        range: self.span_to_range(*span),
+                        selection_range: self.span_to_range(*span),
+                        children: Some(impl_children),
+                    });
+                }
+            }
+        }
+
+        #[allow(deprecated)]
+        let symbol = DocumentSymbol {
+            name: definition.name.name.clone(),
+            detail: None,
+            kind: SymbolKind::CLASS,
+            tags: None,
+            deprecated: None,
+            range: self.span_to_range(name_span),
+            selection_range: self.span_to_range(name_span),
+            children: if children.is_empty() {
+                None
+            } else {
+                Some(children)
+            },
+        };
+
+        Some(symbol)
+    }
+
+    fn token_symbol(&self, definition: &TypedTokenDef) -> Option<DocumentSymbol> {
+        let name_span = definition.name.opt_span()?;
+        let mut children = Vec::new();
+        for part in &definition.parts {
+            match part {
+                TypedTokenPart::Storage(vars) => {
+                    for var in vars {
+                        if let Some(span) = var.name.opt_span() {
+                            #[allow(deprecated)]
+                            let child = DocumentSymbol {
+                                name: var.name.name.clone(),
+                                detail: Some(var.ty.to_string()),
+                                kind: SymbolKind::ENUM_MEMBER,
+                                tags: None,
+                                deprecated: None,
+                                range: self.span_to_range(span),
+                                selection_range: self.span_to_range(span),
+                                children: None,
+                            };
+                            children.push(child);
+                        }
+                    }
+                }
+                TypedTokenPart::Function(function) => {
+                    children.extend(self.function_symbol(function));
+                }
+                TypedTokenPart::AbiImpl { abi, span, parts } => {
+                    let impl_children = parts
+                        .iter()
+                        .flat_map(|function| self.function_symbol(function))
                         .collect::<Vec<_>>();
                     children.push(DocumentSymbol {
                         name: abi.to_compact_string(),

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -973,6 +973,26 @@ impl Compiler {
                     return None;
                 }
             }
+            // Token handles mirror Utxo: always borrowed, the ledger owns them.
+            Type::TokenAny => {
+                if let Some(idx) = self.resources.get("Token") {
+                    ComponentAbiType::Borrow { resource: *idx }
+                } else {
+                    let idx = self.world_type.inner.type_count();
+                    self.world_type
+                        .inner
+                        .import("token", ComponentTypeRef::Type(TypeBounds::SubResource));
+                    self.resources.insert("Token".to_owned(), idx);
+                    ComponentAbiType::Borrow { resource: idx }
+                }
+            }
+            Type::TokenNamed(name) => {
+                if let Some(idx) = self.resources.get(name) {
+                    ComponentAbiType::Borrow { resource: *idx }
+                } else {
+                    return None;
+                }
+            }
             Type::Record(record) => {
                 let fields = record
                     .fields
@@ -1221,7 +1241,7 @@ impl Compiler {
             Type::Unit => 0,
             Type::Bool => 1,
             Type::Int(_) => 1,
-            Type::UtxoAny | Type::UtxoNamed(_) => 1,
+            Type::UtxoAny | Type::UtxoNamed(_) | Type::TokenAny | Type::TokenNamed(_) => 1,
             Type::Tuple(items) => items.iter().map(|t| self.star_count_core_types(t)).sum(),
             Type::Record(record) => record
                 .fields

--- a/starstream-to-wasm/tests/inputs/struct_param.star
+++ b/starstream-to-wasm/tests/inputs/struct_param.star
@@ -1,8 +1,8 @@
-struct Token {
+struct Item {
     amount: i64,
     price: i64,
 }
 
-script fn total_value(token: Token) -> i64 {
-    token.amount * token.price
+script fn total_value(item: Item) -> i64 {
+    item.amount * item.price
 }

--- a/starstream-to-wasm/tests/snapshots/inputs@struct_param.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@struct_param.star.snap
@@ -10,42 +10,42 @@ Program {
             node: Struct(
                 StructDef {
                     name: Identifier {
-                        name: "Token",
-                        span: 7..12,
+                        name: "Item",
+                        span: 7..11,
                     },
                     fields: [
                         StructField {
                             name: Identifier {
                                 name: "amount",
-                                span: 19..25,
+                                span: 18..24,
                             },
                             ty: TypeAnnotation {
                                 name: Identifier {
                                     name: "i64",
-                                    span: 27..30,
+                                    span: 26..29,
                                 },
                                 generics: [],
                             },
-                            span: 19..30,
+                            span: 18..29,
                         },
                         StructField {
                             name: Identifier {
                                 name: "price",
-                                span: 36..41,
+                                span: 35..40,
                             },
                             ty: TypeAnnotation {
                                 name: Identifier {
                                     name: "i64",
-                                    span: 43..46,
+                                    span: 42..45,
                                 },
                                 generics: [],
                             },
-                            span: 36..46,
+                            span: 35..45,
                         },
                     ],
                 },
             ),
-            span: 0..51,
+            span: 0..50,
         },
         Spanned {
             node: Function(
@@ -55,19 +55,19 @@ Program {
                     ),
                     name: Identifier {
                         name: "total_value",
-                        span: 61..72,
+                        span: 60..71,
                     },
                     params: [
                         FunctionParam {
                             public: false,
                             name: Identifier {
-                                name: "token",
-                                span: 73..78,
+                                name: "item",
+                                span: 72..76,
                             },
                             ty: TypeAnnotation {
                                 name: Identifier {
-                                    name: "Token",
-                                    span: 80..85,
+                                    name: "Item",
+                                    span: 78..82,
                                 },
                                 generics: [],
                             },
@@ -77,7 +77,7 @@ Program {
                         TypeAnnotation {
                             name: Identifier {
                                 name: "i64",
-                                span: 90..93,
+                                span: 87..90,
                             },
                             generics: [],
                         },
@@ -93,46 +93,46 @@ Program {
                                             target: Spanned {
                                                 node: Identifier(
                                                     Identifier {
-                                                        name: "token",
-                                                        span: 100..105,
+                                                        name: "item",
+                                                        span: 97..101,
                                                     },
                                                 ),
-                                                span: 100..105,
+                                                span: 97..101,
                                             },
                                             field: Identifier {
                                                 name: "amount",
-                                                span: 106..112,
+                                                span: 102..108,
                                             },
                                         },
-                                        span: 100..113,
+                                        span: 97..109,
                                     },
                                     right: Spanned {
                                         node: FieldAccess {
                                             target: Spanned {
                                                 node: Identifier(
                                                     Identifier {
-                                                        name: "token",
-                                                        span: 115..120,
+                                                        name: "item",
+                                                        span: 111..115,
                                                     },
                                                 ),
-                                                span: 115..120,
+                                                span: 111..115,
                                             },
                                             field: Identifier {
                                                 name: "price",
-                                                span: 121..126,
+                                                span: 116..121,
                                             },
                                         },
-                                        span: 115..127,
+                                        span: 111..122,
                                     },
                                 },
-                                span: 100..127,
+                                span: 97..122,
                             },
                         ),
-                        span: 94..129,
+                        span: 91..124,
                     },
                 },
             ),
-            span: 51..129,
+            span: 50..124,
         },
     ],
 }
@@ -140,12 +140,12 @@ Program {
 ==== Inference trace ====
 
 T-Fn: total_value => i64
-  T-ReturnTail: token.amount * token.price => i64
-    T-Bin-Mul: {token: Token, total_value: fn(Token) -> i64} ⊢ token.amount * token.price ⇒ i64
-      T-FieldAccess: {token: Token, total_value: fn(Token) -> i64} ⊢ token.amount ⇒ i64
-        T-Var: {token: Token, total_value: fn(Token) -> i64} ⊢ token ⇒ Token
-      T-FieldAccess: {token: Token, total_value: fn(Token) -> i64} ⊢ token.price ⇒ i64
-        T-Var: {token: Token, total_value: fn(Token) -> i64} ⊢ token ⇒ Token
+  T-ReturnTail: item.amount * item.price => i64
+    T-Bin-Mul: {item: Item, total_value: fn(Item) -> i64} ⊢ item.amount * item.price ⇒ i64
+      T-FieldAccess: {item: Item, total_value: fn(Item) -> i64} ⊢ item.amount ⇒ i64
+        T-Var: {item: Item, total_value: fn(Item) -> i64} ⊢ item ⇒ Item
+      T-FieldAccess: {item: Item, total_value: fn(Item) -> i64} ⊢ item.price ⇒ i64
+        T-Var: {item: Item, total_value: fn(Item) -> i64} ⊢ item ⇒ Item
       Unify-Const: i64 ~ i64 => {}
     Unify-Const: i64 ~ i64 => {}
 
@@ -156,14 +156,14 @@ TypedProgram {
         Struct(
             TypedStructDef {
                 name: Identifier {
-                    name: "Token",
-                    span: 7..12,
+                    name: "Item",
+                    span: 7..11,
                 },
                 fields: [
                     TypedStructField {
                         name: Identifier {
                             name: "amount",
-                            span: 19..25,
+                            span: 18..24,
                         },
                         ty: Int(
                             I64,
@@ -172,7 +172,7 @@ TypedProgram {
                     TypedStructField {
                         name: Identifier {
                             name: "price",
-                            span: 36..41,
+                            span: 35..40,
                         },
                         ty: Int(
                             I64,
@@ -181,7 +181,7 @@ TypedProgram {
                 ],
                 ty: Record(
                     RecordType {
-                        name: "Token",
+                        name: "Item",
                         fields: [
                             RecordFieldType {
                                 name: "amount",
@@ -207,18 +207,18 @@ TypedProgram {
                 ),
                 name: Identifier {
                     name: "total_value",
-                    span: 61..72,
+                    span: 60..71,
                 },
                 params: [
                     TypedFunctionParam {
                         public: false,
                         name: Identifier {
-                            name: "token",
-                            span: 73..78,
+                            name: "item",
+                            span: 72..76,
                         },
                         ty: Record(
                             RecordType {
-                                name: "Token",
+                                name: "Item",
                                 fields: [
                                     RecordFieldType {
                                         name: "amount",
@@ -261,7 +261,7 @@ TypedProgram {
                                                     node: TypedExpr {
                                                         ty: Record(
                                                             RecordType {
-                                                                name: "Token",
+                                                                name: "Item",
                                                                 fields: [
                                                                     RecordFieldType {
                                                                         name: "amount",
@@ -280,20 +280,20 @@ TypedProgram {
                                                         ),
                                                         kind: Identifier(
                                                             Identifier {
-                                                                name: "token",
-                                                                span: 100..105,
+                                                                name: "item",
+                                                                span: 97..101,
                                                             },
                                                         ),
                                                     },
-                                                    span: 100..105,
+                                                    span: 97..101,
                                                 },
                                                 field: Identifier {
                                                     name: "amount",
-                                                    span: 106..112,
+                                                    span: 102..108,
                                                 },
                                             },
                                         },
-                                        span: 100..113,
+                                        span: 97..109,
                                     },
                                     right: Spanned {
                                         node: TypedExpr {
@@ -305,7 +305,7 @@ TypedProgram {
                                                     node: TypedExpr {
                                                         ty: Record(
                                                             RecordType {
-                                                                name: "Token",
+                                                                name: "Item",
                                                                 fields: [
                                                                     RecordFieldType {
                                                                         name: "amount",
@@ -324,24 +324,24 @@ TypedProgram {
                                                         ),
                                                         kind: Identifier(
                                                             Identifier {
-                                                                name: "token",
-                                                                span: 115..120,
+                                                                name: "item",
+                                                                span: 111..115,
                                                             },
                                                         ),
                                                     },
-                                                    span: 115..120,
+                                                    span: 111..115,
                                                 },
                                                 field: Identifier {
                                                     name: "price",
-                                                    span: 121..126,
+                                                    span: 116..121,
                                                 },
                                             },
                                         },
-                                        span: 115..127,
+                                        span: 111..122,
                                     },
                                 },
                             },
-                            span: 100..127,
+                            span: 97..122,
                         },
                     ),
                 },
@@ -414,8 +414,8 @@ TypedProgram {
           (type (;0;)
             (component
               (type (;0;) (record (field "amount" s64) (field "price" s64)))
-              (import "token" (type (;1;) (eq 0)))
-              (type (;2;) (func (param "token" 1) (result s64)))
+              (import "item" (type (;1;) (eq 0)))
+              (type (;2;) (func (param "item" 1) (result s64)))
               (export (;0;) "total-value" (func (type 2)))
             )
           )
@@ -431,10 +431,10 @@ TypedProgram {
 package root:component;
 
 world root {
-  record token {
+  record item {
     amount: s64,
     price: s64,
   }
 
-  export total-value: func(token: token) -> s64;
+  export total-value: func(item: item) -> s64;
 }

--- a/starstream-types/src/typed_ast.rs
+++ b/starstream-types/src/typed_ast.rs
@@ -161,13 +161,30 @@ pub struct TypedUtxoGlobal {
     pub ty: Type,
 }
 
-/// Shallow typed marker for a `token` definition. Token bodies are not yet
-/// type-checked; this carries just the name/span so the definition survives
-/// lowering. Fleshed out alongside the global `Token` type in a follow-up.
 #[derive(Clone, Debug)]
 pub struct TypedTokenDef {
     pub name: Identifier,
-    pub span: Span,
+    pub parts: Vec<TypedTokenPart>,
+    pub ty: Type,
+}
+
+#[derive(Clone, Debug)]
+pub enum TypedTokenPart {
+    Storage(Vec<TypedTokenGlobal>),
+    Function(Box<TypedFunctionDef>),
+    AbiImpl {
+        span: Span,
+        abi: Type,
+        parts: Vec<TypedFunctionDef>,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct TypedTokenGlobal {
+    /// Whether the field carries the `indexed` modifier.
+    pub indexed: bool,
+    pub name: Identifier,
+    pub ty: Type,
 }
 
 #[derive(Clone, Debug)]

--- a/starstream-types/src/types.rs
+++ b/starstream-types/src/types.rs
@@ -198,6 +198,10 @@ pub enum Type {
     UtxoAny,
     /// The type created by a `utxo` definition.
     UtxoNamed(String),
+    /// The built-in `Token` type.
+    TokenAny,
+    /// The type created by a `token` definition.
+    TokenNamed(String),
     /// The type created by an `abi` definition. Also the type of a Utxo
     /// narrowed via `if x is AbiName`.
     AbiNarrow(Arc<Abi>),
@@ -351,6 +355,8 @@ impl Type {
             },
             Type::UtxoAny => RcDoc::text("Utxo"),
             Type::UtxoNamed(id) => RcDoc::text(id.to_owned()),
+            Type::TokenAny => RcDoc::text("Token"),
+            Type::TokenNamed(id) => RcDoc::text(id.to_owned()),
             Type::AbiNarrow(abi) => RcDoc::text(abi.name.to_string()),
         }
     }


### PR DESCRIPTION
Builds on #138 (parser support). Replaces the parse-only `token` stubs with full type checking, mirroring the existing `utxo` machinery. Token codegen is intentionally left as a follow-up.

> Builds on #138 — until that merges, this PR also includes its parser commits.

## Behavior

A `token` definition is now checked end to end:

```starstream
token MyToken {
    storage {
        indexed let mut supply: u32;
        let mut owner: u64;
    }
    mint fn mint() { supply = 1; }   // storage in scope; no explicit return type
    burn fn burn() { supply = 0; }
    impl Token {                      // built-in interface: attach/detach
        fn attach(to: Utxo) {}
        fn detach(source: Utxo) {}
    }
    fn helper() {}
}
```

Rules enforced: at least one `mint fn`, exactly one `impl Token`, `mint` may not declare a return type, and the `impl Token` block must match the built-in `attach(Utxo) -> ()` / `detach(Utxo) -> ()` signatures. Additional `impl <UserAbi>` blocks are allowed.

## Changes

- **Type model** (`types.rs`): `Type::TokenAny` + `Type::TokenNamed`, parallel to Utxo, threaded through every exhaustive `Type` match (apply, substitute, occurs/free-vars, env, exhaustiveness, docs, to-wasm handle lowering).
- **Typed AST** (`typed_ast.rs`): `TypedTokenDef { name, parts, ty }` with `TypedTokenPart` + `TypedTokenGlobal { indexed }`.
- **Type checking** (`infer.rs`): `register_token` (opaque handle), `Token` annotation → `TokenAny`, a built-in `Token` ABI registered at construction so `impl Token` reuses `check_abi_impl`, a guard rejecting user-declared `abi Token`, and `infer_token` (structural pre-pass, storage scope, mint return-type rule, impl conformance) plus `apply_token` and type export.
- **Errors**: new `E0052`–`E0055` with rendered messages and docs.
- **Language server** (`document.rs`): token symbols, hover, and type-annotation collection.
- **Tests**: 8 typecheck snapshot tests (valid token + each error path).

## Note

`Token` is now a **reserved type name** like `Utxo`. The `struct_param.star` codegen fixture happened to define `struct Token`, so it was renamed to `struct Item` (snapshot regenerated).

### Known parallels-to-utxo / deferred

- `check_abi_impl` does not enforce parameter *arity* (pre-existing utxo limitation).
- No token `unify` arms (utxo has none either; token-typed values don't flow through unification yet).
- Token codegen in `starstream-to-wasm` remains a "not yet supported" stub.