### PR TITLE
Make match arms follow structural typing rules

### DIFF
--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -418,9 +418,9 @@ No user-defined generics at this time.
 
 ### Structural typing rules
 
-- Struct and enum definitions introduce canonical shapes, but names are merely aliases; two independently-declared structs with the same field names/types are interchangeable.
-- Type annotations refer to those named definitions. During type checking the compiler canonicalizes field/variant order before comparing shapes so structurally identical names unify.
-- Unification succeeds for records when both sides have the same field names (order-insensitive) and each corresponding field type unifies. A similar rule holds for enums, matching variant names and payload arity/type.
+- Struct and enum definitions introduce canonical shapes, but names are merely aliases; two independently-declared structs with the same fields — same names, same types, in the same declaration order — are interchangeable.
+- Type annotations refer to those named definitions. Shapes are compared in declaration order; no reordering or canonicalization is performed, so the same field set declared in a different order is a different shape.
+- Unification succeeds for records when both sides declare the same field names in the same order and each corresponding field type unifies. A similar rule holds for enums, matching variant names, variant order, and payload arity/type.
 - Pattern matching and field access operate on these shapes; renaming a type but keeping its layout requires no code changes.
 
 ## Contracts
@@ -651,7 +651,7 @@ visibility modifier:
 - The boolean operators `!`, `&&`, `||` accept booleans and produce
   booleans.
   - `&&` and `||` are short-circuiting.
-- Structural records/enums are compared by shape, not name. Two structs with identical field sets and types are interchangeable; enum variants must likewise line up by name and payload shape.
+- Structural records/enums are compared by shape, not name. Two structs with identical fields declared in the same order are interchangeable; enum variants must likewise line up by name, declaration order, and payload shape.
 - `yield` expressions mark points where a Utxo's execution can be suspended to the ledger.
   They are only valid inside Utxo `main fn`s.
 

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -4857,12 +4857,12 @@ impl Inferencer {
                     "Unify-Arrow",
                 ))
             }
