### PR TITLE
starstream-to-wasm: emit UTXO instance imports for coordination scripts

### DIFF
--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -17,11 +17,11 @@ use starstream_types::{
 };
 use thiserror::Error;
 use wasm_encoder::{
-    BlockType, CodeSection, Component, ComponentExportKind, ComponentExportSection, ComponentType,
-    ComponentTypeRef, ComponentTypeSection, ConstExpr, CustomSection, DataSection, EntityType,
-    ExportKind, ExportSection, FuncType, Function, FunctionSection, GlobalSection, GlobalType,
-    Ieee32, Ieee64, ImportSection, InstanceType, InstructionSink, MemorySection, MemoryType,
-    Module, TypeBounds, TypeSection, ValType,
+    Alias, BlockType, CodeSection, Component, ComponentExportKind, ComponentExportSection,
+    ComponentType, ComponentTypeRef, ComponentTypeSection, ConstExpr, CustomSection, DataSection,
+    EntityType, ExportKind, ExportSection, FuncType, Function, FunctionSection, GlobalSection,
+    GlobalType, Ieee32, Ieee64, ImportSection, InstanceType, InstructionSink, MemorySection,
+    MemoryType, Module, TypeBounds, TypeSection, ValType,
 };
 
 use crate::component_abi::{
@@ -194,6 +194,22 @@ struct ErrorToken;
 
 type Result<T> = std::result::Result<T, ErrorToken>;
 
+/// Whether a component type is being encoded at the root (world) scope or
+/// nested inside an exported instance. UTXO/token resources are referenced by
+/// index, and those indices live in different type-index spaces depending on
+/// scope, so named-resource lookups must be resolved accordingly.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+enum ResourceScope {
+    /// Inside an exported UTXO/token instance: named resources resolve to the
+    /// instance-local resource declared by that instance.
+    #[default]
+    Instance,
+    /// At the world root (e.g. a coordination `script fn` signature): named
+    /// resources resolve to a resource aliased in from a component-instance
+    /// import of the providing UTXO/token.
+    World,
+}
+
 /// Holds the in-progress Wasm sections and other module-wide information
 /// needed to build them.
 #[derive(Default)]
