### PR TITLE
Move event imports into `starstream:events` package

### DIFF
--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -282,7 +282,7 @@ fn score_sync() -> wasmtime::Result<()> {
         assert_eq!(
             events,
             [(
-                "score".into(),
+                "starstream:events/score".into(),
                 "finish".into(),
                 [Val::U64(i * i * 2)].into()
             )]

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -129,10 +129,7 @@ impl Default for CompileOptions {
 impl CompileOptions {
     #[must_use]
     pub fn compile(self, program: &TypedProgram) -> CompileResult {
-        let mut compiler = Compiler {
-            options: self,
-            ..Compiler::default()
-        };
+        let mut compiler = Compiler::new(self);
         compiler.visit_program(program);
         compiler.finish()
     }
@@ -143,10 +140,7 @@ impl CompileOptions {
         graph: &starstream_compiler::TypedModuleGraph,
         entry: starstream_compiler::ModuleId,
     ) -> CompileResult {
-        let mut compiler = Compiler {
-            options: self,
-            ..Compiler::default()
-        };
+        let mut compiler = Compiler::new(self);
 
         // Build a reachable-from-entry set by chasing edges through the typed
         // graph. We don't have the untyped graph's edges here, so we synthesize
@@ -261,6 +255,13 @@ struct UtxoContext {
 }
 
 impl Compiler {
+    fn new(options: CompileOptions) -> Compiler {
+        Compiler {
+            options,
+            ..Compiler::default()
+        }
+    }
+
     /// After [`Compiler::visit_program`], this function collates all the
     /// in-progress sections into an actual Wasm binary module.
     fn finish(mut self) -> CompileResult {

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -1429,7 +1429,8 @@ impl Compiler {
                         _ = self.star_to_core_types(span, &mut core_params, &p.ty);
                     }
 
-                    let interface = to_kebab_case(def.name.as_str());
+                    let interface =
+                        format!("starstream:events/{}", to_kebab_case(def.name.as_str()));
                     let kebab = to_kebab_case(event.name.as_str());
 
                     // Core import

--- a/starstream-to-wasm/tests/snapshots/inputs@events.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@events.star.snap
@@ -138,7 +138,7 @@ TypedProgram {
 ==== Core WebAssembly ====
 (module
   (type (;0;) (func))
-  (import "foo" "hello" (func (;0;) (type 0)))
+  (import "starstream:events/foo" "hello" (func (;0;) (type 0)))
   (export "main" (func 1))
   (func (;1;) (type 0)
     (call 0)
@@ -158,7 +158,7 @@ TypedProgram {
                   (export (;0;) "hello" (func (type 0)))
                 )
               )
-              (import "foo" (instance (;0;) (type 1)))
+              (import "starstream:events/foo" (instance (;0;) (type 1)))
             )
           )
           (export (;0;) "my-namespace:my-package/my-world" (component (type 0)))
@@ -173,9 +173,12 @@ TypedProgram {
 package root:component;
 
 world root {
-  import foo: interface {
-    hello: func();
-  }
+  import starstream:events/foo;
 
   export main: func();
+}
+package starstream:events {
+  interface foo {
+    hello: func();
+  }
 }

--- a/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
@@ -1186,7 +1186,7 @@ TypedProgram {
   (type (;8;) (func (param i32) (result i32 i64 i64 i32)))
   (type (;9;) (func (param i32 i64 i64 i32) (result i32)))
   (import "starstream:std/builtin" "implements-method" (func (;0;) (type 0)))
-  (import "score" "finish" (func (;1;) (type 1)))
+  (import "starstream:events/score" "finish" (func (;1;) (type 1)))
   (import "[export]score-progress" "[resource-new]utxo" (func (;2;) (type 2)))
   (import "[export]score-progress" "[resource-drop]utxo" (func (;3;) (type 3)))
   (memory (;0;) 1)
@@ -1396,7 +1396,7 @@ TypedProgram {
                   (export (;0;) "finish" (func (type 0)))
                 )
               )
-              (import "score" (instance (;0;) (type 0)))
+              (import "starstream:events/score" (instance (;0;) (type 0)))
               (type (;1;)
                 (instance
                   (type (;0;) (tuple u64 u64 u64 u64))
@@ -1443,9 +1443,7 @@ TypedProgram {
 package root:component;
 
 world root {
-  import score: interface {
-    finish: func(x: u64);
-  }
+  import starstream:events/score;
   import starstream:std/builtin;
 
   export score-progress: interface {
@@ -1469,6 +1467,13 @@ world root {
     set-storage: func(storage: storage) -> utxo;
   }
 }
+package starstream:events {
+  interface score {
+    finish: func(x: u64);
+  }
+}
+
+
 package starstream:std {
   interface builtin {
     implements-method: func(hash: tuple<u64, u64, u64, u64>);

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
@@ -252,7 +252,7 @@ TypedProgram {
   (type (;1;) (func (param i32) (result i32)))
   (type (;2;) (func (param i32)))
   (type (;3;) (func (result i32)))
-  (import "foo-abi" "hello-event" (func (;0;) (type 0)))
+  (import "starstream:events/foo-abi" "hello-event" (func (;0;) (type 0)))
   (import "[export]my-utxo" "[resource-new]utxo" (func (;1;) (type 1)))
   (import "[export]my-utxo" "[resource-drop]utxo" (func (;2;) (type 2)))
   (export "my-utxo#[static]utxo.hello-utxo" (func 5))
@@ -283,7 +283,7 @@ TypedProgram {
                   (export (;0;) "hello-event" (func (type 0)))
                 )
               )
-              (import "foo-abi" (instance (;0;) (type 0)))
+              (import "starstream:events/foo-abi" (instance (;0;) (type 0)))
               (type (;1;)
                 (instance
                   (export (;0;) "utxo" (type (sub resource)))
@@ -307,13 +307,16 @@ TypedProgram {
 package root:component;
 
 world root {
-  import foo-abi: interface {
-    hello-event: func();
-  }
+  import starstream:events/foo-abi;
 
   export my-utxo: interface {
     resource utxo {
       hello-utxo: static func() -> utxo;
     }
+  }
+}
+package starstream:events {
+  interface foo-abi {
+    hello-event: func();
   }
 }

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
@@ -165,7 +165,7 @@ TypedProgram {
   (type (;1;) (func (param i32) (result i32)))
   (type (;2;) (func (param i32)))
   (type (;3;) (func (result i32)))
-  (import "foo-abi" "hello-event" (func (;0;) (type 0)))
+  (import "starstream:events/foo-abi" "hello-event" (func (;0;) (type 0)))
   (import "[export]my-utxo" "[resource-new]utxo" (func (;1;) (type 1)))
   (import "[export]my-utxo" "[resource-drop]utxo" (func (;2;) (type 2)))
   (export "my-utxo#[static]utxo.hello-utxo" (func 4))
@@ -193,7 +193,7 @@ TypedProgram {
                   (export (;0;) "hello-event" (func (type 0)))
                 )
               )
-              (import "foo-abi" (instance (;0;) (type 0)))
+              (import "starstream:events/foo-abi" (instance (;0;) (type 0)))
               (type (;1;)
                 (instance
                   (export (;0;) "utxo" (type (sub resource)))
@@ -217,13 +217,16 @@ TypedProgram {
 package root:component;
 
 world root {
-  import foo-abi: interface {
-    hello-event: func();
-  }
+  import starstream:events/foo-abi;
 
   export my-utxo: interface {
     resource utxo {
       hello-utxo: static func() -> utxo;
     }
+  }
+}
+package starstream:events {
+  interface foo-abi {
+    hello-event: func();
   }
 }


### PR DESCRIPTION
Suggested by Roman. This makes it easier for the runtime to know how to fulfill these imports by looking at their package name.