-            (Type::Record(ls), Type::Record(rs))
-                if ls.name == rs.name && ls.fields.len() == rs.fields.len() =>
-            {
+            // Records unify structurally: names are aliases, but fields must
+            // line up in declaration order, matching `unify` below.
+            (Type::Record(ls), Type::Record(rs)) if ls.fields.len() == rs.fields.len() => {
                 let mut children = Vec::new();
                 for (lf, rf) in ls.fields.iter().zip(rs.fields.iter()) {
-                    if lf.name != rf.name {
+                    if lf.name.as_str() != rf.name.as_str() {
                         return Err(());
                     }
                     let (_, child, _) = self.unify_inner(lf.ty.clone(), rf.ty.clone())?;
@@ -4870,11 +4870,9 @@ impl Inferencer {
                 }
                 Ok((Type::Record(ls), children, "Unify-Record"))
             }
-            (Type::Enum(mut ls), Type::Enum(mut rs))
-                if ls.name == rs.name && ls.variants.len() == rs.variants.len() =>
-            {
-                ls.variants.sort_by(|a, b| a.name.cmp(&b.name));
-                rs.variants.sort_by(|a, b| a.name.cmp(&b.name));
+            // Enums likewise unify by shape, not name, with variants compared
+            // in declaration order.
+            (Type::Enum(ls), Type::Enum(rs)) if ls.variants.len() == rs.variants.len() => {
                 let mut children = Vec::new();
                 for (lv, rv) in ls.variants.iter().zip(rs.variants.iter()) {
                     if lv.name != rv.name {
@@ -4894,7 +4892,7 @@ impl Inferencer {
                             if lf.len() == rf.len() =>
                         {
                             for (l, r) in lf.iter().zip(rf.iter()) {
-                                if l.name != r.name {
+                                if l.name.as_str() != r.name.as_str() {
                                     return Err(());
                                 }
                                 let (_, c, _) = self.unify_inner(l.ty.clone(), r.ty.clone())?;
@@ -5071,17 +5069,13 @@ impl Inferencer {
                     "Unify-Arrow",
                 )
             }
-            (Type::Record(mut ls), Type::Record(mut rs)) => {
-                ls.fields
-                    .sort_by(|a, b| a.name.as_str().cmp(b.name.as_str()));
-                rs.fields
-                    .sort_by(|a, b| a.name.as_str().cmp(b.name.as_str()));
+            (Type::Record(ls), Type::Record(rs)) => {
                 if ls.fields.len() != rs.fields.len()
                     || ls
                         .fields
                         .iter()
                         .zip(rs.fields.iter())
-                        .any(|(l, r)| l.name != r.name)
+                        .any(|(l, r)| l.name.as_str() != r.name.as_str())
                 {
                     return Err(TypeError::new(error_kind, left_span)
                         .with_secondary(right_span, "struct field mismatch"));
@@ -5103,9 +5097,7 @@ impl Inferencer {
                 }
                 (Type::Record(ls), record_children, "Unify-Record")
             }
-            (Type::Enum(mut ls), Type::Enum(mut rs)) => {
-                ls.variants.sort_by(|a, b| a.name.cmp(&b.name));
-                rs.variants.sort_by(|a, b| a.name.cmp(&b.name));
+            (Type::Enum(ls), Type::Enum(rs)) => {
                 if ls.variants.len() != rs.variants.len()
                     || ls
                         .variants
@@ -5152,7 +5144,7 @@ impl Inferencer {
                                 || left_fields
                                     .iter()
                                     .zip(right_fields.iter())
-                                    .any(|(l, r)| l.name != r.name)
+                                    .any(|(l, r)| l.name.as_str() != r.name.as_str())
                             {
                                 return Err(TypeError::new(error_kind.clone(), left_span)
                                     .with_secondary(right_span, "enum payload mismatch"));

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__exhaustive_match_all_variants.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__exhaustive_match_all_variants.snap
@@ -21,8 +21,8 @@ T-Fn: test => i64
 } ⇒ i64
       T-Var: {r: Result<i64, i64>, test: fn(Result<i64, i64>) -> i64 [test]} ⊢ r ⇒ Result<i64, i64>
       Unify-Enum: Result<i64, i64> ~ Result => {i64/t1, i64/t2}
-        Unify-Var: i64 ~ t2 => {i64/t2}
         Unify-Var: i64 ~ t1 => {i64/t1}
+        Unify-Var: i64 ~ t2 => {i64/t2}
       T-Tail: value => i64
         T-Var: {r: Result<i64, i64>, test: fn(Result<i64, i64>) -> i64 [test], value: i64} ⊢ value ⇒ i64
       Unify-Enum: Result<i64, i64> ~ Result => {}

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__if_else_record_field_order_mismatch_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__if_else_record_field_order_mismatch_error.snap
@@ -1,0 +1,14 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\nstruct A {\n    x: i64,\n    y: bool,\n}\n\nstruct B {\n    y: bool,\n    x: i64,\n}\n\nfn pick(c: bool, a: A, b: B) -> A {\n    if (c) { a } else { b }\n}\n"
+---
+E0008 (https://starstream.nightstream.dev/errors/E0008)
+
+  x expected type `A`, found `B`
+    ,-[test.star:12:25]
+ 11 | fn pick(c: bool, a: A, b: B) -> A {
+ 12 |     if (c) { a } else { b }
+    :     ^^^^^^^^^^^^|^^^^^^^^^^^^
+    :                 `-- struct field mismatch
+ 13 | }
+    `----

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__if_else_structural_records_unify.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__if_else_structural_records_unify.snap
@@ -1,0 +1,27 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\nstruct A {\n    x: i64,\n    y: bool,\n}\n\nstruct B {\n    y: bool,\n    x: i64,\n}\n\nfn pick(c: bool, a: A, b: B) -> A {\n    if (c) { a } else { b }\n}\n"
+---
+T-Fn: pick => A
+  T-ReturnTail: if (c) {
+    a
+} else {
+    b
+} => A
+    T-If: {a: A, b: B, c: bool, pick: fn(bool, A, B) -> A [pick]} ⊢ if (c) {
+    a
+} else {
+    b
+} ⇒ ()
+      T-Var: {a: A, b: B, c: bool, pick: fn(bool, A, B) -> A [pick]} ⊢ c ⇒ bool
+      Check-Bool: bool => ok
+      T-Tail: a => A
+        T-Var: {a: A, b: B, c: bool, pick: fn(bool, A, B) -> A [pick]} ⊢ a ⇒ A
+      T-Tail: b => B
+        T-Var: {a: A, b: B, c: bool, pick: fn(bool, A, B) -> A [pick]} ⊢ b ⇒ B
+      Unify-Record: A ~ B => {}
+        Unify-Const: i64 ~ i64 => {}
+        Unify-Const: bool ~ bool => {}
+    Unify-Record: A ~ A => {}
+      Unify-Const: i64 ~ i64 => {}
+      Unify-Const: bool ~ bool => {}

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__match_arms_enum_variant_order_mismatch_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__match_arms_enum_variant_order_mismatch_error.snap
@@ -1,0 +1,17 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\nenum First {\n    Go(i64),\n    Stop,\n}\n\nenum Second {\n    Stop,\n    Go(i64),\n}\n\nfn pick(c: bool, a: First, b: Second) -> First {\n    match c {\n        true => { a },\n        false => { b },\n    }\n}\n"
+---
+E0008 (https://starstream.nightstream.dev/errors/E0008)
+
+  x expected type `First`, found `Second`
+    ,-[test.star:14:20]
+ 12 |     match c {
+ 13 |         true => { a },
+    :                   ^|
+    :                    `-- expected `First` due to this
+ 14 |         false => { b },
+    :                    ^|
+    :                     `-- has type `Second`
+ 15 |     }
+    `----

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__match_arms_record_field_order_mismatch_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__match_arms_record_field_order_mismatch_error.snap
@@ -1,0 +1,17 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\nstruct A {\n    x: i64,\n    y: bool,\n}\n\nstruct B {\n    y: bool,\n    x: i64,\n}\n\nfn pick(c: bool, a: A, b: B) -> A {\n    match c {\n        true => { a },\n        false => { b },\n    }\n}\n"
+---
+E0008 (https://starstream.nightstream.dev/errors/E0008)
+
+  x expected type `A`, found `B`
+    ,-[test.star:14:20]
+ 12 |     match c {
+ 13 |         true => { a },
+    :                   ^|
+    :                    `-- expected `A` due to this
+ 14 |         false => { b },
+    :                    ^|
+    :                     `-- has type `B`
+ 15 |     }
+    `----

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__match_arms_record_shape_mismatch_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__match_arms_record_shape_mismatch_error.snap
@@ -1,0 +1,17 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\nstruct A {\n    x: i64,\n}\n\nstruct B {\n    x: i64,\n    y: bool,\n}\n\nfn pick(c: bool, a: A, b: B) -> A {\n    match c {\n        true => { a },\n        false => { b },\n    }\n}\n"
+---
+E0008 (https://starstream.nightstream.dev/errors/E0008)
+
+  x expected type `A`, found `B`
+    ,-[test.star:13:20]
+ 11 |     match c {
+ 12 |         true => { a },
+    :                   ^|
+    :                    `-- expected `A` due to this
+ 13 |         false => { b },
+    :                    ^|
+    :                     `-- has type `B`
+ 14 |     }
+    `----

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__match_arms_structural_enums_unify.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__match_arms_structural_enums_unify.snap
@@ -1,0 +1,31 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\nenum First {\n    Go(i64),\n    Stop,\n}\n\nenum Second {\n    Stop,\n    Go(i64),\n}\n\nfn pick(c: bool, a: First, b: Second) -> First {\n    match c {\n        true => { a },\n        false => { b },\n    }\n}\n"
+---
+T-Fn: pick => First
+  T-ReturnTail: match c {
+    true => {
+        a
+    },
+    false => {
+        b
+    },
+} => Second
+    T-Match: {a: First, b: Second, c: bool, pick: fn(bool, First, Second) -> First [pick]} ⊢ match c {
+    true => {
+        a
+    },
+    false => {
+        b
+    },
+} ⇒ Second
+      T-Var: {a: First, b: Second, c: bool, pick: fn(bool, First, Second) -> First [pick]} ⊢ c ⇒ bool
+      Unify-Const: bool ~ bool => {}
+      T-Tail: a => First
+        T-Var: {a: First, b: Second, c: bool, pick: fn(bool, First, Second) -> First [pick]} ⊢ a ⇒ First
+      Unify-Const: bool ~ bool => {}
+      T-Tail: b => Second
+        T-Var: {a: First, b: Second, c: bool, pick: fn(bool, First, Second) -> First [pick]} ⊢ b ⇒ Second
+      Unify-Enum: Second ~ First => Second
+    Unify-Enum: Second ~ First => {}
+      Unify-Const: i64 ~ i64 => {}

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__match_arms_structural_records_unify.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__match_arms_structural_records_unify.snap
@@ -1,0 +1,32 @@
+---
+source: starstream-compiler/src/typecheck/tests.rs
+description: "Source:\n\nstruct A {\n    x: i64,\n    y: bool,\n}\n\nstruct B {\n    y: bool,\n    x: i64,\n}\n\nfn pick(c: bool, a: A, b: B) -> A {\n    match c {\n        true => { a },\n        false => { b },\n    }\n}\n"
+---
+T-Fn: pick => A
+  T-ReturnTail: match c {
+    true => {
+        a
+    },
+    false => {
+        b
+    },
+} => B
+    T-Match: {a: A, b: B, c: bool, pick: fn(bool, A, B) -> A [pick]} ⊢ match c {
+    true => {
+        a
+    },
+    false => {
+        b
+    },
+} ⇒ B
+      T-Var: {a: A, b: B, c: bool, pick: fn(bool, A, B) -> A [pick]} ⊢ c ⇒ bool
+      Unify-Const: bool ~ bool => {}
+      T-Tail: a => A
+        T-Var: {a: A, b: B, c: bool, pick: fn(bool, A, B) -> A [pick]} ⊢ a ⇒ A
+      Unify-Const: bool ~ bool => {}
+      T-Tail: b => B
+        T-Var: {a: A, b: B, c: bool, pick: fn(bool, A, B) -> A [pick]} ⊢ b ⇒ B
+      Unify-Record: B ~ A => B
+    Unify-Record: B ~ A => {}
+      Unify-Const: i64 ~ i64 => {}
+      Unify-Const: bool ~ bool => {}

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__result_explicit_annotation.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__result_explicit_annotation.snap
@@ -9,5 +9,5 @@ T-Fn: test => ()
       T-Int: {test: fn() -> () [test]} ⊢ 42 ⇒ i64
       Unify-Var: i64 ~ t3 => {i64/t5}
     Unify-Enum: Result<i64, bool> ~ Result => {bool/t4, i64/t3}
-      Unify-Var: bool ~ t4 => {bool/t4}
       Unify-Var: i64 ~ i64 => {i64/t3}
+      Unify-Var: bool ~ t4 => {bool/t4}

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__result_pattern_matching.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__result_pattern_matching.snap
@@ -9,8 +9,8 @@ T-Fn: test => ()
       T-Int: {test: fn() -> () [test]} ⊢ 42 ⇒ i64
       Unify-Var: i64 ~ t3 => {i64/t5}
     Unify-Enum: Result<i64, bool> ~ Result => {bool/t4, i64/t3}
-      Unify-Var: bool ~ t4 => {bool/t4}
       Unify-Var: i64 ~ i64 => {i64/t3}
+      Unify-Var: bool ~ t4 => {bool/t4}
   T-Let: {test: fn() -> () [test], x: Result<i64, bool>} ⊢ let y = match x {
     Result::Ok(v) => {
         v
@@ -29,13 +29,13 @@ T-Fn: test => ()
 } ⇒ i64
       T-Var: {test: fn() -> () [test], x: Result<i64, bool>} ⊢ x ⇒ Result<i64, bool>
       Unify-Enum: Result<i64, bool> ~ Result => {bool/t2, i64/t1}
-        Unify-Var: bool ~ t2 => {bool/t2}
         Unify-Var: i64 ~ t1 => {i64/t1}
+        Unify-Var: bool ~ t2 => {bool/t2}
       T-Tail: v => i64
         T-Var: {test: fn() -> () [test], v: i64, x: Result<i64, bool>} ⊢ v ⇒ i64
       Unify-Enum: Result<i64, bool> ~ Result => {}
-        Unify-Const: bool ~ bool => {}
         Unify-Const: i64 ~ i64 => {}
+        Unify-Const: bool ~ bool => {}
       T-Tail: 0 => i64
         T-Int: {e: bool, test: fn() -> () [test], x: Result<i64, bool>} ⊢ 0 ⇒ i64
       Unify-Var: i64 ~ i64 => i64

--- a/starstream-compiler/src/typecheck/tests.rs
+++ b/starstream-compiler/src/typecheck/tests.rs
@@ -1712,3 +1712,171 @@ fn abi_impl_extra_params_error() {
         "#
     );
 }
+
+// ── match arm structural unification ─────────────────────────────────────────
+
+#[test]
+fn match_arms_structural_records_unify() {
+    // Struct names are aliases, so arms returning `A` and `B` unify when the
+    // fields line up in declaration order — same rule as if/else branches.
+    assert_typecheck_snapshot!(
+        r#"
+        struct A {
+            x: i64,
+            y: bool,
+        }
+
+        struct B {
+            x: i64,
+            y: bool,
+        }
+
+        fn pick(c: bool, a: A, b: B) -> A {
+            match c {
+                true => { a },
+                false => { b },
+            }
+        }
+        "#
+    );
+}
+
+#[test]
+fn match_arms_record_field_order_mismatch_error() {
+    // Declaration order is significant: same field set in a different order
+    // is a different shape.
+    assert_typecheck_snapshot!(
+        r#"
+        struct A {
+            x: i64,
+            y: bool,
+        }
+
+        struct B {
+            y: bool,
+            x: i64,
+        }
+
+        fn pick(c: bool, a: A, b: B) -> A {
+            match c {
+                true => { a },
+                false => { b },
+            }
+        }
+        "#
+    );
+}
+
+#[test]
+fn match_arms_structural_enums_unify() {
+    assert_typecheck_snapshot!(
+        r#"
+        enum First {
+            Go(i64),
+            Stop,
+        }
+
+        enum Second {
+            Go(i64),
+            Stop,
+        }
+
+        fn pick(c: bool, a: First, b: Second) -> First {
+            match c {
+                true => { a },
+                false => { b },
+            }
+        }
+        "#
+    );
+}
+
+#[test]
+fn match_arms_enum_variant_order_mismatch_error() {
+    // Variant order is significant — it determines the runtime tag.
+    assert_typecheck_snapshot!(
+        r#"
+        enum First {
+            Go(i64),
+            Stop,
+        }
+
+        enum Second {
+            Stop,
+            Go(i64),
+        }
+
+        fn pick(c: bool, a: First, b: Second) -> First {
+            match c {
+                true => { a },
+                false => { b },
+            }
+        }
+        "#
+    );
+}
+
+#[test]
+fn match_arms_record_shape_mismatch_error() {
+    assert_typecheck_snapshot!(
+        r#"
+        struct A {
+            x: i64,
+        }
+
+        struct B {
+            x: i64,
+            y: bool,
+        }
+
+        fn pick(c: bool, a: A, b: B) -> A {
+            match c {
+                true => { a },
+                false => { b },
+            }
+        }
+        "#
+    );
+}
+
+#[test]
+fn if_else_structural_records_unify() {
+    assert_typecheck_snapshot!(
+        r#"
+        struct A {
+            x: i64,
+            y: bool,
+        }
+
+        struct B {
+            x: i64,
+            y: bool,
+        }
+
+        fn pick(c: bool, a: A, b: B) -> A {
+            if (c) { a } else { b }
+        }
+        "#
+    );
+}
+
+#[test]
+fn if_else_record_field_order_mismatch_error() {
+    assert_typecheck_snapshot!(
+        r#"
+        struct A {
+            x: i64,
+            y: bool,
+        }
+
+        struct B {
+            y: bool,
+            x: i64,
+        }
+
+        fn pick(c: bool, a: A, b: B) -> A {
+            if (c) { a } else { b }
+        }
+        "#
+    );
+}

--- a/starstream-to-wasm/tests/snapshots/inputs@option_result.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@option_result.star.snap
@@ -802,8 +802,8 @@ T-Fn: make_ok => Result<i64, bool>
       T-Int: {make_none: fn() -> Option<i64> [make_none], make_ok: fn() -> Result<i64, bool> [make_ok], make_some: fn() -> Option<i64> [make_some], unwrap_option: fn(Option<i64>) -> i64 [unwrap_option]} ⊢ 42 ⇒ i64
       Unify-Var: i64 ~ t7 => {i64/t9}
     Unify-Enum: Result ~ Result<i64, bool> => {bool/t8, i64/t7}
-      Unify-Var: t8 ~ bool => {bool/t8}
       Unify-Var: i64 ~ i64 => {i64/t7}
+      Unify-Var: t8 ~ bool => {bool/t8}
 
 T-Fn: make_err => Result<i64, bool>
   T-ReturnTail: Result::Err(false) => Result
@@ -812,8 +812,8 @@ T-Fn: make_err => Result<i64, bool>
       T-Bool: {make_err: fn() -> Result<i64, bool> [make_err], make_none: fn() -> Option<i64> [make_none], make_ok: fn() -> Result<i64, bool> [make_ok], make_some: fn() -> Option<i64> [make_some], unwrap_option: fn(Option<i64>) -> i64 [unwrap_option]} ⊢ false ⇒ bool
       Unify-Var: bool ~ t11 => {bool/t11}
     Unify-Enum: Result ~ Result<i64, bool> => {i64/t10}
-      Unify-Const: bool ~ bool => {}
       Unify-Var: t10 ~ i64 => {i64/t10}
+      Unify-Const: bool ~ bool => {}
 
 T-Fn: unwrap_result => i64
   T-ReturnTail: match res {
@@ -834,13 +834,13 @@ T-Fn: unwrap_result => i64
 } ⇒ i64
       T-Var: {make_err: fn() -> Result<i64, bool> [make_err], make_none: fn() -> Option<i64> [make_none], make_ok: fn() -> Result<i64, bool> [make_ok], make_some: fn() -> Option<i64> [make_some], res: Result<i64, bool>, unwrap_option: fn(Option<i64>) -> i64 [unwrap_option], unwrap_result: fn(Result<i64, bool>) -> i64 [unwrap_result]} ⊢ res ⇒ Result<i64, bool>
       Unify-Enum: Result<i64, bool> ~ Result => {bool/t2, i64/t1}
-        Unify-Var: bool ~ t2 => {bool/t2}
         Unify-Var: i64 ~ t1 => {i64/t1}
+        Unify-Var: bool ~ t2 => {bool/t2}
       T-Tail: v => i64
         T-Var: {make_err: fn() -> Result<i64, bool> [make_err], make_none: fn() -> Option<i64> [make_none], make_ok: fn() -> Result<i64, bool> [make_ok], make_some: fn() -> Option<i64> [make_some], res: Result<i64, bool>, unwrap_option: fn(Option<i64>) -> i64 [unwrap_option], unwrap_result: fn(Result<i64, bool>) -> i64 [unwrap_result], v: i64} ⊢ v ⇒ i64
       Unify-Enum: Result<i64, bool> ~ Result => {}
-        Unify-Const: bool ~ bool => {}
         Unify-Const: i64 ~ i64 => {}
+        Unify-Const: bool ~ bool => {}
       T-Tail: 0 => i64
         T-Int: {e: bool, make_err: fn() -> Result<i64, bool> [make_err], make_none: fn() -> Option<i64> [make_none], make_ok: fn() -> Result<i64, bool> [make_ok], make_some: fn() -> Option<i64> [make_some], res: Result<i64, bool>, unwrap_option: fn(Option<i64>) -> i64 [unwrap_option], unwrap_result: fn(Result<i64, bool>) -> i64 [unwrap_result]} ⊢ 0 ⇒ i64
       Unify-Var: i64 ~ i64 => i64
@@ -861,8 +861,8 @@ T-Fn: run => ()
       T-Call: {make_err: fn() -> Result<i64, bool> [make_err], make_none: fn() -> Option<i64> [make_none], make_ok: fn() -> Result<i64, bool> [make_ok], make_some: fn() -> Option<i64> [make_some], run: fn(Thing, Result<i64, bool>) -> () [run], unwrap_option: fn(Option<i64>) -> i64 [unwrap_option], unwrap_result: fn(Result<i64, bool>) -> i64 [unwrap_result], x: Thing, y: Result<i64, bool>} ⊢ make_ok() ⇒ Result<i64, bool>
         T-Var: {make_err: fn() -> Result<i64, bool> [make_err], make_none: fn() -> Option<i64> [make_none], make_ok: fn() -> Result<i64, bool> [make_ok], make_some: fn() -> Option<i64> [make_some], run: fn(Thing, Result<i64, bool>) -> () [run], unwrap_option: fn(Option<i64>) -> i64 [unwrap_option], unwrap_result: fn(Result<i64, bool>) -> i64 [unwrap_result], x: Thing, y: Result<i64, bool>} ⊢ make_ok ⇒ fn() -> Result<i64, bool> [make_ok]
       Unify-Enum: Result<i64, bool> ~ Result<i64, bool> => {}
-        Unify-Const: bool ~ bool => {}
         Unify-Const: i64 ~ i64 => {}
+        Unify-Const: bool ~ bool => {}
 
 ==== Typed AST ====
 TypedProgram {


### PR DESCRIPTION
The spec says struct and enum names are merely aliases: two independently-declared types with the same shape are interchangeable. `if`/`else` branches follow this (they unify via `unify`), but `match` arms go through `unify_match_arms` → `unify_inner`, which required both records and enums to have the **same name**. So this typechecked:

```starstream
struct A { x: i64, y: bool }
struct B { x: i64, y: bool }

fn pick(c: bool, a: A, b: B) -> A {
    if (c) { a } else { b }   // ok
}
```

while the equivalent `match` was rejected with `expected type A, found B`:

```starstream
fn pick(c: bool, a: A, b: B) -> A {
    match c {
        true => { a },    // error
        false => { b },
    }
}
```

Three changes, all in the unification layer:

1. **Match arms unify structurally like if/else.** `unify_inner` drops the name-equality requirement for records and enums, mirroring `unify`.

2. **Field names are compared by text, not `Identifier` equality.** `Identifier`'s derived `PartialEq` includes the source span, so field-name comparisons in both `unify` and `unify_inner` never matched across two distinct declarations — the `if`/`else` example above also fails on `main` with `struct field mismatch`. Record fields and enum struct-payload fields now compare with `as_str()`.

3. **Declaration order is significant — no sorting.** `unify` previously sorted record fields and enum variants alphabetically before comparing, making unification order-insensitive. That sorting is removed: fields and variants must line up in declaration order, and the same field/variant set declared in a different order is a different shape. This keeps unification consistent with codegen, where variant tags and field layout follow declaration order (the sort also mutated the merged type, so a unified record came out with alphabetized fields). The structural typing section of `docs/language-spec.md` is updated accordingly.

Snapshot tests cover: match arms and `if`/`else` unifying same-shape records/enums with different names, order-mismatch rejections for both record fields and enum variants, and a shape mismatch. A few existing trace snapshots changed only in child order because `Result`'s payloads now unify in declaration order (`Ok` before `Err`) instead of alphabetical.