### PR TITLE
build: update Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 version = "0.0.0"
 authors = []
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.94.0"
 repository = "https://github.com/LFDT-Nightstream/Starstream"
 license = "MIT/Apache-2.0"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.96.0"
 targets = ["wasm32-unknown-unknown"]

--- a/starstream-sandbox-web/src/lib.rs
+++ b/starstream-sandbox-web/src/lib.rs
@@ -5,6 +5,7 @@ use log::error;
 use wit_component::{ComponentEncoder, DecodedWasm};
 
 // Imports to manipulate the UI contents, provided by the JS page.
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     unsafe fn read_input(ptr: *mut u8, len: usize);
 


### PR DESCRIPTION
- Wasmtime 46 release is coming soon and will require Rust 1.94, bump MSRV in anticipation of that
- Update rust-toolchain.toml Rust version to latest stable