### PR TITLE
feat: add `utxo` resource import support

### DIFF
--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -8,7 +8,7 @@ use wasmtime::component::{
     LinkerInstance, ResourceAny, ResourceType, Type, Val, types,
 };
 use wasmtime::error::Context as _;
-use wasmtime::{AsContext, AsContextMut, Engine, Store, StoreContext, StoreContextMut, bail};
+use wasmtime::{AsContextMut, Engine, Store, bail};
 
 pub mod bindings {
     wasmtime::component::bindgen!({
@@ -21,6 +21,9 @@ pub mod bindings {
                 import starstream:std/cardano;
             }
         ",
+        with: {
+            "starstream:std/builtin.utxo": crate::Utxo,
+        },
         imports: {
             "starstream:std/builtin.implements-method": tracing | trappable,
             default: tracing,
@@ -30,6 +33,7 @@ pub mod bindings {
 
 pub trait Host:
     bindings::starstream::std::builtin::Host
+    + bindings::starstream::std::builtin::HostUtxo
     + bindings::starstream::std::cardano::Host
     + EventHandler
     + 'static
@@ -38,6 +42,7 @@ pub trait Host:
 
 impl<T> Host for T where
     T: bindings::starstream::std::builtin::Host
+        + bindings::starstream::std::builtin::HostUtxo
         + bindings::starstream::std::cardano::Host
         + EventHandler
         + 'static
@@ -543,7 +548,7 @@ impl<T: Host> Contract<T> {
             use core::marker::PhantomData;
 
             use tracing::{error, trace};
-            use wasmtime::DebugEvent;
+            use wasmtime::{DebugEvent, StoreContextMut};
 
             struct DebugHandler<T>(PhantomData<fn() -> T>);
 
@@ -598,65 +603,57 @@ impl<T: Host> Contract<T> {
     #[instrument(level = "trace", skip_all)]
     fn construct_utxo(
         &self,
-        mut store: Store<T>,
+        store: &mut Store<T>,
         name: impl ExportLookup,
         params: impl AsRef<[Val]>,
-    ) -> wasmtime::Result<Utxo<T>> {
-        let instance = self.instantiate(&mut store)?;
+    ) -> wasmtime::Result<Utxo> {
+        let instance = self.instantiate(store)?;
         let f = instance
-            .get_func(&mut store, name)
+            .get_func(&mut *store, name)
             .context("failed to lookup constructor function export")?;
         debug!("calling constructor function");
         let mut results = [Val::Bool(false)];
-        f.call(&mut store, params.as_ref(), &mut results)
+        f.call(store, params.as_ref(), &mut results)
             .context("failed to call constructor function")?;
         let [Val::Resource(resource)] = results else {
             bail!("invalid return value")
         };
-        Ok(Utxo {
-            store,
-            instance,
-            resource,
-        })
+        Ok(Utxo { instance, resource })
     }
 
     #[instrument(level = "trace", skip_all)]
     #[cfg(feature = "async")]
     async fn construct_utxo_async(
         &self,
-        mut store: Store<T>,
+        store: &mut Store<T>,
         name: impl ExportLookup,
         params: impl AsRef<[Val]>,
-    ) -> wasmtime::Result<Utxo<T>>
+    ) -> wasmtime::Result<Utxo>
     where
         T: Send,
     {
-        let instance = self.instantiate_async(&mut store).await?;
+        let instance = self.instantiate_async(store).await?;
         let f = instance
-            .get_func(&mut store, name)
+            .get_func(&mut *store, name)
             .context("failed to lookup constructor function export")?;
         debug!("calling constructor function");
         let mut results = [Val::Bool(false)];
-        f.call_async(&mut store, params.as_ref(), &mut results)
+        f.call_async(&mut *store, params.as_ref(), &mut results)
             .await
             .context("failed to call constructor function")?;
         let [Val::Resource(resource)] = results else {
             bail!("invalid return value")
         };
-        Ok(Utxo {
-            store,
-            instance,
-            resource,
-        })
+        Ok(Utxo { instance, resource })
     }
 
     #[instrument(level = "trace", skip_all)]
     pub fn create_utxo(
         &self,
-        store: Store<T>,
+        store: &mut Store<T>,
         ConstructorExport { idx, .. }: &ConstructorExport,
         params: impl AsRef<[Val]>,
-    ) -> wasmtime::Result<Utxo<T>> {
+    ) -> wasmtime::Result<Utxo> {
         self.construct_utxo(store, idx, params)
     }
 
@@ -664,10 +661,10 @@ impl<T: Host> Contract<T> {
     #[cfg(feature = "async")]
     pub async fn create_utxo_async(
         &self,
-        store: Store<T>,
+        store: &mut Store<T>,
         ConstructorExport { idx, .. }: &ConstructorExport,
         params: impl AsRef<[Val]>,
-    ) -> wasmtime::Result<Utxo<T>>
+    ) -> wasmtime::Result<Utxo>
     where
         T: Send,
     {
@@ -677,10 +674,10 @@ impl<T: Host> Contract<T> {
     #[instrument(level = "trace", skip_all)]
     pub fn load_utxo(
         &self,
-        store: Store<T>,
+        store: &mut Store<T>,
         UtxoStorageExport { set, .. }: &UtxoStorageExport,
         fields: impl Into<Vec<(String, Val)>>,
-    ) -> wasmtime::Result<Utxo<T>> {
+    ) -> wasmtime::Result<Utxo> {
         self.construct_utxo(store, set, [Val::Record(fields.into())])
     }
 
@@ -688,10 +685,10 @@ impl<T: Host> Contract<T> {
     #[cfg(feature = "async")]
     pub async fn load_utxo_async(
         &self,
-        store: Store<T>,
+        store: &mut Store<T>,
         UtxoStorageExport { set, .. }: &UtxoStorageExport,
         fields: impl Into<Vec<(String, Val)>>,
-    ) -> wasmtime::Result<Utxo<T>>
+    ) -> wasmtime::Result<Utxo>
     where
         T: Send,
     {
@@ -807,125 +804,93 @@ impl CoordinationScriptExport {
     }
 }
 
-pub struct Utxo<T: 'static> {
-    store: Store<T>,
+pub struct Utxo {
     instance: Instance,
     resource: ResourceAny,
 }
 
-impl<T: 'static> AsContext for Utxo<T> {
-    type Data = T;
-
-    fn as_context(&self) -> StoreContext<'_, Self::Data> {
-        self.store.as_context()
-    }
-}
-
-impl<T: 'static> AsContextMut for Utxo<T> {
-    fn as_context_mut(&mut self) -> StoreContextMut<'_, Self::Data> {
-        self.store.as_context_mut()
-    }
-}
-
-impl<T: 'static> Utxo<T> {
-    pub fn store(&mut self) -> &mut Store<T> {
-        &mut self.store
-    }
-
+impl Utxo {
     #[must_use]
     pub fn resource(&self) -> ResourceAny {
         self.resource
     }
 
-    pub fn storage(&mut self, export: &UtxoStorageExport) -> UtxoStorage<'_, T> {
+    pub fn storage(&self, export: &UtxoStorageExport) -> UtxoStorage<'_> {
         UtxoStorage {
             utxo: self,
             get: export.get,
         }
     }
 
-    fn get_function_export(&mut self, name: impl ExportLookup) -> wasmtime::Result<Func> {
+    fn get_function_export(
+        &self,
+        store: impl AsContextMut,
+        name: impl ExportLookup,
+    ) -> wasmtime::Result<Func> {
         self.instance
-            .get_func(&mut self.store, name)
+            .get_func(store, name)
             .context("function export not found")
     }
 
     #[instrument(level = "trace", skip_all)]
     pub fn call(
-        &mut self,
+        &self,
+        mut store: impl AsContextMut,
         export: &MethodExport,
         params: impl AsRef<[Val]>,
     ) -> wasmtime::Result<Box<[Val]>> {
-        let f = self.get_function_export(export.idx)?;
+        let f = self.get_function_export(&mut store, export.idx)?;
         let mut results = vec![Val::Bool(false); export.ty.results().len()];
-        f.call(&mut self.store, params.as_ref(), &mut results)
+        f.call(&mut store, params.as_ref(), &mut results)
             .context("failed to call method")?;
         Ok(results.into_boxed_slice())
     }
 
     #[instrument(level = "trace", skip_all)]
     #[cfg(feature = "async")]
-    pub async fn call_async(
-        &mut self,
+    pub async fn call_async<T: Send>(
+        &self,
+        mut store: impl AsContextMut<Data = T>,
         export: &MethodExport,
         params: impl AsRef<[Val]>,
-    ) -> wasmtime::Result<Box<[Val]>>
-    where
-        T: Send,
-    {
-        let f = self.get_function_export(export.idx)?;
+    ) -> wasmtime::Result<Box<[Val]>> {
+        let f = self.get_function_export(&mut store, export.idx)?;
         let mut results = vec![Val::Bool(false); export.ty.results().len()];
-        f.call_async(&mut self.store, params.as_ref(), &mut results)
+        f.call_async(&mut store, params.as_ref(), &mut results)
             .await
             .context("failed to call method")?;
         Ok(results.into_boxed_slice())
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub fn drop(mut self) -> wasmtime::Result<()> {
-        self.resource.resource_drop(&mut self.store)?;
+    pub fn drop(self, mut store: impl AsContextMut) -> wasmtime::Result<()> {
+        self.resource.resource_drop(&mut store)?;
         Ok(())
     }
 
     #[instrument(level = "trace", skip_all)]
     #[cfg(feature = "async")]
-    pub async fn drop_async(mut self) -> wasmtime::Result<()>
-    where
-        T: Send,
-    {
-        self.resource.resource_drop_async(&mut self.store).await?;
+    pub async fn drop_async<T: Send>(
+        self,
+        mut store: impl AsContextMut<Data = T>,
+    ) -> wasmtime::Result<()> {
+        self.resource.resource_drop_async(&mut store).await?;
         Ok(())
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    pub fn into_inner(mut self) -> wasmtime::Result<T> {
-        self.resource.resource_drop(&mut self.store)?;
-        Ok(self.store.into_data())
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    #[cfg(feature = "async")]
-    pub async fn into_inner_async(mut self) -> wasmtime::Result<T>
-    where
-        T: Send,
-    {
-        self.resource.resource_drop_async(&mut self.store).await?;
-        Ok(self.store.into_data())
     }
 }
 
-pub struct UtxoStorage<'a, T: 'static> {
-    utxo: &'a mut Utxo<T>,
+pub struct UtxoStorage<'a> {
+    utxo: &'a Utxo,
     get: ComponentExportIndex,
 }
 
-impl<T: 'static> UtxoStorage<'_, T> {
+impl UtxoStorage<'_> {
     #[instrument(level = "trace", skip_all)]
-    pub fn get(&mut self) -> wasmtime::Result<Vec<(String, Val)>> {
-        let f = self.utxo.get_function_export(self.get)?;
+    pub fn get(&self, mut store: impl AsContextMut) -> wasmtime::Result<Vec<(String, Val)>> {
+        let f = self.utxo.get_function_export(&mut store, self.get)?;
         let mut results = [Val::Bool(false); 1];
         f.call(
-            &mut self.utxo.store,
+            &mut store,
             &[Val::Resource(self.utxo.resource)],
             &mut results,
         )
@@ -938,14 +903,14 @@ impl<T: 'static> UtxoStorage<'_, T> {
 
     #[instrument(level = "trace", skip_all)]
     #[cfg(feature = "async")]
-    pub async fn get_async(&mut self) -> wasmtime::Result<Vec<(String, Val)>>
-    where
-        T: Send,
-    {
-        let f = self.utxo.get_function_export(self.get)?;
+    pub async fn get_async<T: Send>(
+        &self,
+        mut store: impl AsContextMut<Data = T>,
+    ) -> wasmtime::Result<Vec<(String, Val)>> {
+        let f = self.utxo.get_function_export(&mut store, self.get)?;
         let mut results = [Val::Bool(false); 1];
         f.call_async(
-            &mut self.utxo.store,
+            &mut store,
             &[Val::Resource(self.utxo.resource)],
             &mut results,
         )

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -96,17 +96,14 @@ pub fn link_abi_event_function<T: EventHandler>(
     )
 }
 
-/// Link dynamic imported instance in a [`LinkerInstance`].
+/// Link dynamic imported ABI instance in a [`LinkerInstance`].
 #[instrument(level = "trace", skip_all)]
-pub fn link_instance<T: EventHandler>(
+pub fn link_abi_instance<T: EventHandler>(
     engine: &Engine,
     linker: &mut LinkerInstance<T>,
     ty: &types::ComponentInstance,
     instance: &str,
 ) -> wasmtime::Result<()> {
-    if let Some(_utxo) = ty.get_export(engine, "utxo") {
-        bail!("coordination scripts not supported yet")
-    }
     for (name, types::ComponentExtern { ty, .. }) in ty.exports(engine) {
         debug!(name, "linking ABI instance item");
         match ty {
@@ -130,6 +127,71 @@ pub fn link_instance<T: EventHandler>(
         }
     }
     Ok(())
+}
+
+/// Link UTXO [`types::ComponentFunc`] in a [`LinkerInstance`]
+#[instrument(level = "trace", skip_all)]
+pub fn link_utxo_function<T>(
+    linker: &mut LinkerInstance<T>,
+    _ty: types::ComponentFunc,
+    instance: &str,
+    name: &str,
+) -> wasmtime::Result<()> {
+    debug!(instance, name, "linking UTXO instance function");
+    linker.func_new(name, move |_store, _ty, _params, _results| {
+        bail!("calling UTXO functions/methods not supported yet")
+    })
+}
+
+/// Link dynamic imported UTXO instance in a [`LinkerInstance`].
+#[instrument(level = "trace", skip_all)]
+pub fn link_utxo_instance<T>(
+    engine: &Engine,
+    linker: &mut LinkerInstance<T>,
+    ty: &types::ComponentInstance,
+    instance: &str,
+) -> wasmtime::Result<()> {
+    for (name, types::ComponentExtern { ty, .. }) in ty.exports(engine) {
+        debug!(name, "linking UTXO instance item");
+        match ty {
+            types::ComponentItem::ComponentFunc(ty) => {
+                link_utxo_function(linker, ty, instance, name)?;
+            }
+            types::ComponentItem::CoreFunc(..) => {
+                bail!("UTXO instance core function imports unsupported")
+            }
+            types::ComponentItem::Module(..) => bail!("UTXO instance module imports unsupported"),
+            types::ComponentItem::Component(..) => {
+                bail!("UTXO instance component imports unsupported")
+            }
+            types::ComponentItem::ComponentInstance(..) => {
+                bail!("UTXO instance component instance imports unsupported")
+            }
+            types::ComponentItem::Type(..) => {}
+            types::ComponentItem::Resource(..) if name == "utxo" => {
+                linker.resource("utxo", ResourceType::host::<Utxo>(), |_, _| Ok(()))?;
+            }
+            types::ComponentItem::Resource(..) => {
+                bail!("UTXO instance resource imports unsupported")
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Link dynamic imported instance in a [`LinkerInstance`].
+#[instrument(level = "trace", skip_all)]
+pub fn link_instance<T: EventHandler>(
+    engine: &Engine,
+    linker: &mut LinkerInstance<T>,
+    ty: &types::ComponentInstance,
+    instance: &str,
+) -> wasmtime::Result<()> {
+    if ty.get_export(engine, "utxo").is_some() {
+        link_utxo_instance(engine, linker, ty, instance)
+    } else {
+        link_abi_instance(engine, linker, ty, instance)
+    }
 }
 
 /// Link dynamic imports of the contract

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -11,9 +11,9 @@ use starstream_runtime_next::{
     bindings, new_wasmtime_config,
 };
 use starstream_to_wasm::compile;
-use wasmtime::bail;
-use wasmtime::component::Val;
+use wasmtime::component::{Resource, Val};
 use wasmtime::error::Context as _;
+use wasmtime::{Store, bail};
 
 /// Compile a single Starstream contract source to a core Wasm module in-process.
 ///
@@ -48,6 +48,12 @@ struct Ctx {
 impl bindings::starstream::std::builtin::Host for Ctx {
     fn implements_method(&mut self, hash: (u64, u64, u64, u64)) -> wasmtime::Result<()> {
         self.methods.push(hash);
+        Ok(())
+    }
+}
+
+impl bindings::starstream::std::builtin::HostUtxo for Ctx {
+    fn drop(&mut self, _utxo: Resource<Utxo>) -> wasmtime::Result<()> {
         Ok(())
     }
 }
@@ -188,25 +194,27 @@ impl<'a> FromIterator<&'a (String, Val)> for ProgressStorage {
     }
 }
 
-fn get_progress_storage<T>(
-    utxo: &mut Utxo<T>,
+fn get_progress_storage<T: 'static>(
+    store: &mut Store<T>,
+    utxo: &Utxo,
     storage: &UtxoStorageExport,
 ) -> wasmtime::Result<ProgressStorage> {
     let storage = utxo
         .storage(storage)
-        .get()
+        .get(store)
         .context("failed to get storage")?;
     Ok(storage.iter().collect())
 }
 
 #[cfg(feature = "async")]
-async fn get_progress_storage_async<T: Send>(
-    utxo: &mut Utxo<T>,
+async fn get_progress_storage_async<T: Send + 'static>(
+    store: &mut Store<T>,
+    utxo: &Utxo,
     storage: &UtxoStorageExport,
 ) -> wasmtime::Result<ProgressStorage> {
     let storage = utxo
         .storage(storage)
-        .get_async()
+        .get_async(store)
         .await
         .context("failed to get storage")?;
     Ok(storage.iter().collect())
@@ -227,13 +235,15 @@ fn score_sync() -> wasmtime::Result<()> {
     } = assert_progress_utxo(&contract)?;
 
     let utxos: [_; 5] = array::from_fn(|_| {
-        contract
-            .create_utxo(wasmtime::Store::new(&engine, Ctx::default()), &new, [])
-            .expect("failed to construct UTXO")
+        let mut store = Store::new(&engine, Ctx::default());
+        let utxo = contract
+            .create_utxo(&mut store, &new, [])
+            .expect("failed to construct UTXO");
+        (store, utxo)
     });
 
-    for (i, mut utxo) in zip(0.., utxos) {
-        let Ctx { methods, events } = utxo.store().data();
+    for (i, (mut store, utxo)) in zip(0.., utxos) {
+        let Ctx { methods, events } = store.data();
         assert_eq!(methods.as_ref(), *METHODS);
         assert_eq!(events.as_ref(), []);
 
@@ -242,24 +252,36 @@ fn score_sync() -> wasmtime::Result<()> {
             mult,
             r#yield,
             yield1,
-        } = get_progress_storage(&mut utxo, &storage)?;
+        } = get_progress_storage(&mut store, &utxo, &storage)?;
         assert_eq!(chips, 0);
         assert_eq!(mult, 0);
         assert_eq!(r#yield, 1);
         assert_eq!(yield1, 1);
 
         let res = utxo
-            .call(&plus_chips, [Val::Resource(utxo.resource()), Val::U64(i)])
+            .call(
+                &mut store,
+                &plus_chips,
+                [Val::Resource(utxo.resource()), Val::U64(i)],
+            )
             .context("failed to call `plus-chips`")?;
         assert!(res.is_empty());
 
         let res = utxo
-            .call(&plus_mult, [Val::Resource(utxo.resource()), Val::U64(i)])
+            .call(
+                &mut store,
+                &plus_mult,
+                [Val::Resource(utxo.resource()), Val::U64(i)],
+            )
             .context("failed to call `plus-mult`")?;
         assert!(res.is_empty());
 
         let res = utxo
-            .call(&mult_mult, [Val::Resource(utxo.resource()), Val::U64(200)])
+            .call(
+                &mut store,
+                &mult_mult,
+                [Val::Resource(utxo.resource()), Val::U64(200)],
+            )
             .context("failed to call `mult-mult`")?;
         assert!(res.is_empty());
 
@@ -268,18 +290,19 @@ fn score_sync() -> wasmtime::Result<()> {
             mult,
             r#yield,
             yield1,
-        } = get_progress_storage(&mut utxo, &storage)?;
+        } = get_progress_storage(&mut store, &utxo, &storage)?;
         assert_eq!(chips, i as i64);
         assert_eq!(mult, (i * 2) as i64);
         assert_eq!(r#yield, 1);
         assert_eq!(yield1, 1);
 
         let res = utxo
-            .call(&finish, [Val::Resource(utxo.resource())])
+            .call(&mut store, &finish, [Val::Resource(utxo.resource())])
             .context("failed to call `finish`")?;
         assert!(res.is_empty());
 
-        let Ctx { methods, events } = utxo.into_inner().context("failed to drop UTXO")?;
+        utxo.drop(&mut store).context("failed to drop UTXO")?;
+        let Ctx { methods, events } = store.into_data();
         assert_eq!(methods, *METHODS);
         assert_eq!(
             events,
@@ -309,13 +332,19 @@ async fn score_async() -> wasmtime::Result<()> {
     } = assert_progress_utxo(&contract)?;
 
     let [utxo0, utxo1, utxo2, utxo3, utxo4] = array::from_fn(|_| {
-        contract.create_utxo_async(wasmtime::Store::new(&engine, Ctx::default()), &new, [])
+        let mut store = Store::new(&engine, Ctx::default());
+        async {
+            contract
+                .create_utxo_async(&mut store, &new, [])
+                .await
+                .map(|utxo| (store, utxo))
+        }
     });
-    let utxos =
+    let (utxo0, utxo1, utxo2, utxo3, utxo4) =
         tokio::try_join!(utxo0, utxo1, utxo2, utxo3, utxo4).context("failed to construct UTXOs")?;
 
-    for (i, mut utxo) in zip(0.., [utxos.0, utxos.1, utxos.2, utxos.3, utxos.4]) {
-        let Ctx { methods, events } = utxo.store().data();
+    for (i, (mut store, utxo)) in zip(0.., [utxo0, utxo1, utxo2, utxo3, utxo4]) {
+        let Ctx { methods, events } = store.data();
         assert_eq!(methods.as_ref(), *METHODS);
         assert_eq!(events.as_ref(), []);
 
@@ -324,26 +353,38 @@ async fn score_async() -> wasmtime::Result<()> {
             mult,
             r#yield,
             yield1,
-        } = get_progress_storage_async(&mut utxo, &storage).await?;
+        } = get_progress_storage_async(&mut store, &utxo, &storage).await?;
         assert_eq!(chips, 0);
         assert_eq!(mult, 0);
         assert_eq!(r#yield, 1);
         assert_eq!(yield1, 1);
 
         let res = utxo
-            .call_async(&plus_chips, [Val::Resource(utxo.resource()), Val::U64(i)])
+            .call_async(
+                &mut store,
+                &plus_chips,
+                [Val::Resource(utxo.resource()), Val::U64(i)],
+            )
             .await
             .context("failed to call `plus-chips`")?;
         assert!(res.is_empty());
 
         let res = utxo
-            .call_async(&plus_mult, [Val::Resource(utxo.resource()), Val::U64(i)])
+            .call_async(
+                &mut store,
+                &plus_mult,
+                [Val::Resource(utxo.resource()), Val::U64(i)],
+            )
             .await
             .context("failed to call `plus-mult`")?;
         assert!(res.is_empty());
 
         let res = utxo
-            .call_async(&mult_mult, [Val::Resource(utxo.resource()), Val::U64(200)])
+            .call_async(
+                &mut store,
+                &mult_mult,
+                [Val::Resource(utxo.resource()), Val::U64(200)],
+            )
             .await
             .context("failed to call `mult-mult`")?;
         assert!(res.is_empty());
@@ -353,22 +394,22 @@ async fn score_async() -> wasmtime::Result<()> {
             mult,
             r#yield,
             yield1,
-        } = get_progress_storage_async(&mut utxo, &storage).await?;
+        } = get_progress_storage_async(&mut store, &utxo, &storage).await?;
         assert_eq!(chips, i as i64);
         assert_eq!(mult, (i * 2) as i64);
         assert_eq!(r#yield, 1);
         assert_eq!(yield1, 1);
 
         let res = utxo
-            .call_async(&finish, [Val::Resource(utxo.resource())])
+            .call_async(&mut store, &finish, [Val::Resource(utxo.resource())])
             .await
             .context("failed to call `finish`")?;
         assert!(res.is_empty());
 
-        let Ctx { methods, events } = utxo
-            .into_inner_async()
+        utxo.drop_async(&mut store)
             .await
             .context("failed to drop UTXO")?;
+        let Ctx { methods, events } = store.into_data();
         assert_eq!(methods, *METHODS);
         assert_eq!(
             events,

--- a/starstream-to-wasm/wit/builtin.wit
+++ b/starstream-to-wasm/wit/builtin.wit
@@ -3,5 +3,7 @@ package starstream:std;
 /// Core builtins that the Starstream compiler depends on and that (almost) all
 /// Starstream programs require.
 interface builtin {
+    resource utxo {}
+
     implements-method: func(hash: tuple<u64, u64, u64, u64>);
 }


### PR DESCRIPTION
Add `starstream:std/builtin#utxo` resource to `starstream-to-wasm` WIT (assuming the option 1. from #167 for now) and implement it in the runtime.

To facilitate this, trim down the `Utxo` structure, remove the `Store`, making `Utxo` not generic, such that we could use that in the bindgen.