### PR TITLE
Add partial wasm codegen for `token` definitions

### DIFF
--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -417,10 +417,10 @@ displayed in IDE hover tooltips above the type information.
   - `mint fn` items act as this type's constructors (analogous to a `utxo`'s
     `main fn`); each produces a handle to the newly minted token.
   - **Work in progress.** Tokens are parsed, type-checked, and have partial wasm
-    codegen: the token resource, `mint` constructors, and storage get/set are
-    emitted. Still outstanding: `burn`, the `impl Token` `attach`/`detach`
-    exports (they need cross-resource WIT handling), `indexed` storage support,
-    and runtime support.
+    codegen: the token resource, `mint` constructors, `burn` functions, and
+    storage get/set are emitted. Still outstanding: the `impl Token`
+    `attach`/`detach` exports (they need cross-resource WIT handling), `indexed`
+    storage support, and runtime support.
 
 No user-defined generics at this time.
 

--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -416,11 +416,11 @@ displayed in IDE hover tooltips above the type information.
   ordinary functions.
   - `mint fn` items act as this type's constructors (analogous to a `utxo`'s
     `main fn`); each produces a handle to the newly minted token.
-  - **Work in progress.** Tokens are parsed, type-checked, and have partial wasm
-    codegen: the token resource, `mint` constructors, `burn` functions, and
-    storage get/set are emitted. Still outstanding: the `impl Token`
-    `attach`/`detach` exports (they need cross-resource WIT handling), `indexed`
-    storage support, and runtime support.
+  - **Work in progress.** Tokens are parsed, type-checked, and compiled to wasm:
+    the token resource, `mint` constructors, `burn` functions, the `impl Token`
+    methods (`attach`/`detach`, generated exactly like a `utxo`'s `impl <Abi>`,
+    since `Token` is a built-in ABI), and storage get/set are all emitted. Still
+    outstanding: `indexed` storage support and runtime support.
 
 No user-defined generics at this time.
 

--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -414,9 +414,13 @@ displayed in IDE hover tooltips above the type information.
   fields (optionally `indexed`), one or more `mint` functions, zero or more
   `burn` functions, an `impl Token { … }` block (with `attach`/`detach`), and
   ordinary functions.
-  - **Parsing only at this time.** Token definitions are recognized by the parser
-    and formatter but are not yet type-checked or compiled, and the global `Token`
-    type (parallel to the root `Utxo` handle) is not yet part of the type system.
+  - `mint fn` items act as this type's constructors (analogous to a `utxo`'s
+    `main fn`); each produces a handle to the newly minted token.
+  - **Work in progress.** Tokens are parsed, type-checked, and have partial wasm
+    codegen: the token resource, `mint` constructors, and storage get/set are
+    emitted. Still outstanding: `burn`, the `impl Token` `attach`/`detach`
+    exports (they need cross-resource WIT handling), `indexed` storage support,
+    and runtime support.
 
 No user-defined generics at this time.
 

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -1810,12 +1810,33 @@ impl Compiler {
                                 iface.export_fn(&wit_name, &sig);
                             }
                         }
-                        // TODO(token-burn): the WIT shape of `burn fn` is not yet
-                        // decided — likely a consuming `[method]token.<name>` that
-                        // takes `self: own<token>`, or a call into the resource's
-                        // drop. For now the body is compiled (above) but the
-                        // function is not exported.
-                        Some(FunctionExport::TokenBurn) => {}
+                        // `burn fn` carries no special wasm semantics — what
+                        // burning actually does is a runtime concern. It is
+                        // exported as a plain static function on the token,
+                        // distinguished only by its export name.
+                        Some(FunctionExport::TokenBurn) => {
+                            let sig = self.star_to_component_signature(
+                                None,
+                                &function.params,
+                                &function.return_type,
+                            );
+                            let wit_name = format!(
+                                "[static]{resource_name}.{}",
+                                to_kebab_case(function.name.as_str())
+                            );
+                            if let Some(func_idx) = self.make_component_export_wrapper_fn(
+                                function.name.span,
+                                &sig,
+                                core.idx,
+                                &core.ty,
+                            ) {
+                                self.export_core_fn(
+                                    &format!("{interface_name}#{wit_name}"),
+                                    func_idx,
+                                );
+                                iface.export_fn(&wit_name, &sig);
+                            }
+                        }
                         // Plain helper functions are compiled but not exported,
                         // matching `utxo` non-`main` functions.
                         _ => {}