@@ -234,6 +250,12 @@ struct Compiler {
     callables: HashMap<String, u32>,
     /// Map from name to resource index.
     resources: HashMap<String, u32>,
+    /// Current resource-index resolution scope for component-type encoding.
+    resource_scope: ResourceScope,
+    /// Map from UTXO name to the world-level resource type index aliased in
+    /// from its component-instance import (created on demand when a coordination
+    /// script references the UTXO type).
+    imported_utxo_world_resources: HashMap<String, u32>,
     /// Function bodies.
     code_bytes: Vec<Vec<u8>>,
 
@@ -931,7 +953,11 @@ impl Compiler {
     // Type conversion
 
     fn star_to_component_type(&mut self, ty: &Type) -> Option<Rc<ComponentAbiType>> {
-        if let Some(cat) = self.star_to_component.get(ty) {
+        // The cache maps a `Type` to a single `ComponentAbiType`, but named
+        // resources encode to different indices depending on the scope, so the
+        // cache is only sound at the (default) instance scope.
+        let use_cache = self.resource_scope == ResourceScope::Instance;
+        if use_cache && let Some(cat) = self.star_to_component.get(ty) {
             return Some(cat.clone());
         }
 
@@ -968,11 +994,17 @@ impl Compiler {
                 }
             }
             Type::UtxoNamed(name) => {
-                if let Some(idx) = self.resources.get(name) {
-                    ComponentAbiType::Borrow { resource: *idx }
+                let idx = if self.resource_scope == ResourceScope::World {
+                    // A coordination script references the UTXO type: it is
+                    // imported as a component instance and its `utxo` resource
+                    // is aliased up to the world root.
+                    self.import_utxo_instance(name)?
+                } else if let Some(idx) = self.resources.get(name) {
+                    *idx
                 } else {
                     return None;
-                }
+                };
+                ComponentAbiType::Borrow { resource: idx }
             }
             // Token handles mirror Utxo: always borrowed, the ledger owns them.
             Type::TokenAny => {
@@ -1092,8 +1124,57 @@ impl Compiler {
         };
 
         let cat = Rc::new(cat);
-        self.star_to_component.insert(ty.clone(), cat.clone());
+        if use_cache {
+            self.star_to_component.insert(ty.clone(), cat.clone());
+        }
         Some(cat)
+    }
+
+    /// Emit a component-instance import for the named UTXO (mirroring its
+    /// exported interface) and alias its `utxo` resource to the world root,
+    /// returning the world-level resource type index. Idempotent per UTXO name.
+    ///
+    /// This is how a coordination `script fn` references a UTXO type: the
+    /// providing contract is linked to the import at instantiation time.
+    fn import_utxo_instance(&mut self, name: &str) -> Option<u32> {
+        if let Some(&idx) = self.imported_utxo_world_resources.get(name) {
+            return Some(idx);
+        }
+        let interface_name = to_kebab_case(name);
+        // Reuse the exported interface's type shape for the import.
+        let iface = self.exported_interfaces.get(&interface_name)?.inner.clone();
+
+        let (instance_ty_idx, encoder) = self.world_type.ty();
+        encoder.instance(&iface);
+
+        // Import under an interface-id (`namespace:package/name`) so it is a
+        // named interface import (`WorldKey::Interface`); world-root script
+        // signatures can then reference (`use`) its resource.
+        let import_name = format!("starstream:coordination/{interface_name}");
+        let instance_idx = self.world_type.inner.instance_count();
+        self.world_type
+            .inner
+            .import(&import_name, ComponentTypeRef::Instance(instance_ty_idx));
+
+        let alias_idx = self.world_type.inner.type_count();
+        self.world_type.inner.alias(Alias::InstanceExport {
+            instance: instance_idx,
+            kind: ComponentExportKind::Type,
+            name: "utxo",
+        });
+
+        // Re-import the aliased resource under a unique world-level name (what a
+        // WIT `use <iface>.{utxo as <name>-utxo}` compiles to) so world-root
+        // script signatures can reference it.
+        let resource_idx = self.world_type.inner.type_count();
+        self.world_type.inner.import(
+            &format!("{interface_name}-utxo"),
+            ComponentTypeRef::Type(TypeBounds::Eq(alias_idx)),
+        );
+
+        self.imported_utxo_world_resources
+            .insert(name.to_owned(), resource_idx);
+        Some(resource_idx)
     }
 
     fn star_to_core_types(&mut self, span: Span, dest: &mut Vec<ValType>, ty: &Type) -> Result<()> {
@@ -1327,8 +1408,12 @@ impl Compiler {
                 TypedDefinition::Function(func) => {
                     let core = self.visit_function(None, func, &());
                     if let Some(FunctionExport::Script) = func.export {
+                        // A coordination script is a world-root export; UTXO
+                        // parameters resolve to instance-imported resources.
+                        self.resource_scope = ResourceScope::World;
                         let sig =
                             self.star_to_component_signature(None, &func.params, &func.return_type);
+                        self.resource_scope = ResourceScope::Instance;
                         self.export_component_fn(
                             &to_kebab_case(func.name.as_str()),
                             func.name.span,

--- a/starstream-to-wasm/tests/inputs/coordination_script.star
+++ b/starstream-to-wasm/tests/inputs/coordination_script.star
@@ -1,0 +1,31 @@
+utxo Alpha {
+    storage {
+        let mut a: u64;
+    }
+    main fn new(pub start: u64) {
+        a = start;
+        yield();
+    }
+}
+
+utxo Beta {
+    storage {
+        let mut b: u64;
+    }
+    main fn new(pub start: u64) {
+        b = start;
+        yield();
+    }
+}
+
+script fn use_one(x: Alpha) -> u64 {
+    0
+}
+
+script fn same_type(x: Alpha, y: Alpha) -> u64 {
+    0
+}
+
+script fn diff_types(p: Alpha, q: Beta) -> u64 {
+    0
+}

--- a/starstream-to-wasm/tests/snapshots/inputs@coordination_script.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@coordination_script.star.snap
@@ -1,0 +1,1118 @@
+---
+source: starstream-to-wasm/tests/snapshots.rs
+input_file: starstream-to-wasm/tests/inputs/coordination_script.star
+---
+==== AST ====
+Program {
+    shebang: None,
+    definitions: [
+        Spanned {
+            node: Utxo(
+                UtxoDef {
+                    name: Identifier {
+                        name: "Alpha",
+                        span: 5..10,
+                    },
+                    parts: [
+                        Storage(
+                            [
+                                UtxoGlobal {
+                                    name: Identifier {
+                                        name: "a",
+                                        span: 43..44,
+                                    },
+                                    ty: TypeAnnotation {
+                                        name: Identifier {
+                                            name: "u64",
+                                            span: 46..49,
+                                        },
+                                        generics: [],
+                                    },
+                                },
+                            ],
+                        ),
+                        Function(
+                            FunctionDef {
+                                export: Some(
+                                    UtxoMain,
+                                ),
+                                name: Identifier {
+                                    name: "new",
+                                    span: 69..72,
+                                },
+                                params: [
+                                    FunctionParam {
+                                        public: true,
+                                        name: Identifier {
+                                            name: "start",
+                                            span: 77..82,
+                                        },
+                                        ty: TypeAnnotation {
+                                            name: Identifier {
+                                                name: "u64",
+                                                span: 84..87,
+                                            },
+                                            generics: [],
+                                        },
+                                    },
+                                ],
+                                return_type: None,
+                                body: Block {
+                                    statements: [
+                                        Spanned {
+                                            node: Assignment {
+                                                target: Identifier {
+                                                    name: "a",
+                                                    span: 99..100,
+                                                },
+                                                value: Spanned {
+                                                    node: ScopedName(
+                                                        [
+                                                            Identifier {
+                                                                name: "start",
+                                                                span: 103..108,
+                                                            },
+                                                        ],
+                                                    ),
+                                                    span: 103..108,
+                                                },
+                                            },
+                                            span: 99..118,
+                                        },
+                                        Spanned {
+                                            node: Expression(
+                                                Spanned {
+                                                    node: Yield {
+                                                        abis: [],
+                                                    },
+                                                    span: 118..125,
+                                                },
+                                            ),
+                                            span: 118..131,
+                                        },
+                                    ],
+                                    tail_expression: None,
+                                    span: 89..133,
+                                },
+                            },
+                        ),
+                    ],
+                },
+            ),
+            span: 0..136,
+        },
+        Spanned {
+            node: Utxo(
+                UtxoDef {
+                    name: Identifier {
+                        name: "Beta",
+                        span: 141..145,
+                    },
+                    parts: [
+                        Storage(
+                            [
+                                UtxoGlobal {
+                                    name: Identifier {
+                                        name: "b",
+                                        span: 178..179,
+                                    },
+                                    ty: TypeAnnotation {
+                                        name: Identifier {
+                                            name: "u64",
+                                            span: 181..184,
+                                        },
+                                        generics: [],
+                                    },
+                                },
+                            ],
+                        ),
+                        Function(
+                            FunctionDef {
+                                export: Some(
+                                    UtxoMain,
+                                ),
+                                name: Identifier {
+                                    name: "new",
+                                    span: 204..207,
+                                },
+                                params: [
+                                    FunctionParam {
+                                        public: true,
+                                        name: Identifier {
+                                            name: "start",
+                                            span: 212..217,
+                                        },
+                                        ty: TypeAnnotation {
+                                            name: Identifier {
+                                                name: "u64",
+                                                span: 219..222,
+                                            },
+                                            generics: [],
+                                        },
+                                    },
+                                ],
+                                return_type: None,
+                                body: Block {
+                                    statements: [
+                                        Spanned {
+                                            node: Assignment {
+                                                target: Identifier {
+                                                    name: "b",
+                                                    span: 234..235,
+                                                },
+                                                value: Spanned {
+                                                    node: ScopedName(
+                                                        [
+                                                            Identifier {
+                                                                name: "start",
+                                                                span: 238..243,
+                                                            },
+                                                        ],
+                                                    ),
+                                                    span: 238..243,
+                                                },
+                                            },
+                                            span: 234..253,
+                                        },
+                                        Spanned {
+                                            node: Expression(
+                                                Spanned {
+                                                    node: Yield {
+                                                        abis: [],
+                                                    },
+                                                    span: 253..260,
+                                                },
+                                            ),
+                                            span: 253..266,
+                                        },
+                                    ],
+                                    tail_expression: None,
+                                    span: 224..268,
+                                },
+                            },
+                        ),
+                    ],
+                },
+            ),
+            span: 136..271,
+        },
+        Spanned {
+            node: Function(
+                FunctionDef {
+                    export: Some(
+                        Script,
+                    ),
+                    name: Identifier {
+                        name: "use_one",
+                        span: 281..288,
+                    },
+                    params: [
+                        FunctionParam {
+                            public: false,
+                            name: Identifier {
+                                name: "x",
+                                span: 289..290,
+                            },
+                            ty: TypeAnnotation {
+                                name: Identifier {
+                                    name: "Alpha",
+                                    span: 292..297,
+                                },
+                                generics: [],
+                            },
+                        },
+                    ],
+                    return_type: Some(
+                        TypeAnnotation {
+                            name: Identifier {
+                                name: "u64",
+                                span: 302..305,
+                            },
+                            generics: [],
+                        },
+                    ),
+                    body: Block {
+                        statements: [],
+                        tail_expression: Some(
+                            Spanned {
+                                node: Literal(
+                                    Integer(
+                                        0,
+                                    ),
+                                ),
+                                span: 312..313,
+                            },
+                        ),
+                        span: 306..317,
+                    },
+                },
+            ),
+            span: 271..317,
+        },
+        Spanned {
+            node: Function(
+                FunctionDef {
+                    export: Some(
+                        Script,
+                    ),
+                    name: Identifier {
+                        name: "same_type",
+                        span: 327..336,
+                    },
+                    params: [
+                        FunctionParam {
+                            public: false,
+                            name: Identifier {
+                                name: "x",
+                                span: 337..338,
+                            },
+                            ty: TypeAnnotation {
+                                name: Identifier {
+                                    name: "Alpha",
+                                    span: 340..345,
+                                },
+                                generics: [],
+                            },
+                        },
+                        FunctionParam {
+                            public: false,
+                            name: Identifier {
+                                name: "y",
+                                span: 347..348,
+                            },
+                            ty: TypeAnnotation {
+                                name: Identifier {
+                                    name: "Alpha",
+                                    span: 350..355,
+                                },
+                                generics: [],
+                            },
+                        },
+                    ],
+                    return_type: Some(
+                        TypeAnnotation {
+                            name: Identifier {
+                                name: "u64",
+                                span: 360..363,
+                            },
+                            generics: [],
+                        },
+                    ),
+                    body: Block {
+                        statements: [],
+                        tail_expression: Some(
+                            Spanned {
+                                node: Literal(
+                                    Integer(
+                                        0,
+                                    ),
+                                ),
+                                span: 370..371,
+                            },
+                        ),
+                        span: 364..375,
+                    },
+                },
+            ),
+            span: 317..375,
+        },
+        Spanned {
+            node: Function(
+                FunctionDef {
+                    export: Some(
+                        Script,
+                    ),
+                    name: Identifier {
+                        name: "diff_types",
+                        span: 385..395,
+                    },
+                    params: [
+                        FunctionParam {
+                            public: false,
+                            name: Identifier {
+                                name: "p",
+                                span: 396..397,
+                            },
+                            ty: TypeAnnotation {
+                                name: Identifier {
+                                    name: "Alpha",
+                                    span: 399..404,
+                                },
+                                generics: [],
+                            },
+                        },
+                        FunctionParam {
+                            public: false,
+                            name: Identifier {
+                                name: "q",
+                                span: 406..407,
+                            },
+                            ty: TypeAnnotation {
+                                name: Identifier {
+                                    name: "Beta",
+                                    span: 409..413,
+                                },
+                                generics: [],
+                            },
+                        },
+                    ],
+                    return_type: Some(
+                        TypeAnnotation {
+                            name: Identifier {
+                                name: "u64",
+                                span: 418..421,
+                            },
+                            generics: [],
+                        },
+                    ),
+                    body: Block {
+                        statements: [],
+                        tail_expression: Some(
+                            Spanned {
+                                node: Literal(
+                                    Integer(
+                                        0,
+                                    ),
+                                ),
+                                span: 428..429,
+                            },
+                        ),
+                        span: 422..432,
+                    },
+                },
+            ),
+            span: 375..432,
+        },
+    ],
+}
+
+==== Inference trace ====
+T-Utxo: Alpha => 
+  T-Fn: new => ()
+    T-Assign: {a: u64, new: fn(u64) -> () [new], start: u64} ⊢ a = start; ⇒ u64
+      T-Var: {a: u64, new: fn(u64) -> () [new], start: u64} ⊢ start ⇒ u64
+      Unify-Const: u64 ~ u64 => {}
+    T-Expr: {a: u64, new: fn(u64) -> () [new], start: u64} ⊢ yield(); ⇒ ()
+
+T-Utxo: Beta => 
+  T-Fn: new => ()
+    T-Assign: {b: u64, new: fn(u64) -> () [new], start: u64} ⊢ b = start; ⇒ u64
+      T-Var: {b: u64, new: fn(u64) -> () [new], start: u64} ⊢ start ⇒ u64
+      Unify-Const: u64 ~ u64 => {}
+    T-Expr: {b: u64, new: fn(u64) -> () [new], start: u64} ⊢ yield(); ⇒ ()
+
+T-Fn: use_one => u64
+  T-ReturnTail: 0 => u64
+    T-Int: {use_one: fn(Alpha) -> u64 [use_one], x: Alpha} ⊢ 0 ⇒ i64
+    Unify-Var: i64 ~ u64 => {u64/t3}
+
+T-Fn: same_type => u64
+  T-ReturnTail: 0 => u64
+    T-Int: {same_type: fn(Alpha, Alpha) -> u64 [same_type], use_one: fn(Alpha) -> u64 [use_one], x: Alpha, y: Alpha} ⊢ 0 ⇒ i64
+    Unify-Var: i64 ~ u64 => {u64/t4}
+
+T-Fn: diff_types => u64
+  T-ReturnTail: 0 => u64
+    T-Int: {diff_types: fn(Alpha, Beta) -> u64 [diff_types], p: Alpha, q: Beta, same_type: fn(Alpha, Alpha) -> u64 [same_type], use_one: fn(Alpha) -> u64 [use_one]} ⊢ 0 ⇒ i64
+    Unify-Var: i64 ~ u64 => {u64/t5}
+
+==== Typed AST ====
+TypedProgram {
+    has_yields: true,
+    definitions: [
+        Utxo(
+            TypedUtxoDef {
+                name: Identifier {
+                    name: "Alpha",
+                    span: 5..10,
+                },
+                parts: [
+                    Storage(
+                        [
+                            TypedUtxoGlobal {
+                                name: Identifier {
+                                    name: "a",
+                                    span: 43..44,
+                                },
+                                ty: Int(
+                                    U64,
+                                ),
+                            },
+                        ],
+                    ),
+                    Function(
+                        TypedFunctionDef {
+                            export: Some(
+                                UtxoMain,
+                            ),
+                            name: Identifier {
+                                name: "new",
+                                span: 69..72,
+                            },
+                            params: [
+                                TypedFunctionParam {
+                                    public: true,
+                                    name: Identifier {
+                                        name: "start",
+                                        span: 77..82,
+                                    },
+                                    ty: Int(
+                                        U64,
+                                    ),
+                                },
+                            ],
+                            return_type: Unit,
+                            body: TypedBlock {
+                                statements: [
+                                    Assignment {
+                                        target: Identifier {
+                                            name: "a",
+                                            span: 99..100,
+                                        },
+                                        value: Spanned {
+                                            node: TypedExpr {
+                                                ty: Int(
+                                                    U64,
+                                                ),
+                                                kind: ScopedName {
+                                                    name: [
+                                                        Identifier {
+                                                            name: "start",
+                                                            span: 103..108,
+                                                        },
+                                                    ],
+                                                    constant: None,
+                                                },
+                                            },
+                                            span: 103..108,
+                                        },
+                                    },
+                                    Expression(
+                                        Spanned {
+                                            node: TypedExpr {
+                                                ty: Unit,
+                                                kind: Yield {
+                                                    abis: [],
+                                                },
+                                            },
+                                            span: 118..125,
+                                        },
+                                    ),
+                                ],
+                                tail_expression: None,
+                            },
+                        },
+                    ),
+                ],
+                ty: UtxoNamed(
+                    "Alpha",
+                ),
+            },
+        ),
+        Utxo(
+            TypedUtxoDef {
+                name: Identifier {
+                    name: "Beta",
+                    span: 141..145,
+                },
+                parts: [
+                    Storage(
+                        [
+                            TypedUtxoGlobal {
+                                name: Identifier {
+                                    name: "b",
+                                    span: 178..179,
+                                },
+                                ty: Int(
+                                    U64,
+                                ),
+                            },
+                        ],
+                    ),
+                    Function(
+                        TypedFunctionDef {
+                            export: Some(
+                                UtxoMain,
+                            ),
+                            name: Identifier {
+                                name: "new",
+                                span: 204..207,
+                            },
+                            params: [
+                                TypedFunctionParam {
+                                    public: true,
+                                    name: Identifier {
+                                        name: "start",
+                                        span: 212..217,
+                                    },
+                                    ty: Int(
+                                        U64,
+                                    ),
+                                },
+                            ],
+                            return_type: Unit,
+                            body: TypedBlock {
+                                statements: [
+                                    Assignment {
+                                        target: Identifier {
+                                            name: "b",
+                                            span: 234..235,
+                                        },
+                                        value: Spanned {
+                                            node: TypedExpr {
+                                                ty: Int(
+                                                    U64,
+                                                ),
+                                                kind: ScopedName {
+                                                    name: [
+                                                        Identifier {
+                                                            name: "start",
+                                                            span: 238..243,
+                                                        },
+                                                    ],
+                                                    constant: None,
+                                                },
+                                            },
+                                            span: 238..243,
+                                        },
+                                    },
+                                    Expression(
+                                        Spanned {
+                                            node: TypedExpr {
+                                                ty: Unit,
+                                                kind: Yield {
+                                                    abis: [],
+                                                },
+                                            },
+                                            span: 253..260,
+                                        },
+                                    ),
+                                ],
+                                tail_expression: None,
+                            },
+                        },
+                    ),
+                ],
+                ty: UtxoNamed(
+                    "Beta",
+                ),
+            },
+        ),
+        Function(
+            TypedFunctionDef {
+                export: Some(
+                    Script,
+                ),
+                name: Identifier {
+                    name: "use_one",
+                    span: 281..288,
+                },
+                params: [
+                    TypedFunctionParam {
+                        public: false,
+                        name: Identifier {
+                            name: "x",
+                            span: 289..290,
+                        },
+                        ty: UtxoNamed(
+                            "Alpha",
+                        ),
+                    },
+                ],
+                return_type: Int(
+                    U64,
+                ),
+                body: TypedBlock {
+                    statements: [],
+                    tail_expression: Some(
+                        Spanned {
+                            node: TypedExpr {
+                                ty: Int(
+                                    U64,
+                                ),
+                                kind: Literal(
+                                    Integer(
+                                        0,
+                                    ),
+                                ),
+                            },
+                            span: 312..313,
+                        },
+                    ),
+                },
+            },
+        ),
+        Function(
+            TypedFunctionDef {
+                export: Some(
+                    Script,
+                ),
+                name: Identifier {
+                    name: "same_type",
+                    span: 327..336,
+                },
+                params: [
+                    TypedFunctionParam {
+                        public: false,
+                        name: Identifier {
+                            name: "x",
+                            span: 337..338,
+                        },
+                        ty: UtxoNamed(
+                            "Alpha",
+                        ),
+                    },
+                    TypedFunctionParam {
+                        public: false,
+                        name: Identifier {
+                            name: "y",
+                            span: 347..348,
+                        },
+                        ty: UtxoNamed(
+                            "Alpha",
+                        ),
+                    },
+                ],
+                return_type: Int(
+                    U64,
+                ),
+                body: TypedBlock {
+                    statements: [],
+                    tail_expression: Some(
+                        Spanned {
+                            node: TypedExpr {
+                                ty: Int(
+                                    U64,
+                                ),
+                                kind: Literal(
+                                    Integer(
+                                        0,
+                                    ),
+                                ),
+                            },
+                            span: 370..371,
+                        },
+                    ),
+                },
+            },
+        ),
+        Function(
+            TypedFunctionDef {
+                export: Some(
+                    Script,
+                ),
+                name: Identifier {
+                    name: "diff_types",
+                    span: 385..395,
+                },
+                params: [
+                    TypedFunctionParam {
+                        public: false,
+                        name: Identifier {
+                            name: "p",
+                            span: 396..397,
+                        },
+                        ty: UtxoNamed(
+                            "Alpha",
+                        ),
+                    },
+                    TypedFunctionParam {
+                        public: false,
+                        name: Identifier {
+                            name: "q",
+                            span: 406..407,
+                        },
+                        ty: UtxoNamed(
+                            "Beta",
+                        ),
+                    },
+                ],
+                return_type: Int(
+                    U64,
+                ),
+                body: TypedBlock {
+                    statements: [],
+                    tail_expression: Some(
+                        Spanned {
+                            node: TypedExpr {
+                                ty: Int(
+                                    U64,
+                                ),
+                                kind: Literal(
+                                    Integer(
+                                        0,
+                                    ),
+                                ),
+                            },
+                            span: 428..429,
+                        },
+                    ),
+                },
+            },
+        ),
+    ],
+}
+
+==== Core WebAssembly ====
+(module
+  (type (;0;) (func (param i64 i64 i64 i64)))
+  (type (;1;) (func (param i32) (result i32)))
+  (type (;2;) (func (param i32)))
+  (type (;3;) (func))
+  (type (;4;) (func (param i64) (result i32)))
+  (type (;5;) (func (param i32) (result i32 i64 i64 i32)))
+  (type (;6;) (func (param i32 i64 i64 i32) (result i32)))
+  (type (;7;) (func (param i32) (result i64)))
+  (type (;8;) (func (param i32 i32) (result i64)))
+  (import "starstream:std/builtin" "implements-method" (func (;0;) (type 0)))
+  (import "[export]alpha" "[resource-new]utxo" (func (;1;) (type 1)))
+  (import "[export]alpha" "[resource-drop]utxo" (func (;2;) (type 2)))
+  (import "[export]beta" "[resource-new]utxo" (func (;3;) (type 1)))
+  (import "[export]beta" "[resource-drop]utxo" (func (;4;) (type 2)))
+  (memory (;0;) 1)
+  (global (;0;) (mut i32) (i32.const 0))
+  (global (;1;) (mut i64) (i64.const 0))
+  (global (;2;) (mut i64) (i64.const 0))
+  (global (;3;) (mut i32) (i32.const 0))
+  (global (;4;) (mut i64) (i64.const 0))
+  (global (;5;) (mut i64) (i64.const 0))
+  (global (;6;) (mut i32) (i32.const 0))
+  (export "alpha#[static]utxo.new" (func 6))
+  (export "alpha#get-storage" (func 9))
+  (export "alpha#set-storage" (func 10))
+  (export "beta#[static]utxo.new" (func 12))
+  (export "beta#get-storage" (func 15))
+  (export "beta#set-storage" (func 16))
+  (export "use-one" (func 17))
+  (export "same-type" (func 18))
+  (export "diff-types" (func 19))
+  (export "memory" (memory 0))
+  (func (;5;) (type 3)
+    (block ;; label = @1
+      (br_if 0 (;@1;)
+        (i32.ne
+          (global.get 0)
+          (i32.const 1)))
+      (return_call 7))
+    (unreachable)
+  )
+  (func (;6;) (type 4) (param i64) (result i32)
+    (local i32)
+    (local.set 1
+      (call 1
+        (i32.const 0)))
+    (global.set 1
+      (local.get 0))
+    (global.set 0
+      (i32.const 1))
+    (global.set 2
+      (local.get 0))
+    (global.set 3
+      (local.get 1))
+    (local.get 1)
+  )
+  (func (;7;) (type 3)
+    (local i64 i32)
+    (local.set 0
+      (global.get 2))
+    (global.set 2
+      (i64.const 0))
+    (local.set 1
+      (global.get 3))
+    (global.set 3
+      (i32.const 0))
+  )
+  (func (;8;) (type 5) (param i32) (result i32 i64 i64 i32)
+    (local i32)
+    (global.get 0)
+    (global.get 1)
+    (global.get 2)
+    (global.get 3)
+  )
+  (func (;9;) (type 1) (param i32) (result i32)
+    (local i32 i32 i64 i64 i32)
+    (i32.const 8)
+    (call 8
+      (local.get 0))
+    (local.set 5)
+    (local.set 4)
+    (local.set 3)
+    (local.set 2)
+    (local.set 1)
+    (i32.store
+      (local.get 1)
+      (local.get 2))
+    (i64.store offset=8
+      (local.get 1)
+      (local.get 3))
+    (i64.store offset=16
+      (local.get 1)
+      (local.get 4))
+    (i32.store offset=24
+      (local.get 1)
+      (local.get 5))
+    (i32.const 8)
+  )
+  (func (;10;) (type 6) (param i32 i64 i64 i32) (result i32)
+    (local i32 i64 i64 i32)
+    (global.set 0
+      (local.get 0))
+    (global.set 1
+      (local.get 1))
+    (global.set 2
+      (local.get 2))
+    (global.set 3
+      (local.get 3))
+    (return_call 1
+      (i32.const 0))
+  )
+  (func (;11;) (type 3)
+    (block ;; label = @1
+      (br_if 0 (;@1;)
+        (i32.ne
+          (global.get 0)
+          (i32.const 2)))
+      (return_call 13))
+    (unreachable)
+  )
+  (func (;12;) (type 4) (param i64) (result i32)
+    (local i32)
+    (local.set 1
+      (call 3
+        (i32.const 0)))
+    (global.set 4
+      (local.get 0))
+    (global.set 0
+      (i32.const 2))
+    (global.set 5
+      (local.get 0))
+    (global.set 6
+      (local.get 1))
+    (local.get 1)
+  )
+  (func (;13;) (type 3)
+    (local i64 i32)
+    (local.set 0
+      (global.get 5))
+    (global.set 5
+      (i64.const 0))
+    (local.set 1
+      (global.get 6))
+    (global.set 6
+      (i32.const 0))
+  )
+  (func (;14;) (type 5) (param i32) (result i32 i64 i64 i32)
+    (local i32)
+    (global.get 0)
+    (global.get 4)
+    (global.get 5)
+    (global.get 6)
+  )
+  (func (;15;) (type 1) (param i32) (result i32)
+    (local i32 i32 i64 i64 i32)
+    (i32.const 40)
+    (call 14
+      (local.get 0))
+    (local.set 5)
+    (local.set 4)
+    (local.set 3)
+    (local.set 2)
+    (local.set 1)
+    (i32.store
+      (local.get 1)
+      (local.get 2))
+    (i64.store offset=8
+      (local.get 1)
+      (local.get 3))
+    (i64.store offset=16
+      (local.get 1)
+      (local.get 4))
+    (i32.store offset=24
+      (local.get 1)
+      (local.get 5))
+    (i32.const 40)
+  )
+  (func (;16;) (type 6) (param i32 i64 i64 i32) (result i32)
+    (local i32 i64 i64 i32)
+    (global.set 0
+      (local.get 0))
+    (global.set 4
+      (local.get 1))
+    (global.set 5
+      (local.get 2))
+    (global.set 6
+      (local.get 3))
+    (return_call 3
+      (i32.const 0))
+  )
+  (func (;17;) (type 7) (param i32) (result i64)
+    (i64.const 0)
+  )
+  (func (;18;) (type 8) (param i32 i32) (result i64)
+    (i64.const 0)
+  )
+  (func (;19;) (type 8) (param i32 i32) (result i64)
+    (i64.const 0)
+  )
+  (@custom "component-type"
+    (component
+      (@custom "wit-component-encoding" "\04\00")
+      (type (;0;)
+        (component
+          (type (;0;)
+            (component
+              (type (;0;)
+                (instance
+                  (export (;0;) "utxo" (type (sub resource)))
+                  (type (;1;) (own 0))
+                  (type (;2;) (func (param "start" u64) (result 1)))
+                  (export (;0;) "[static]utxo.new" (func (type 2)))
+                  (type (;3;) (record (field "yield" s32) (field "a" s64) (field "yield1" s64) (field "yield1-v1" s32)))
+                  (export (;4;) "storage" (type (eq 3)))
+                  (type (;5;) (borrow 0))
+                  (type (;6;) (func (param "self" 5) (result 4)))
+                  (export (;1;) "get-storage" (func (type 6)))
+                  (type (;7;) (func (param "storage" 4) (result 1)))
+                  (export (;2;) "set-storage" (func (type 7)))
+                )
+              )
+              (import "starstream:coordination/alpha" (instance (;0;) (type 0)))
+              (alias export 0 "utxo" (type (;1;)))
+              (import "alpha-utxo" (type (;2;) (eq 1)))
+              (type (;3;) (borrow 2))
+              (type (;4;) (func (param "x" 3) (result u64)))
+              (export (;0;) "use-one" (func (type 4)))
+              (type (;5;) (func (param "x" 3) (param "y" 3) (result u64)))
+              (export (;1;) "same-type" (func (type 5)))
+              (type (;6;)
+                (instance
+                  (export (;0;) "utxo" (type (sub resource)))
+                  (type (;1;) (own 0))
+                  (type (;2;) (func (param "start" u64) (result 1)))
+                  (export (;0;) "[static]utxo.new" (func (type 2)))
+                  (type (;3;) (record (field "yield" s32) (field "b" s64) (field "yield2" s64) (field "yield2-v1" s32)))
+                  (export (;4;) "storage" (type (eq 3)))
+                  (type (;5;) (borrow 0))
+                  (type (;6;) (func (param "self" 5) (result 4)))
+                  (export (;1;) "get-storage" (func (type 6)))
+                  (type (;7;) (func (param "storage" 4) (result 1)))
+                  (export (;2;) "set-storage" (func (type 7)))
+                )
+              )
+              (import "starstream:coordination/beta" (instance (;1;) (type 6)))
+              (alias export 1 "utxo" (type (;7;)))
+              (import "beta-utxo" (type (;8;) (eq 7)))
+              (type (;9;) (borrow 8))
+              (type (;10;) (func (param "p" 3) (param "q" 9) (result u64)))
+              (export (;2;) "diff-types" (func (type 10)))
+              (type (;11;)
+                (instance
+                  (type (;0;) (tuple u64 u64 u64 u64))
+                  (type (;1;) (func (param "hash" 0)))
+                  (export (;0;) "implements-method" (func (type 1)))
+                )
+              )
+              (import "starstream:std/builtin" (instance (;2;) (type 11)))
+              (type (;12;)
+                (instance
+                  (export (;0;) "utxo" (type (sub resource)))
+                  (type (;1;) (own 0))
+                  (type (;2;) (func (param "start" u64) (result 1)))
+                  (export (;0;) "[static]utxo.new" (func (type 2)))
+                  (type (;3;) (record (field "yield" s32) (field "a" s64) (field "yield1" s64) (field "yield1-v1" s32)))
+                  (export (;4;) "storage" (type (eq 3)))
+                  (type (;5;) (borrow 0))
+                  (type (;6;) (func (param "self" 5) (result 4)))
+                  (export (;1;) "get-storage" (func (type 6)))
+                  (type (;7;) (func (param "storage" 4) (result 1)))
+                  (export (;2;) "set-storage" (func (type 7)))
+                )
+              )
+              (export (;3;) "alpha" (instance (type 12)))
+              (type (;13;)
+                (instance
+                  (export (;0;) "utxo" (type (sub resource)))
+                  (type (;1;) (own 0))
+                  (type (;2;) (func (param "start" u64) (result 1)))
+                  (export (;0;) "[static]utxo.new" (func (type 2)))
+                  (type (;3;) (record (field "yield" s32) (field "b" s64) (field "yield2" s64) (field "yield2-v1" s32)))
+                  (export (;4;) "storage" (type (eq 3)))
+                  (type (;5;) (borrow 0))
+                  (type (;6;) (func (param "self" 5) (result 4)))
+                  (export (;1;) "get-storage" (func (type 6)))
+                  (type (;7;) (func (param "storage" 4) (result 1)))
+                  (export (;2;) "set-storage" (func (type 7)))
+                )
+              )
+              (export (;4;) "beta" (instance (type 13)))
+            )
+          )
+          (export (;0;) "my-namespace:my-package/my-world" (component (type 0)))
+        )
+      )
+      (export (;1;) "x" (type 0))
+    )
+  )
+)
+
+==== WIT ====
+package root:component;
+
+world root {
+  import starstream:coordination/alpha;
+  import starstream:coordination/beta;
+  import starstream:std/builtin;
+  use starstream:coordination/alpha.{utxo as alpha-utxo};
+  use starstream:coordination/beta.{utxo as beta-utxo};
+
+  export use-one: func(x: borrow<alpha-utxo>) -> u64;
+  export same-type: func(x: borrow<alpha-utxo>, y: borrow<alpha-utxo>) -> u64;
+  export diff-types: func(p: borrow<alpha-utxo>, q: borrow<beta-utxo>) -> u64;
+  export alpha: interface {
+    resource utxo {
+      new: static func(start: u64) -> utxo;
+    }
+
+    record storage {
+      yield: s32,
+      a: s64,
+      yield1: s64,
+      yield1-v1: s32,
+    }
+
+    get-storage: func(self: borrow<utxo>) -> storage;
+
+    set-storage: func(storage: storage) -> utxo;
+  }
+  export beta: interface {
+    resource utxo {
+      new: static func(start: u64) -> utxo;
+    }
+
+    record storage {
+      yield: s32,
+      b: s64,
+      yield2: s64,
+      yield2-v1: s32,
+    }
+
+    get-storage: func(self: borrow<utxo>) -> storage;
+
+    set-storage: func(storage: storage) -> utxo;
+  }
+}
+package starstream:coordination {
+  interface alpha {
+    resource utxo;
+  }
+  interface beta {
+    resource utxo;
+  }
+}
+
+
+package starstream:std {
+  interface builtin {
+    implements-method: func(hash: tuple<u64, u64, u64, u64>);
+  }
+}

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
@@ -152,15 +152,24 @@ TypedProgram {
           (type (;0;)
             (component
               (import "utxo" (type (;0;) (sub resource)))
-              (type (;1;) (borrow 0))
-              (type (;2;) (func (param "utxo" 1) (param "my-utxo" 1)))
-              (export (;0;) "script-accepts-utxos" (func (type 2)))
-              (type (;3;)
+              (type (;1;)
                 (instance
                   (export (;0;) "utxo" (type (sub resource)))
                 )
               )
-              (export (;0;) "my-utxo" (instance (type 3)))
+              (import "starstream:coordination/my-utxo" (instance (;0;) (type 1)))
+              (alias export 0 "utxo" (type (;2;)))
+              (import "my-utxo-utxo" (type (;3;) (eq 2)))
+              (type (;4;) (borrow 0))
+              (type (;5;) (borrow 3))
+              (type (;6;) (func (param "utxo" 4) (param "my-utxo" 5)))
+              (export (;0;) "script-accepts-utxos" (func (type 6)))
+              (type (;7;)
+                (instance
+                  (export (;0;) "utxo" (type (sub resource)))
+                )
+              )
+              (export (;1;) "my-utxo" (instance (type 7)))
             )
           )
           (export (;0;) "my-namespace:my-package/my-world" (component (type 0)))
@@ -175,10 +184,18 @@ TypedProgram {
 package root:component;
 
 world root {
+  import starstream:coordination/my-utxo;
+  use starstream:coordination/my-utxo.{utxo as my-utxo-utxo};
+
   resource utxo;
 
-  export script-accepts-utxos: func(utxo: borrow<utxo>, my-utxo: borrow<utxo>);
+  export script-accepts-utxos: func(utxo: borrow<utxo>, my-utxo: borrow<my-utxo-utxo>);
   export my-utxo: interface {
+    resource utxo;
+  }
+}
+package starstream:coordination {
+  interface my-utxo {
     resource utxo;
   }
 }


### PR DESCRIPTION
A `script fn` that references a UTXO type is a world-root export whose parameters must borrow the UTXO's `utxo` resource. Previously the named UTXO type resolved to the *exported* instance's resource index, which is only valid inside that instance's type-index space, not at the world root. The generated component-type custom section was therefore invalid: a typed-UTXO script parameter referenced an out-of-scope type (`unknown type 0`), so componentization failed. When an untyped `Utxo` happened to also be present, the typed parameter silently aliased the untyped world-root `utxo` resource instead, collapsing distinct UTXO types together.

Resolve named UTXO types by scope. At the world root (coordination script signatures) each referenced UTXO type is now imported as a named component instance (`starstream:coordination/<utxo>`) mirroring its exported interface, and its `utxo` resource is aliased/`use`d into the world under a unique name (`<utxo>-utxo`). Script parameters borrow that per-type resource, so two parameters of the same UTXO type share one import while different UTXO types get distinct imports (type identity disambiguates them). Inside exported UTXO instances, named resources still resolve to the instance-local resource as before.

Add a `coordination_script.star` snapshot input exercising a single typed-UTXO parameter, two parameters of the same type, and parameters of two different types; update the `utxo_types.star` snapshot, where the typed parameter now correctly binds to its own imported resource rather than the untyped `Utxo` world resource.

Assisted-by: anthropic:claude-opus-4-8