### PR TITLE
Check parameter count in ABI impl blocks

### DIFF
--- a/starstream-compiler/src/typecheck/errors.rs
+++ b/starstream-compiler/src/typecheck/errors.rs
@@ -604,15 +604,11 @@ impl fmt::Display for TypeErrorKind {
                 )
             }
             TypeErrorKind::ArityMismatch { expected, found } => {
-                let args = if *expected == 1 {
-                    "argument"
-                } else {
-                    "arguments"
-                };
-
                 write!(
                     f,
-                    "function expects {expected} {args} but {found} were provided"
+                    "function expects {expected} argument{} but {found} {} provided",
+                    if *expected == 1 { "" } else { "s" },
+                    if *found == 1 { "was" } else { "were" },
                 )
             }
             TypeErrorKind::ArgumentTypeMismatch {
@@ -634,15 +630,11 @@ impl fmt::Display for TypeErrorKind {
                 expected,
                 found,
             } => {
-                let args = if *expected == 1 {
-                    "argument"
-                } else {
-                    "arguments"
-                };
-
                 write!(
                     f,
-                    "event `{event_name}` expects {expected} {args} but {found} were provided"
+                    "event `{event_name}` expects {expected} argument{} but {found} {} provided",
+                    if *expected == 1 { "" } else { "s" },
+                    if *found == 1 { "was" } else { "were" },
                 )
             }
             TypeErrorKind::EventArgumentTypeMismatch {
@@ -723,7 +715,9 @@ impl fmt::Display for TypeErrorKind {
             } => {
                 write!(
                     f,
-                    "type `{type_name}` expects {expected} generic argument(s) but {found} were provided"
+                    "type `{type_name}` expects {expected} generic argument{} but {found} {} provided",
+                    if *expected == 1 { "" } else { "s" },
+                    if *found == 1 { "was" } else { "were" },
                 )
             }
             TypeErrorKind::ReturnTypeNotAllowed => {

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -1936,7 +1936,38 @@ impl Inferencer {
 
         for impl_method in methods {
             if let Some(abi_method) = abi_methods.remove(impl_method.name.as_str()) {
-                // Method found, make sure parameters match
+                // Method found, make sure the parameter counts match
+                if abi_method.params.len() != impl_method.params.len() {
+                    return Err(TypeError::new(
+                        TypeErrorKind::ArityMismatch {
+                            expected: abi_method.params.len(),
+                            found: impl_method.params.len(),
+                        },
+                        impl_method.name.span(),
+                    )
+                    .with_primary_message(format!(
+                        "implemented with {} parameter{} here",
+                        impl_method.params.len(),
+                        if impl_method.params.len() == 1 {
+                            ""
+                        } else {
+                            "s"
+                        },
+                    ))
+                    .with_secondary(
+                        abi_method.name.span,
+                        format!(
+                            "declared with {} parameter{} here",
+                            abi_method.params.len(),
+                            if abi_method.params.len() == 1 {
+                                ""
+                            } else {
+                                "s"
+                            },
+                        ),
+                    ));
+                }
+                // And that the parameter types match
                 for (i, (abi_param, impl_param)) in abi_method
                     .params
                     .iter()

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__abi_impl_extra_params_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__abi_impl_extra_params_error.snap
@@ -1,0 +1,21 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\nabi MyAbi {\n    fn transfer(amount: i64);\n}\n\nutxo Foo {\n    main fn new() {\n        yield(MyAbi);\n    }\n\n    impl MyAbi {\n        fn transfer(amount: i64, extra: i64) {}\n    }\n}\n"
+---
+E0030 (https://starstream.nightstream.dev/errors/E0030)
+
+  x function expects 1 argument but 2 were provided
+   ,-[test.star:2:8]
+ 1 | abi MyAbi {
+ 2 |     fn transfer(amount: i64);
+   :        ^^^^|^^^
+   :            `-- declared with 1 parameter here
+ 3 | }
+   `----
+    ,-[test.star:11:12]
+ 10 |     impl MyAbi {
+ 11 |         fn transfer(amount: i64, extra: i64) {}
+    :            ^^^^|^^^
+    :                `-- implemented with 2 parameters here
+ 12 |     }
+    `----

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__abi_impl_fewer_params_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__abi_impl_fewer_params_error.snap
@@ -1,0 +1,21 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\nabi MyAbi {\n    fn transfer(amount: i64);\n}\n\nutxo Foo {\n    main fn new() {\n        yield(MyAbi);\n    }\n\n    impl MyAbi {\n        fn transfer() {}\n    }\n}\n"
+---
+E0030 (https://starstream.nightstream.dev/errors/E0030)
+
+  x function expects 1 argument but 0 were provided
+   ,-[test.star:2:8]
+ 1 | abi MyAbi {
+ 2 |     fn transfer(amount: i64);
+   :        ^^^^|^^^
+   :            `-- declared with 1 parameter here
+ 3 | }
+   `----
+    ,-[test.star:11:12]
+ 10 |     impl MyAbi {
+ 11 |         fn transfer() {}
+    :            ^^^^|^^^
+    :                `-- implemented with 0 parameters here
+ 12 |     }
+    `----

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__call_arity_mismatch_too_few_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__call_arity_mismatch_too_few_error.snap
@@ -4,7 +4,7 @@ description: "Source:\n\nfn add(a: i64, b: i64) -> i64 {\n    a + b\n}\n\nfn tes
 ---
 E0030 (https://starstream.nightstream.dev/errors/E0030)
 
-  x function expects 2 arguments but 1 were provided
+  x function expects 2 arguments but 1 was provided
    ,-[test.star:6:5]
  5 | fn test() {
  6 |     add(1);

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__emit_arity_mismatch_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__emit_arity_mismatch_error.snap
@@ -4,7 +4,7 @@ description: "Source:\n\nabi Events {\n    event Transfer(sender: i64, to: i64);
 ---
 E0030 (https://starstream.nightstream.dev/errors/E0030)
 
-  x function expects 2 arguments but 1 were provided
+  x function expects 2 arguments but 1 was provided
    ,-[test.star:6:5]
  5 | fn main() {
  6 |     emit Transfer(1);

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__option_missing_generic_args_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__option_missing_generic_args_error.snap
@@ -4,7 +4,7 @@ description: "Source:\n\nfn test() {\n    let x: Option = Option::Some(42);\n}\n
 ---
 E0042 (https://starstream.nightstream.dev/errors/E0042)
 
-  x type `Option` expects 1 generic argument(s) but 0 were provided
+  x type `Option` expects 1 generic argument but 0 were provided
    ,-[test.star:2:12]
  1 | fn test() {
  2 |     let x: Option = Option::Some(42);

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__option_wrong_arity.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__option_wrong_arity.snap
@@ -4,7 +4,7 @@ description: "Source:\n\nfn test() {\n    let x: Option<i64, bool> = Option::Som
 ---
 E0042 (https://starstream.nightstream.dev/errors/E0042)
 
-  x type `Option` expects 1 generic argument(s) but 2 were provided
+  x type `Option` expects 1 generic argument but 2 were provided
    ,-[test.star:2:12]
  1 | fn test() {
  2 |     let x: Option<i64, bool> = Option::Some(42);

--- a/starstream-compiler/src/typecheck/tests.rs
+++ b/starstream-compiler/src/typecheck/tests.rs
@@ -1668,3 +1668,47 @@ fn token_reserved_abi_name_error() {
         "#
     );
 }
+
+// ── impl <Abi> arity ─────────────────────────────────────────────────────────
+
+#[test]
+fn abi_impl_fewer_params_error() {
+    assert_typecheck_snapshot!(
+        r#"
+        abi MyAbi {
+            fn transfer(amount: i64);
+        }
+
+        utxo Foo {
+            main fn new() {
+                yield(MyAbi);
+            }
+
+            impl MyAbi {
+                fn transfer() {}
+            }
+        }
+        "#
+    );
+}
+
+#[test]
+fn abi_impl_extra_params_error() {
+    assert_typecheck_snapshot!(
+        r#"
+        abi MyAbi {
+            fn transfer(amount: i64);
+        }
+
+        utxo Foo {
+            main fn new() {
+                yield(MyAbi);
+            }
+
+            impl MyAbi {
+                fn transfer(amount: i64, extra: i64) {}
+            }
+        }
+        "#
+    );
+}

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi_err.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi_err.star.snap
@@ -209,6 +209,23 @@ Program {
     :          ^^^^^
  13 | }
     `----
+]8;;https://starstream.nightstream.dev/errors/E0030\E0030 (link)]8;;\
+
+  x function expects 0 arguments but 1 were provided
+   ,-[2:8]
+ 1 | abi MyAbi {
+ 2 |     fn hello();
+   :        ^^|^^
+   :          `-- declared with 0 parameters here
+ 3 | }
+   `----
+    ,-[17:12]
+ 16 |     impl MyAbi {
+ 17 |         fn hello(x: i32) { }
+    :            ^^|^^
+    :              `-- implemented with 1 parameter here
+ 18 |     }
+    `----
 ]8;;https://starstream.nightstream.dev/errors/E0009\E0009 (link)]8;;\
 
   x return type `i32` does not match function signature `()`

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi_err.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi_err.star.snap
@@ -211,7 +211,7 @@ Program {
     `----
 ]8;;https://starstream.nightstream.dev/errors/E0030\E0030 (link)]8;;\
 
-  x function expects 0 arguments but 1 were provided
+  x function expects 0 arguments but 1 was provided
    ,-[2:8]
  1 | abi MyAbi {
  2 |     fn hello();


### PR DESCRIPTION
`check_abi_impl` compared the parameters of an `impl <Abi>` method against the ABI declaration with `zip`, which silently truncates to the shorter list. As a result, an implementation with fewer or more parameters than the ABI declares passed type-checking:

```starstream
abi MyAbi {
    fn transfer(amount: i64);
}

utxo Foo {
    main fn new() {
        yield(MyAbi);
    }

    impl MyAbi {
        fn transfer() {} // compiled without complaint
    }
}
```

This adds an explicit parameter-count check before the per-parameter type comparison, reusing the existing `ArityMismatch` error (E0030) with labels pointing at both the implementation site and the ABI declaration:

```
E0030

  x function expects 1 argument but 0 were provided
   ,-[test.star:2:8]
 1 | abi MyAbi {
 2 |     fn transfer(amount: i64);
   :        ^^^^|^^^
   :            `-- declared with 1 parameter here
 3 | }
   `----
    ,-[test.star:11:12]
 10 |     impl MyAbi {
 11 |         fn transfer() {}
    :            ^^^^|^^^
    :                `-- implemented with 0 parameters here
 12 |     }
    `----
```

The check applies to both `utxo` and `token` impl blocks since they share `check_abi_impl`. Snapshot tests cover the fewer-params and extra-params cases.