@@ -1832,15 +1853,14 @@ impl Compiler {
                         // validated, but do NOT export it yet.
                         //
                         // TODO(token-impl-export): `impl Token`'s `attach`/`detach`
-                        // take a `Utxo` parameter, i.e. they reference a *foreign*
-                        // resource from inside the token interface. The current
-                        // resource-index model (raw indices shared with
-                        // `world_type`) conflates that `Utxo` borrow with the
-                        // token's own resource, so the emitted WIT would be wrong
-                        // (`borrow<token>` instead of `borrow<utxo>`). Exporting
-                        // these methods needs proper cross-resource index handling
-                        // in the component encoder. Until then they are compiled
-                        // but unexported.
+                        // take a `Utxo` parameter — a *foreign* resource referenced
+                        // from inside the token interface. The current resource-index
+                        // model (raw indices shared with `world_type`) conflates that
+                        // `Utxo` borrow with the token's own resource, so the emitted
+                        // WIT is wrong (`borrow<token>` instead of `borrow<utxo>`).
+                        // Exporting these needs proper cross-resource (cross-interface)
+                        // resource references in the component encoder. The bodies are
+                        // compiled here; only the WIT export is held back.
                         let _core = self.visit_function(
                             Some(&token.ty),
                             function,

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -1847,25 +1847,34 @@ impl Compiler {
                     abi,
                     parts,
                 } => {
+                    // `impl Token` (and any `impl <UserAbi>`) is generated exactly
+                    // like a `utxo`'s `impl <Abi>`: each method is exported as a
+                    // `[method]` on the resource. `Token` is simply a built-in ABI.
                     _ = abi; // TODO: generate cast functions (mirrors `utxo`)
                     for function in parts {
-                        // Compile (and storage/type-check) the body so it is
-                        // validated, but do NOT export it yet.
-                        //
-                        // TODO(token-impl-export): `impl Token`'s `attach`/`detach`
-                        // take a `Utxo` parameter — a *foreign* resource referenced
-                        // from inside the token interface. The current resource-index
-                        // model (raw indices shared with `world_type`) conflates that
-                        // `Utxo` borrow with the token's own resource, so the emitted
-                        // WIT is wrong (`borrow<token>` instead of `borrow<utxo>`).
-                        // Exporting these needs proper cross-resource (cross-interface)
-                        // resource references in the component encoder. The bodies are
-                        // compiled here; only the WIT export is held back.
-                        let _core = self.visit_function(
+                        let core = self.visit_function(
                             Some(&token.ty),
                             function,
                             &(&() as &dyn Locals, &token_storage),
                         );
+                        let sig = self.star_to_component_signature(
+                            Some(&token.ty),
+                            &function.params,
+                            &function.return_type,
+                        );
+                        let wit_name = format!(
+                            "[method]{resource_name}.{}",
+                            to_kebab_case(function.name.as_str())
+                        );
+                        if let Some(func_idx) = self.make_component_export_wrapper_fn(
+                            function.name.span,
+                            &sig,
+                            core.idx,
+                            &core.ty,
+                        ) {
+                            self.export_core_fn(&format!("{interface_name}#{wit_name}"), func_idx);
+                            iface.export_fn(&wit_name, &sig);
+                        }
                     }
                 }
             }

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -13,8 +13,7 @@ use starstream_types::{
     TypedEnumDef, TypedEnumPatternPayload, TypedExpr, TypedExprKind, TypedFunctionDef,
     TypedFunctionParam, TypedIfCondition, TypedImportDef, TypedImportItems, TypedImportSource,
     TypedMatchArm, TypedPattern, TypedProgram, TypedStatement, TypedStructDef, TypedTokenDef,
-    TypedTokenPart, TypedUtxoDef, TypedUtxoPart, UnaryOp,
-    ast::Identifier,
+    TypedTokenPart, TypedUtxoDef, TypedUtxoPart, UnaryOp, ast::Identifier,
 };
 use thiserror::Error;
 use wasm_encoder::{

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -12,8 +12,9 @@ use starstream_types::{
     TypedAbiDef, TypedAbiPart, TypedBlock, TypedDefinition, TypedEnumConstructorPayload,
     TypedEnumDef, TypedEnumPatternPayload, TypedExpr, TypedExprKind, TypedFunctionDef,
     TypedFunctionParam, TypedIfCondition, TypedImportDef, TypedImportItems, TypedImportSource,
-    TypedMatchArm, TypedPattern, TypedProgram, TypedStatement, TypedStructDef, TypedUtxoDef,
-    TypedUtxoPart, UnaryOp,
+    TypedMatchArm, TypedPattern, TypedProgram, TypedStatement, TypedStructDef, TypedTokenDef,
+    TypedTokenPart, TypedUtxoDef, TypedUtxoPart, UnaryOp,
+    ast::Identifier,
 };
 use thiserror::Error;
 use wasm_encoder::{
@@ -250,10 +251,10 @@ struct Compiler {
     yield_id: i32,
     yield_funcs: Vec<u32>,
 
-    current_utxo: Option<UtxoContext>,
+    current_resource: Option<ResourceContext>,
 }
 
-struct UtxoContext {
+struct ResourceContext {
     resume_fn: u32,
     resource_new_fn: u32,
     // resource_drop_fn: u32,
@@ -419,12 +420,12 @@ impl Compiler {
 
     fn generate_storage_exports(
         &mut self,
-        utxo: &TypedUtxoDef,
+        name: &Identifier,
+        ty: &Type,
         iface: &mut TypeBuilder<InstanceType>,
         interface_name: &str,
         fields: impl Iterator<Item = u32> + Clone,
     ) {
-        let name = &utxo.name;
         let storage_flat: Vec<ValType> = fields
             .clone()
             .map(|g| self.global_details[g as usize].1)
@@ -449,7 +450,7 @@ impl Compiler {
         });
         iface.export_ty("storage", &storage_record);
 
-        let utxo_borrow = self.star_to_component_type(&utxo.ty).unwrap();
+        let utxo_borrow = self.star_to_component_type(ty).unwrap();
         let utxo_own = utxo_borrow.convert_resource_to_owned();
 
         // get-storage(self: borrow<utxo>) -> storage
@@ -488,7 +489,7 @@ impl Compiler {
             }
             code.instructions()
                 .i32_const(0)
-                .return_call(self.current_utxo.as_ref().unwrap().resource_new_fn)
+                .return_call(self.current_resource.as_ref().unwrap().resource_new_fn)
                 .end();
             let func = self.add_function(&ty, code.into_raw_body());
             if let Some(func_idx) =
@@ -1158,7 +1159,9 @@ impl Compiler {
                     .and(ok);
                 dest.extend(flat);
             }
-            Type::UtxoAny | Type::UtxoNamed(_) => dest.push(ValType::I32),
+            Type::UtxoAny | Type::UtxoNamed(_) | Type::TokenAny | Type::TokenNamed(_) => {
+                dest.push(ValType::I32)
+            }
             _ => ok = Err(self.push_error(span, format!("unknown core lowering for {ty:?}"))),
         }
         ok
@@ -1308,6 +1311,7 @@ impl Compiler {
                 TypedDefinition::Import(def) => self.visit_import(def),
                 TypedDefinition::Abi(def) => self.visit_abi(def),
                 TypedDefinition::Utxo(def) => self.pre_visit_utxo(def),
+                TypedDefinition::Token(def) => self.pre_visit_token(def),
                 // All others handled below.
                 _ => {}
             }
@@ -1318,7 +1322,7 @@ impl Compiler {
                 TypedDefinition::Import(_) => { /* Handled above. */ }
                 TypedDefinition::Abi(_) => { /* Handled above. */ }
                 TypedDefinition::Contract => { /* Pure marker, no codegen. */ }
-                TypedDefinition::Token(_) => { /* Token codegen not yet supported. */ }
+                TypedDefinition::Token(token) => self.visit_token(token),
 
                 TypedDefinition::Function(func) => {
                     let core = self.visit_function(None, func, &());
@@ -1508,9 +1512,11 @@ impl Compiler {
         let mut bb = bb_orig;
 
         let resource_local = match function.export {
-            Some(FunctionExport::UtxoMain) => {
-                // A `utxo main` fn starts by spawning a resource to represent the created Utxo.
-                let ctx = self.current_utxo.as_mut().unwrap();
+            // A `utxo main` fn spawns the created Utxo; a token `mint fn` spawns
+            // the minted token. Both start by allocating a fresh resource handle
+            // that becomes the function's (owned) return value.
+            Some(FunctionExport::UtxoMain) | Some(FunctionExport::TokenMint) => {
+                let ctx = self.current_resource.as_mut().unwrap();
                 let resource_local = func.add_locals([ValType::I32]);
                 ctx.resource_local = resource_local;
                 func.instructions(&bb)
@@ -1557,7 +1563,7 @@ impl Compiler {
             self.yield_funcs.push(idx);
         }
 
-        if let Some(utxo) = &mut self.current_utxo {
+        if let Some(utxo) = &mut self.current_resource {
             utxo.resource_local = u32::MAX;
         }
 
@@ -1615,7 +1621,7 @@ impl Compiler {
         let yield_start = self.yield_id;
         let resume_fn = self.add_function(&FuncType::new([], []), Vec::new());
         let resume_code_idx = self.code_bytes.len() - 1;
-        self.current_utxo = Some(UtxoContext {
+        self.current_resource = Some(ResourceContext {
             resume_fn,
             resource_new_fn,
             // resource_drop_fn,
@@ -1701,7 +1707,8 @@ impl Compiler {
         // Generate storage exports.
         let end_global = self.globals.len();
         self.generate_storage_exports(
-            utxo,
+            &utxo.name,
+            &utxo.ty,
             &mut iface,
             &interface_name,
             self.yield_global
@@ -1710,7 +1717,154 @@ impl Compiler {
         );
 
         self.exported_interfaces.insert(interface_name, iface);
-        self.current_utxo = None;
+        self.current_resource = None;
+    }
+
+    fn pre_visit_token(&mut self, token: &TypedTokenDef) {
+        let interface_name = to_kebab_case(token.name.as_str());
+        let resource_name = "token";
+
+        // Allocate the synthetic `resource.new` and `resource.drop` imports.
+        let ty = self.add_core_func_type(&FuncType::new([ValType::I32], [ValType::I32]));
+        let new_fn = self.import_function(
+            &format!("[export]{interface_name}"),
+            &format!("[resource-new]{resource_name}"),
+            ty,
+        );
+        let ty = self.add_core_func_type(&FuncType::new([ValType::I32], []));
+        let drop_fn = self.import_function(
+            &format!("[export]{interface_name}"),
+            &format!("[resource-drop]{resource_name}"),
+            ty,
+        );
+        self.resource_abi_fns
+            .insert(token.ty.clone(), (new_fn, drop_fn));
+    }
+
+    fn visit_token(&mut self, token: &TypedTokenDef) {
+        let mut iface = TypeBuilder::<InstanceType>::default();
+
+        // Declare the resource type.
+        let interface_name = to_kebab_case(token.name.as_str());
+        let resource_name = "token";
+        let resource = self.world_type.inner.type_count();
+        iface.inner.export(
+            resource_name,
+            ComponentTypeRef::Type(TypeBounds::SubResource),
+        );
+        self.resources.insert(token.name.to_string(), resource);
+
+        let (resource_new_fn, _resource_drop_fn) = *self.resource_abi_fns.get(&token.ty).unwrap();
+
+        // Tokens have no coroutine/`yield` semantics, so there is no `resume;`
+        // function to reserve (unlike `utxo`). `resume_fn` is never read because
+        // a `mint fn` body cannot yield.
+        self.current_resource = Some(ResourceContext {
+            resume_fn: u32::MAX,
+            resource_new_fn,
+            resource_local: u32::MAX,
+        });
+
+        // Visit each token part.
+        let mut token_storage = HashMap::new();
+        let start_global = self.globals.len();
+        for part in &token.parts {
+            match part {
+                TypedTokenPart::Storage(vars) => {
+                    for var in vars {
+                        // NOTE: `indexed` is carried on the typed field but does
+                        // not yet affect codegen; indexing support is deferred.
+                        let mut types = Vec::new();
+                        _ = self.star_to_core_types(token.name.span(), &mut types, &var.ty);
+                        let idx = self.add_globals(types.iter().copied(), var.name.as_str());
+                        token_storage.insert(var.name.name.clone(), Var::Global(idx));
+                    }
+                }
+                TypedTokenPart::Function(function) => {
+                    let core =
+                        self.visit_function(None, function, &(&() as &dyn Locals, &token_storage));
+                    match function.export {
+                        // A `mint fn` is a constructor: it returns an owned
+                        // handle to the freshly minted token (see the resource
+                        // spawn in `visit_function`).
+                        Some(FunctionExport::TokenMint) => {
+                            let mut sig = self.star_to_component_signature(
+                                None,
+                                &function.params,
+                                &function.return_type,
+                            );
+                            sig.result = Some(Rc::new(ComponentAbiType::Own { resource }));
+                            let wit_name = format!(
+                                "[static]{resource_name}.{}",
+                                to_kebab_case(function.name.as_str())
+                            );
+                            if let Some(func_idx) = self.make_component_export_wrapper_fn(
+                                function.name.span,
+                                &sig,
+                                core.idx,
+                                &core.ty,
+                            ) {
+                                self.export_core_fn(
+                                    &format!("{interface_name}#{wit_name}"),
+                                    func_idx,
+                                );
+                                iface.export_fn(&wit_name, &sig);
+                            }
+                        }
+                        // TODO(token-burn): the WIT shape of `burn fn` is not yet
+                        // decided — likely a consuming `[method]token.<name>` that
+                        // takes `self: own<token>`, or a call into the resource's
+                        // drop. For now the body is compiled (above) but the
+                        // function is not exported.
+                        Some(FunctionExport::TokenBurn) => {}
+                        // Plain helper functions are compiled but not exported,
+                        // matching `utxo` non-`main` functions.
+                        _ => {}
+                    }
+                }
+                TypedTokenPart::AbiImpl {
+                    span: _,
+                    abi,
+                    parts,
+                } => {
+                    _ = abi; // TODO: generate cast functions (mirrors `utxo`)
+                    for function in parts {
+                        // Compile (and storage/type-check) the body so it is
+                        // validated, but do NOT export it yet.
+                        //
+                        // TODO(token-impl-export): `impl Token`'s `attach`/`detach`
+                        // take a `Utxo` parameter, i.e. they reference a *foreign*
+                        // resource from inside the token interface. The current
+                        // resource-index model (raw indices shared with
+                        // `world_type`) conflates that `Utxo` borrow with the
+                        // token's own resource, so the emitted WIT would be wrong
+                        // (`borrow<token>` instead of `borrow<utxo>`). Exporting
+                        // these methods needs proper cross-resource index handling
+                        // in the component encoder. Until then they are compiled
+                        // but unexported.
+                        let _core = self.visit_function(
+                            Some(&token.ty),
+                            function,
+                            &(&() as &dyn Locals, &token_storage),
+                        );
+                    }
+                }
+            }
+        }
+
+        // Generate storage exports. Unlike `utxo`, tokens have no yield global
+        // to fold into storage.
+        let end_global = self.globals.len();
+        self.generate_storage_exports(
+            &token.name,
+            &token.ty,
+            &mut iface,
+            &interface_name,
+            start_global..end_global,
+        );
+
+        self.exported_interfaces.insert(interface_name, iface);
+        self.current_resource = None;
     }
 
     fn generate_resume_fn(&mut self, range: Range<i32>) -> Vec<u8> {
@@ -1858,7 +2012,7 @@ impl Compiler {
                     func.cfg.fill(
                         *bb,
                         Out::ReturnCall {
-                            func: self.current_utxo.as_ref().unwrap().resume_fn,
+                            func: self.current_resource.as_ref().unwrap().resume_fn,
                         },
                     );
                     *bb = usize::MAX;

--- a/starstream-to-wasm/tests/inputs/token_mint.star
+++ b/starstream-to-wasm/tests/inputs/token_mint.star
@@ -1,0 +1,12 @@
+token MyToken {
+    storage {
+        indexed let mut supply: u32;
+    }
+    mint fn mint() {
+        supply = 1;
+    }
+    impl Token {
+        fn attach(to: Utxo) { }
+        fn detach(source: Utxo) { }
+    }
+}

--- a/starstream-to-wasm/tests/inputs/token_mint_burn.star
+++ b/starstream-to-wasm/tests/inputs/token_mint_burn.star
@@ -1,0 +1,15 @@
+token MyToken {
+    storage {
+        let mut total: u64;
+    }
+    mint fn mint() {
+        total = total + 1;
+    }
+    burn fn burn() {
+        total = total - 1;
+    }
+    impl Token {
+        fn attach(to: Utxo) { }
+        fn detach(source: Utxo) { }
+    }
+}

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
@@ -1,0 +1,407 @@
+---
+source: starstream-to-wasm/tests/snapshots.rs
+input_file: starstream-to-wasm/tests/inputs/token_mint.star
+---
+==== AST ====
+Program {
+    shebang: None,
+    definitions: [
+        Spanned {
+            node: Token(
+                TokenDef {
+                    name: Identifier {
+                        name: "MyToken",
+                        span: 6..13,
+                    },
+                    parts: [
+                        Storage(
+                            [
+                                TokenGlobal {
+                                    indexed: true,
+                                    name: Identifier {
+                                        name: "supply",
+                                        span: 54..60,
+                                    },
+                                    ty: TypeAnnotation {
+                                        name: Identifier {
+                                            name: "u32",
+                                            span: 62..65,
+                                        },
+                                        generics: [],
+                                    },
+                                },
+                            ],
+                        ),
+                        Function(
+                            FunctionDef {
+                                export: Some(
+                                    TokenMint,
+                                ),
+                                name: Identifier {
+                                    name: "mint",
+                                    span: 85..89,
+                                },
+                                params: [],
+                                return_type: None,
+                                body: Block {
+                                    statements: [
+                                        Spanned {
+                                            node: Assignment {
+                                                target: Identifier {
+                                                    name: "supply",
+                                                    span: 102..108,
+                                                },
+                                                value: Spanned {
+                                                    node: Literal(
+                                                        Integer(
+                                                            1,
+                                                        ),
+                                                    ),
+                                                    span: 111..112,
+                                                },
+                                            },
+                                            span: 102..118,
+                                        },
+                                    ],
+                                    tail_expression: None,
+                                    span: 92..124,
+                                },
+                            },
+                        ),
+                        AbiImpl {
+                            abi: Identifier {
+                                name: "Token",
+                                span: 129..134,
+                            },
+                            parts: [
+                                FunctionDef {
+                                    export: None,
+                                    name: Identifier {
+                                        name: "attach",
+                                        span: 148..154,
+                                    },
+                                    params: [
+                                        FunctionParam {
+                                            public: false,
+                                            name: Identifier {
+                                                name: "to",
+                                                span: 155..157,
+                                            },
+                                            ty: TypeAnnotation {
+                                                name: Identifier {
+                                                    name: "Utxo",
+                                                    span: 159..163,
+                                                },
+                                                generics: [],
+                                            },
+                                        },
+                                    ],
+                                    return_type: None,
+                                    body: Block {
+                                        statements: [],
+                                        tail_expression: None,
+                                        span: 165..177,
+                                    },
+                                },
+                                FunctionDef {
+                                    export: None,
+                                    name: Identifier {
+                                        name: "detach",
+                                        span: 180..186,
+                                    },
+                                    params: [
+                                        FunctionParam {
+                                            public: false,
+                                            name: Identifier {
+                                                name: "source",
+                                                span: 187..193,
+                                            },
+                                            ty: TypeAnnotation {
+                                                name: Identifier {
+                                                    name: "Utxo",
+                                                    span: 195..199,
+                                                },
+                                                generics: [],
+                                            },
+                                        },
+                                    ],
+                                    return_type: None,
+                                    body: Block {
+                                        statements: [],
+                                        tail_expression: None,
+                                        span: 201..209,
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ),
+            span: 0..213,
+        },
+    ],
+}
+
+==== Inference trace ====
+T-Token: MyToken => 
+  T-Fn: mint => ()
+    T-Assign: {mint: fn() -> (), supply: u32} ⊢ supply = 1; ⇒ u32
+      T-Int: {mint: fn() -> (), supply: u32} ⊢ 1 ⇒ i64
+      Unify-Var: i64 ~ u32 => {u32/t3}
+  T-Fn: attach => ()
+  T-Fn: detach => ()
+
+==== Typed AST ====
+TypedProgram {
+    has_yields: false,
+    definitions: [
+        Token(
+            TypedTokenDef {
+                name: Identifier {
+                    name: "MyToken",
+                    span: 6..13,
+                },
+                parts: [
+                    Storage(
+                        [
+                            TypedTokenGlobal {
+                                indexed: true,
+                                name: Identifier {
+                                    name: "supply",
+                                    span: 54..60,
+                                },
+                                ty: Int(
+                                    U32,
+                                ),
+                            },
+                        ],
+                    ),
+                    Function(
+                        TypedFunctionDef {
+                            export: Some(
+                                TokenMint,
+                            ),
+                            name: Identifier {
+                                name: "mint",
+                                span: 85..89,
+                            },
+                            params: [],
+                            return_type: Unit,
+                            effect: Pure,
+                            body: TypedBlock {
+                                statements: [
+                                    Assignment {
+                                        target: Identifier {
+                                            name: "supply",
+                                            span: 102..108,
+                                        },
+                                        value: Spanned {
+                                            node: TypedExpr {
+                                                ty: Int(
+                                                    U32,
+                                                ),
+                                                kind: Literal(
+                                                    Integer(
+                                                        1,
+                                                    ),
+                                                ),
+                                            },
+                                            span: 111..112,
+                                        },
+                                    },
+                                ],
+                                tail_expression: None,
+                            },
+                        },
+                    ),
+                    AbiImpl {
+                        span: 129..134,
+                        abi: AbiNarrow(
+                            Abi {
+                                name: Identifier {
+                                    name: "Token",
+                                    span: 0..0,
+                                },
+                                methods: [
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "attach",
+                                            span: 0..0,
+                                        },
+                                        params: [
+                                            TypedFunctionParam {
+                                                public: false,
+                                                name: Identifier {
+                                                    name: "utxo",
+                                                    span: 0..0,
+                                                },
+                                                ty: UtxoAny,
+                                            },
+                                        ],
+                                        return_type: Unit,
+                                        span: 0..0,
+                                    },
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "detach",
+                                            span: 0..0,
+                                        },
+                                        params: [
+                                            TypedFunctionParam {
+                                                public: false,
+                                                name: Identifier {
+                                                    name: "utxo",
+                                                    span: 0..0,
+                                                },
+                                                ty: UtxoAny,
+                                            },
+                                        ],
+                                        return_type: Unit,
+                                        span: 0..0,
+                                    },
+                                ],
+                            },
+                        ),
+                        parts: [
+                            TypedFunctionDef {
+                                export: None,
+                                name: Identifier {
+                                    name: "attach",
+                                    span: 148..154,
+                                },
+                                params: [
+                                    TypedFunctionParam {
+                                        public: false,
+                                        name: Identifier {
+                                            name: "to",
+                                            span: 155..157,
+                                        },
+                                        ty: UtxoAny,
+                                    },
+                                ],
+                                return_type: Unit,
+                                effect: Pure,
+                                body: TypedBlock {
+                                    statements: [],
+                                    tail_expression: None,
+                                },
+                            },
+                            TypedFunctionDef {
+                                export: None,
+                                name: Identifier {
+                                    name: "detach",
+                                    span: 180..186,
+                                },
+                                params: [
+                                    TypedFunctionParam {
+                                        public: false,
+                                        name: Identifier {
+                                            name: "source",
+                                            span: 187..193,
+                                        },
+                                        ty: UtxoAny,
+                                    },
+                                ],
+                                return_type: Unit,
+                                effect: Pure,
+                                body: TypedBlock {
+                                    statements: [],
+                                    tail_expression: None,
+                                },
+                            },
+                        ],
+                    },
+                ],
+                ty: TokenNamed(
+                    "MyToken",
+                ),
+            },
+        ),
+    ],
+}
+
+==== Core WebAssembly ====
+(module
+  (type (;0;) (func (param i32) (result i32)))
+  (type (;1;) (func (param i32)))
+  (type (;2;) (func (result i32)))
+  (type (;3;) (func (param i32 i32)))
+  (import "[export]my-token" "[resource-new]token" (func (;0;) (type 0)))
+  (import "[export]my-token" "[resource-drop]token" (func (;1;) (type 1)))
+  (global (;0;) (mut i32) (i32.const 0))
+  (export "my-token#[static]token.mint" (func 2))
+  (export "my-token#get-storage" (func 5))
+  (export "my-token#set-storage" (func 6))
+  (func (;2;) (type 2) (result i32)
+    (local i32)
+    (local.set 0
+      (call 0
+        (i32.const 0)))
+    (global.set 0
+      (i32.const 1))
+    (local.get 0)
+  )
+  (func (;3;) (type 3) (param i32 i32))
+  (func (;4;) (type 3) (param i32 i32))
+  (func (;5;) (type 0) (param i32) (result i32)
+    (local i32)
+    (global.get 0)
+  )
+  (func (;6;) (type 0) (param i32) (result i32)
+    (local i32)
+    (global.set 0
+      (local.get 0))
+    (return_call 0
+      (i32.const 0))
+  )
+  (@custom "component-type"
+    (component
+      (@custom "wit-component-encoding" "\04\00")
+      (type (;0;)
+        (component
+          (type (;0;)
+            (component
+              (type (;0;)
+                (instance
+                  (export (;0;) "token" (type (sub resource)))
+                  (type (;1;) (own 0))
+                  (type (;2;) (func (result 1)))
+                  (export (;0;) "[static]token.mint" (func (type 2)))
+                  (type (;3;) (record (field "supply" s32)))
+                  (export (;4;) "storage" (type (eq 3)))
+                  (type (;5;) (borrow 0))
+                  (type (;6;) (func (param "self" 5) (result 4)))
+                  (export (;1;) "get-storage" (func (type 6)))
+                  (type (;7;) (func (param "storage" 4) (result 1)))
+                  (export (;2;) "set-storage" (func (type 7)))
+                )
+              )
+              (export (;0;) "my-token" (instance (type 0)))
+            )
+          )
+          (export (;0;) "my-namespace:my-package/my-world" (component (type 0)))
+        )
+      )
+      (export (;1;) "x" (type 0))
+    )
+  )
+)
+
+==== WIT ====
+package root:component;
+
+world root {
+  export my-token: interface {
+    resource token {
+      mint: static func() -> token;
+    }
+
+    record storage {
+      supply: s32,
+    }
+
+    get-storage: func(self: borrow<token>) -> storage;
+
+    set-storage: func(storage: storage) -> token;
+  }
+}

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
@@ -330,6 +330,8 @@ TypedProgram {
   (import "[export]my-token" "[resource-drop]token" (func (;1;) (type 1)))
   (global (;0;) (mut i32) (i32.const 0))
   (export "my-token#[static]token.mint" (func 2))
+  (export "my-token#[method]token.attach" (func 3))
+  (export "my-token#[method]token.detach" (func 4))
   (export "my-token#get-storage" (func 5))
   (export "my-token#set-storage" (func 6))
   (func (;2;) (type 2) (result i32)
@@ -361,22 +363,27 @@ TypedProgram {
         (component
           (type (;0;)
             (component
-              (type (;0;)
+              (import "utxo" (type (;0;) (sub resource)))
+              (type (;1;)
                 (instance
                   (export (;0;) "token" (type (sub resource)))
                   (type (;1;) (own 0))
                   (type (;2;) (func (result 1)))
                   (export (;0;) "[static]token.mint" (func (type 2)))
-                  (type (;3;) (record (field "supply" s32)))
-                  (export (;4;) "storage" (type (eq 3)))
-                  (type (;5;) (borrow 0))
-                  (type (;6;) (func (param "self" 5) (result 4)))
-                  (export (;1;) "get-storage" (func (type 6)))
-                  (type (;7;) (func (param "storage" 4) (result 1)))
-                  (export (;2;) "set-storage" (func (type 7)))
+                  (type (;3;) (borrow 0))
+                  (type (;4;) (func (param "self" 3) (param "to" 3)))
+                  (export (;1;) "[method]token.attach" (func (type 4)))
+                  (type (;5;) (func (param "self" 3) (param "source" 3)))
+                  (export (;2;) "[method]token.detach" (func (type 5)))
+                  (type (;6;) (record (field "supply" s32)))
+                  (export (;7;) "storage" (type (eq 6)))
+                  (type (;8;) (func (param "self" 3) (result 7)))
+                  (export (;3;) "get-storage" (func (type 8)))
+                  (type (;9;) (func (param "storage" 7) (result 1)))
+                  (export (;4;) "set-storage" (func (type 9)))
                 )
               )
-              (export (;0;) "my-token" (instance (type 0)))
+              (export (;0;) "my-token" (instance (type 1)))
             )
           )
           (export (;0;) "my-namespace:my-package/my-world" (component (type 0)))
@@ -391,9 +398,13 @@ TypedProgram {
 package root:component;
 
 world root {
+  resource utxo;
+
   export my-token: interface {
     resource token {
       mint: static func() -> token;
+      attach: func(to: borrow<token>);
+      detach: func(source: borrow<token>);
     }
 
     record storage {

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
@@ -499,6 +499,8 @@ TypedProgram {
   (global (;0;) (mut i64) (i64.const 0))
   (export "my-token#[static]token.mint" (func 3))
   (export "my-token#[static]token.burn" (func 5))
+  (export "my-token#[method]token.attach" (func 6))
+  (export "my-token#[method]token.detach" (func 7))
   (export "my-token#get-storage" (func 8))
   (export "my-token#set-storage" (func 9))
   (func (;2;) (type 2) (param i64 i64) (result i64)
@@ -584,7 +586,8 @@ TypedProgram {
         (component
           (type (;0;)
             (component
-              (type (;0;)
+              (import "utxo" (type (;0;) (sub resource)))
+              (type (;1;)
                 (instance
                   (export (;0;) "token" (type (sub resource)))
                   (type (;1;) (own 0))
@@ -592,16 +595,20 @@ TypedProgram {
                   (export (;0;) "[static]token.mint" (func (type 2)))
                   (type (;3;) (func))
                   (export (;1;) "[static]token.burn" (func (type 3)))
-                  (type (;4;) (record (field "total" s64)))
-                  (export (;5;) "storage" (type (eq 4)))
-                  (type (;6;) (borrow 0))
-                  (type (;7;) (func (param "self" 6) (result 5)))
-                  (export (;2;) "get-storage" (func (type 7)))
-                  (type (;8;) (func (param "storage" 5) (result 1)))
-                  (export (;3;) "set-storage" (func (type 8)))
+                  (type (;4;) (borrow 0))
+                  (type (;5;) (func (param "self" 4) (param "to" 4)))
+                  (export (;2;) "[method]token.attach" (func (type 5)))
+                  (type (;6;) (func (param "self" 4) (param "source" 4)))
+                  (export (;3;) "[method]token.detach" (func (type 6)))
+                  (type (;7;) (record (field "total" s64)))
+                  (export (;8;) "storage" (type (eq 7)))
+                  (type (;9;) (func (param "self" 4) (result 8)))
+                  (export (;4;) "get-storage" (func (type 9)))
+                  (type (;10;) (func (param "storage" 8) (result 1)))
+                  (export (;5;) "set-storage" (func (type 10)))
                 )
               )
-              (export (;0;) "my-token" (instance (type 0)))
+              (export (;0;) "my-token" (instance (type 1)))
             )
           )
           (export (;0;) "my-namespace:my-package/my-world" (component (type 0)))
@@ -616,10 +623,14 @@ TypedProgram {
 package root:component;
 
 world root {
+  resource utxo;
+
   export my-token: interface {
     resource token {
       mint: static func() -> token;
       burn: static func();
+      attach: func(to: borrow<token>);
+      detach: func(source: borrow<token>);
     }
 
     record storage {

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
@@ -1,0 +1,629 @@
+---
+source: starstream-to-wasm/tests/snapshots.rs
+input_file: starstream-to-wasm/tests/inputs/token_mint_burn.star
+---
+==== AST ====
+Program {
+    shebang: None,
+    definitions: [
+        Spanned {
+            node: Token(
+                TokenDef {
+                    name: Identifier {
+                        name: "MyToken",
+                        span: 6..13,
+                    },
+                    parts: [
+                        Storage(
+                            [
+                                TokenGlobal {
+                                    indexed: false,
+                                    name: Identifier {
+                                        name: "total",
+                                        span: 46..51,
+                                    },
+                                    ty: TypeAnnotation {
+                                        name: Identifier {
+                                            name: "u64",
+                                            span: 53..56,
+                                        },
+                                        generics: [],
+                                    },
+                                },
+                            ],
+                        ),
+                        Function(
+                            FunctionDef {
+                                export: Some(
+                                    TokenMint,
+                                ),
+                                name: Identifier {
+                                    name: "mint",
+                                    span: 76..80,
+                                },
+                                params: [],
+                                return_type: None,
+                                body: Block {
+                                    statements: [
+                                        Spanned {
+                                            node: Assignment {
+                                                target: Identifier {
+                                                    name: "total",
+                                                    span: 93..98,
+                                                },
+                                                value: Spanned {
+                                                    node: Binary {
+                                                        op: Add,
+                                                        left: Spanned {
+                                                            node: Identifier(
+                                                                Identifier {
+                                                                    name: "total",
+                                                                    span: 101..106,
+                                                                },
+                                                            ),
+                                                            span: 101..107,
+                                                        },
+                                                        right: Spanned {
+                                                            node: Literal(
+                                                                Integer(
+                                                                    1,
+                                                                ),
+                                                            ),
+                                                            span: 109..110,
+                                                        },
+                                                    },
+                                                    span: 101..110,
+                                                },
+                                            },
+                                            span: 93..116,
+                                        },
+                                    ],
+                                    tail_expression: None,
+                                    span: 83..122,
+                                },
+                            },
+                        ),
+                        Function(
+                            FunctionDef {
+                                export: Some(
+                                    TokenBurn,
+                                ),
+                                name: Identifier {
+                                    name: "burn",
+                                    span: 130..134,
+                                },
+                                params: [],
+                                return_type: None,
+                                body: Block {
+                                    statements: [
+                                        Spanned {
+                                            node: Assignment {
+                                                target: Identifier {
+                                                    name: "total",
+                                                    span: 147..152,
+                                                },
+                                                value: Spanned {
+                                                    node: Binary {
+                                                        op: Subtract,
+                                                        left: Spanned {
+                                                            node: Identifier(
+                                                                Identifier {
+                                                                    name: "total",
+                                                                    span: 155..160,
+                                                                },
+                                                            ),
+                                                            span: 155..161,
+                                                        },
+                                                        right: Spanned {
+                                                            node: Literal(
+                                                                Integer(
+                                                                    1,
+                                                                ),
+                                                            ),
+                                                            span: 163..164,
+                                                        },
+                                                    },
+                                                    span: 155..164,
+                                                },
+                                            },
+                                            span: 147..170,
+                                        },
+                                    ],
+                                    tail_expression: None,
+                                    span: 137..176,
+                                },
+                            },
+                        ),
+                        AbiImpl {
+                            abi: Identifier {
+                                name: "Token",
+                                span: 181..186,
+                            },
+                            parts: [
+                                FunctionDef {
+                                    export: None,
+                                    name: Identifier {
+                                        name: "attach",
+                                        span: 200..206,
+                                    },
+                                    params: [
+                                        FunctionParam {
+                                            public: false,
+                                            name: Identifier {
+                                                name: "to",
+                                                span: 207..209,
+                                            },
+                                            ty: TypeAnnotation {
+                                                name: Identifier {
+                                                    name: "Utxo",
+                                                    span: 211..215,
+                                                },
+                                                generics: [],
+                                            },
+                                        },
+                                    ],
+                                    return_type: None,
+                                    body: Block {
+                                        statements: [],
+                                        tail_expression: None,
+                                        span: 217..229,
+                                    },
+                                },
+                                FunctionDef {
+                                    export: None,
+                                    name: Identifier {
+                                        name: "detach",
+                                        span: 232..238,
+                                    },
+                                    params: [
+                                        FunctionParam {
+                                            public: false,
+                                            name: Identifier {
+                                                name: "source",
+                                                span: 239..245,
+                                            },
+                                            ty: TypeAnnotation {
+                                                name: Identifier {
+                                                    name: "Utxo",
+                                                    span: 247..251,
+                                                },
+                                                generics: [],
+                                            },
+                                        },
+                                    ],
+                                    return_type: None,
+                                    body: Block {
+                                        statements: [],
+                                        tail_expression: None,
+                                        span: 253..261,
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ),
+            span: 0..265,
+        },
+    ],
+}
+
+==== Inference trace ====
+T-Token: MyToken => 
+  T-Fn: mint => ()
+    T-Assign: {mint: fn() -> (), total: u64} ⊢ total = total + 1; ⇒ u64
+      T-Bin-Add: {mint: fn() -> (), total: u64} ⊢ total + 1 ⇒ u64
+        T-Var: {mint: fn() -> (), total: u64} ⊢ total ⇒ u64
+        T-Int: {mint: fn() -> (), total: u64} ⊢ 1 ⇒ i64
+        Unify-Var: u64 ~ i64 => {u64/t3}
+      Unify-Const: u64 ~ u64 => {}
+  T-Fn: burn => ()
+    T-Assign: {burn: fn() -> (), mint: fn() -> (), total: u64} ⊢ total = total - 1; ⇒ u64
+      T-Bin-Sub: {burn: fn() -> (), mint: fn() -> (), total: u64} ⊢ total - 1 ⇒ u64
+        T-Var: {burn: fn() -> (), mint: fn() -> (), total: u64} ⊢ total ⇒ u64
+        T-Int: {burn: fn() -> (), mint: fn() -> (), total: u64} ⊢ 1 ⇒ i64
+        Unify-Var: u64 ~ i64 => {u64/t4}
+      Unify-Const: u64 ~ u64 => {}
+  T-Fn: attach => ()
+  T-Fn: detach => ()
+
+==== Typed AST ====
+TypedProgram {
+    has_yields: false,
+    definitions: [
+        Token(
+            TypedTokenDef {
+                name: Identifier {
+                    name: "MyToken",
+                    span: 6..13,
+                },
+                parts: [
+                    Storage(
+                        [
+                            TypedTokenGlobal {
+                                indexed: false,
+                                name: Identifier {
+                                    name: "total",
+                                    span: 46..51,
+                                },
+                                ty: Int(
+                                    U64,
+                                ),
+                            },
+                        ],
+                    ),
+                    Function(
+                        TypedFunctionDef {
+                            export: Some(
+                                TokenMint,
+                            ),
+                            name: Identifier {
+                                name: "mint",
+                                span: 76..80,
+                            },
+                            params: [],
+                            return_type: Unit,
+                            effect: Pure,
+                            body: TypedBlock {
+                                statements: [
+                                    Assignment {
+                                        target: Identifier {
+                                            name: "total",
+                                            span: 93..98,
+                                        },
+                                        value: Spanned {
+                                            node: TypedExpr {
+                                                ty: Int(
+                                                    U64,
+                                                ),
+                                                kind: Binary {
+                                                    op: Add,
+                                                    left: Spanned {
+                                                        node: TypedExpr {
+                                                            ty: Int(
+                                                                U64,
+                                                            ),
+                                                            kind: Identifier(
+                                                                Identifier {
+                                                                    name: "total",
+                                                                    span: 101..106,
+                                                                },
+                                                            ),
+                                                        },
+                                                        span: 101..107,
+                                                    },
+                                                    right: Spanned {
+                                                        node: TypedExpr {
+                                                            ty: Int(
+                                                                U64,
+                                                            ),
+                                                            kind: Literal(
+                                                                Integer(
+                                                                    1,
+                                                                ),
+                                                            ),
+                                                        },
+                                                        span: 109..110,
+                                                    },
+                                                },
+                                            },
+                                            span: 101..110,
+                                        },
+                                    },
+                                ],
+                                tail_expression: None,
+                            },
+                        },
+                    ),
+                    Function(
+                        TypedFunctionDef {
+                            export: Some(
+                                TokenBurn,
+                            ),
+                            name: Identifier {
+                                name: "burn",
+                                span: 130..134,
+                            },
+                            params: [],
+                            return_type: Unit,
+                            effect: Pure,
+                            body: TypedBlock {
+                                statements: [
+                                    Assignment {
+                                        target: Identifier {
+                                            name: "total",
+                                            span: 147..152,
+                                        },
+                                        value: Spanned {
+                                            node: TypedExpr {
+                                                ty: Int(
+                                                    U64,
+                                                ),
+                                                kind: Binary {
+                                                    op: Subtract,
+                                                    left: Spanned {
+                                                        node: TypedExpr {
+                                                            ty: Int(
+                                                                U64,
+                                                            ),
+                                                            kind: Identifier(
+                                                                Identifier {
+                                                                    name: "total",
+                                                                    span: 155..160,
+                                                                },
+                                                            ),
+                                                        },
+                                                        span: 155..161,
+                                                    },
+                                                    right: Spanned {
+                                                        node: TypedExpr {
+                                                            ty: Int(
+                                                                U64,
+                                                            ),
+                                                            kind: Literal(
+                                                                Integer(
+                                                                    1,
+                                                                ),
+                                                            ),
+                                                        },
+                                                        span: 163..164,
+                                                    },
+                                                },
+                                            },
+                                            span: 155..164,
+                                        },
+                                    },
+                                ],
+                                tail_expression: None,
+                            },
+                        },
+                    ),
+                    AbiImpl {
+                        span: 181..186,
+                        abi: AbiNarrow(
+                            Abi {
+                                name: Identifier {
+                                    name: "Token",
+                                    span: 0..0,
+                                },
+                                methods: [
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "attach",
+                                            span: 0..0,
+                                        },
+                                        params: [
+                                            TypedFunctionParam {
+                                                public: false,
+                                                name: Identifier {
+                                                    name: "utxo",
+                                                    span: 0..0,
+                                                },
+                                                ty: UtxoAny,
+                                            },
+                                        ],
+                                        return_type: Unit,
+                                        span: 0..0,
+                                    },
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "detach",
+                                            span: 0..0,
+                                        },
+                                        params: [
+                                            TypedFunctionParam {
+                                                public: false,
+                                                name: Identifier {
+                                                    name: "utxo",
+                                                    span: 0..0,
+                                                },
+                                                ty: UtxoAny,
+                                            },
+                                        ],
+                                        return_type: Unit,
+                                        span: 0..0,
+                                    },
+                                ],
+                            },
+                        ),
+                        parts: [
+                            TypedFunctionDef {
+                                export: None,
+                                name: Identifier {
+                                    name: "attach",
+                                    span: 200..206,
+                                },
+                                params: [
+                                    TypedFunctionParam {
+                                        public: false,
+                                        name: Identifier {
+                                            name: "to",
+                                            span: 207..209,
+                                        },
+                                        ty: UtxoAny,
+                                    },
+                                ],
+                                return_type: Unit,
+                                effect: Pure,
+                                body: TypedBlock {
+                                    statements: [],
+                                    tail_expression: None,
+                                },
+                            },
+                            TypedFunctionDef {
+                                export: None,
+                                name: Identifier {
+                                    name: "detach",
+                                    span: 232..238,
+                                },
+                                params: [
+                                    TypedFunctionParam {
+                                        public: false,
+                                        name: Identifier {
+                                            name: "source",
+                                            span: 239..245,
+                                        },
+                                        ty: UtxoAny,
+                                    },
+                                ],
+                                return_type: Unit,
+                                effect: Pure,
+                                body: TypedBlock {
+                                    statements: [],
+                                    tail_expression: None,
+                                },
+                            },
+                        ],
+                    },
+                ],
+                ty: TokenNamed(
+                    "MyToken",
+                ),
+            },
+        ),
+    ],
+}
+
+==== Core WebAssembly ====
+(module
+  (type (;0;) (func (param i32) (result i32)))
+  (type (;1;) (func (param i32)))
+  (type (;2;) (func (param i64 i64) (result i64)))
+  (type (;3;) (func (result i32)))
+  (type (;4;) (func))
+  (type (;5;) (func (param i32 i32)))
+  (type (;6;) (func (param i32) (result i64)))
+  (type (;7;) (func (param i64) (result i32)))
+  (import "[export]my-token" "[resource-new]token" (func (;0;) (type 0)))
+  (import "[export]my-token" "[resource-drop]token" (func (;1;) (type 1)))
+  (global (;0;) (mut i64) (i64.const 0))
+  (export "my-token#[static]token.mint" (func 3))
+  (export "my-token#get-storage" (func 8))
+  (export "my-token#set-storage" (func 9))
+  (func (;2;) (type 2) (param i64 i64) (result i64)
+    (local i64)
+    (local.tee 2
+      (i64.add
+        (local.get 0)
+        (local.get 1)))
+    (if ;; label = @1
+      (i32.ne
+        (i32.and
+          (i64.ge_s
+            (i64.xor
+              (local.get 0)
+              (local.get 1))
+            (i64.const 0))
+          (i64.lt_s
+            (i64.xor
+              (local.get 2)
+              (local.get 0))
+            (i64.const 0)))
+        (i32.const 0))
+      (then
+        (unreachable)))
+  )
+  (func (;3;) (type 3) (result i32)
+    (local i32)
+    (local.set 0
+      (call 0
+        (i32.const 0)))
+    (global.set 0
+      (call 2
+        (global.get 0)
+        (i64.const 1)))
+    (local.get 0)
+  )
+  (func (;4;) (type 2) (param i64 i64) (result i64)
+    (local i64)
+    (local.tee 2
+      (i64.sub
+        (local.get 0)
+        (local.get 1)))
+    (if ;; label = @1
+      (i32.ne
+        (i32.and
+          (i64.lt_s
+            (i64.xor
+              (local.get 0)
+              (local.get 1))
+            (i64.const 0))
+          (i64.lt_s
+            (i64.xor
+              (local.get 2)
+              (local.get 0))
+            (i64.const 0)))
+        (i32.const 0))
+      (then
+        (unreachable)))
+  )
+  (func (;5;) (type 4)
+    (global.set 0
+      (call 4
+        (global.get 0)
+        (i64.const 1)))
+  )
+  (func (;6;) (type 5) (param i32 i32))
+  (func (;7;) (type 5) (param i32 i32))
+  (func (;8;) (type 6) (param i32) (result i64)
+    (local i32)
+    (global.get 0)
+  )
+  (func (;9;) (type 7) (param i64) (result i32)
+    (local i64)
+    (global.set 0
+      (local.get 0))
+    (return_call 0
+      (i32.const 0))
+  )
+  (@custom "component-type"
+    (component
+      (@custom "wit-component-encoding" "\04\00")
+      (type (;0;)
+        (component
+          (type (;0;)
+            (component
+              (type (;0;)
+                (instance
+                  (export (;0;) "token" (type (sub resource)))
+                  (type (;1;) (own 0))
+                  (type (;2;) (func (result 1)))
+                  (export (;0;) "[static]token.mint" (func (type 2)))
+                  (type (;3;) (record (field "total" s64)))
+                  (export (;4;) "storage" (type (eq 3)))
+                  (type (;5;) (borrow 0))
+                  (type (;6;) (func (param "self" 5) (result 4)))
+                  (export (;1;) "get-storage" (func (type 6)))
+                  (type (;7;) (func (param "storage" 4) (result 1)))
+                  (export (;2;) "set-storage" (func (type 7)))
+                )
+              )
+              (export (;0;) "my-token" (instance (type 0)))
+            )
+          )
+          (export (;0;) "my-namespace:my-package/my-world" (component (type 0)))
+        )
+      )
+      (export (;1;) "x" (type 0))
+    )
+  )
+)
+
+==== WIT ====
+package root:component;
+
+world root {
+  export my-token: interface {
+    resource token {
+      mint: static func() -> token;
+    }
+
+    record storage {
+      total: s64,
+    }
+
+    get-storage: func(self: borrow<token>) -> storage;
+
+    set-storage: func(storage: storage) -> token;
+  }
+}

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
@@ -498,6 +498,7 @@ TypedProgram {
   (import "[export]my-token" "[resource-drop]token" (func (;1;) (type 1)))
   (global (;0;) (mut i64) (i64.const 0))
   (export "my-token#[static]token.mint" (func 3))
+  (export "my-token#[static]token.burn" (func 5))
   (export "my-token#get-storage" (func 8))
   (export "my-token#set-storage" (func 9))
   (func (;2;) (type 2) (param i64 i64) (result i64)
@@ -589,13 +590,15 @@ TypedProgram {
                   (type (;1;) (own 0))
                   (type (;2;) (func (result 1)))
                   (export (;0;) "[static]token.mint" (func (type 2)))
-                  (type (;3;) (record (field "total" s64)))
-                  (export (;4;) "storage" (type (eq 3)))
-                  (type (;5;) (borrow 0))
-                  (type (;6;) (func (param "self" 5) (result 4)))
-                  (export (;1;) "get-storage" (func (type 6)))
-                  (type (;7;) (func (param "storage" 4) (result 1)))
-                  (export (;2;) "set-storage" (func (type 7)))
+                  (type (;3;) (func))
+                  (export (;1;) "[static]token.burn" (func (type 3)))
+                  (type (;4;) (record (field "total" s64)))
+                  (export (;5;) "storage" (type (eq 4)))
+                  (type (;6;) (borrow 0))
+                  (type (;7;) (func (param "self" 6) (result 5)))
+                  (export (;2;) "get-storage" (func (type 7)))
+                  (type (;8;) (func (param "storage" 5) (result 1)))
+                  (export (;3;) "set-storage" (func (type 8)))
                 )
               )
               (export (;0;) "my-token" (instance (type 0)))
@@ -616,6 +619,7 @@ world root {
   export my-token: interface {
     resource token {
       mint: static func() -> token;
+      burn: static func();
     }
 
     record storage {


### PR DESCRIPTION
Replaces the token codegen stub in `starstream-to-wasm` with real Component-Model output, mirroring the existing `utxo` codegen. For a `token MyToken { ... }` it now emits:

```wit
export my-token: interface {
  resource token {
    mint: static func() -> token;
  }
  record storage { supply: s32, ... }
  get-storage: func(self: borrow<token>) -> storage;
  set-storage: func(storage: storage) -> token;
}
```

## What's emitted

- **`mint`** is compiled as a constructor: it spawns a fresh token resource at entry (reusing the `UtxoMain` spawn path in `visit_function`) and returns an owned token handle, exported as `[static]token.<name>`. Multiple mints → multiple static constructors.
- **Storage** → mutable wasm globals plus the `storage` record and `get-storage`/`set-storage` exports, identical to utxos.
- **`burn`, `impl Token` `attach`/`detach`, and plain helpers** are compiled and validated (real core functions, storage-checked) but **not exported** yet — see TODOs.

## Supporting changes

- Generalized the resource machinery: `UtxoContext`/`current_utxo` → `ResourceContext`/`current_resource`, and `generate_storage_exports` now takes `(name, ty)` so tokens and utxos share it (pure refactor).
- Lowered `Type::TokenAny`/`Type::TokenNamed` to an i32 core handle — `star_to_core_types` has a `_ => Err` fallthrough that previously missed them (compiled, but errored on a method's `self` param).

## TODOs left (deliberately deferred)

- **`TODO(token-burn)`** — the WIT shape of `burn` is undecided (consuming `[method]token.burn(self: own<token>)` vs a resource-drop). Body compiled, not exported.
- **`TODO(token-impl-export)`** — `attach`/`detach` take a `Utxo`, i.e. a *foreign* resource referenced from inside the token interface. The current resource-index model (raw indices shared with `world_type`) conflates that borrow with the token's own resource, so exporting them produced wrong WIT (`borrow<token>` instead of `borrow<utxo>`). Correctly emitting cross-resource references needs encoder index-space work; compiled-but-unexported until then.
- **`indexed`** storage is carried inert (per team decision to handle later).
- **Runtime** (`starstream-runtime-next`) has no token support; out of scope.