### PR TITLE
Remove deprecated baseUrl and approve tree-sitter install scripts

### DIFF
--- a/tree-sitter-starstream/package.json
+++ b/tree-sitter-starstream/package.json
@@ -45,5 +45,9 @@
     "prestart": "tree-sitter build --wasm",
     "start": "tree-sitter playground",
     "test": "node --test bindings/node/*_test.js"
+  },
+  "allowScripts": {
+    "tree-sitter@0.25.0": true,
+    "tree-sitter-cli@0.26.9": true
   }
 }

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -2,7 +2,6 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
     "strictNullChecks": true,
     "noImplicitAny": true,
     "types": ["webpack/module"]


### PR DESCRIPTION
Some things that Typescript 7 and NPM 12.0 are complaining about.

> Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
> Visit https://aka.ms/ts6 for migration information.