### PR TITLE
feat(rt-next): implement UTXO constructors and methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,13 @@ repository = "https://github.com/LFDT-Nightstream/Starstream"
 license = "MIT/Apache-2.0"
 
 [workspace.dependencies]
+anyhow = { version = "1.0.102", default-features = false }
 ariadne = "0.5.1"
 chumsky = "0.11.1"
 indoc = "2.0"
 insta = "1.43"
 miette = "7.6.0"
+sha2 = "0.10.9"
 serde = "1.0.219"
 serde_json = "1.0"
 starstream-compiler = { path = "starstream-compiler" }
@@ -40,9 +42,11 @@ starstream-runtime-next = { path = "starstream-runtime-next" }
 starstream-to-wasm = { path = "starstream-to-wasm" }
 starstream-types = { path = "starstream-types" }
 thiserror = "2.0.17"
+tokio = { version = "1.47.1", default-features = false }
 tower-lsp-server = { version = "0.22.1", default-features = false, features = [
   "runtime-agnostic",
 ] }
+tracing = { version = "0.1.44", default-features = false }
 wasm-encoder = "0.240.0"
 wasmprinter = "0.240.0"
 wasmparser = "0.240.0"

--- a/starstream-runtime-next/Cargo.toml
+++ b/starstream-runtime-next/Cargo.toml
@@ -14,10 +14,8 @@ wasmtime-custom-fiber = ["wasmtime/custom-fiber"]
 wasmtime-custom-virtual-memory = ["wasmtime/custom-virtual-memory"]
 
 [dependencies]
-anyhow = { version = "1.0.102", default-features = false }
-tracing = { version = "0.1.44", default-features = false, features = [
-    "attributes",
-] }
+anyhow = { workspace = true }
+tracing = { workspace = true, features = ["attributes"] }
 wasmparser = { workspace = true }
 wasmtime = { workspace = true, features = [
     "anyhow",
@@ -28,7 +26,7 @@ wasmtime = { workspace = true, features = [
 wit-component = { workspace = true }
 
 [dev-dependencies]
-sha2 = "0.10.9"
+sha2 = { workspace = true }
 starstream-compiler = { workspace = true }
 starstream-to-wasm = { workspace = true }
-tokio = { version = "1.47.1", features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/starstream-runtime-next/Cargo.toml
+++ b/starstream-runtime-next/Cargo.toml
@@ -8,8 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [features]
-async = ["wasmtime/async"]
-trace = ["async", "wasmtime/debug"]
+trace = ["wasmtime/debug"]
 wasmtime-custom-fiber = ["wasmtime/custom-fiber"]
 wasmtime-custom-virtual-memory = ["wasmtime/custom-virtual-memory"]
 
@@ -19,6 +18,7 @@ tracing = { workspace = true, features = ["attributes"] }
 wasmparser = { workspace = true }
 wasmtime = { workspace = true, features = [
     "anyhow",
+    "async",
     "component-model",
     "cranelift",
     "runtime",

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -1,5 +1,3 @@
-use core::ops::Deref;
-
 use std::sync::Arc;
 
 use tracing::{debug, instrument};
@@ -319,14 +317,6 @@ impl<T: 'static> Clone for Contract<T> {
     }
 }
 
-impl<T: 'static> Deref for Contract<T> {
-    type Target = InstancePre<T>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.pre
-    }
-}
-
 impl<T: Host> Contract<T> {
     /// Compile and pre-instantiate a Starstream [Contract]
     #[instrument(level = "trace", skip_all)]
@@ -420,8 +410,8 @@ impl<T: Host> Contract<T> {
             Ok(idx)
         }
 
-        let engine = self.engine();
-        let component = self.component();
+        let engine = self.pre.engine();
+        let component = self.pre.component();
         let instance_idx = component
             .get_export_index(None, name)
             .context("export not found")?;
@@ -460,7 +450,7 @@ impl<T: Host> Contract<T> {
     pub fn get_utxo(&self, name: &str) -> wasmtime::Result<UtxoExport> {
         let types::ComponentExtern { ty, .. } = self
             .ty
-            .get_export(self.engine(), name)
+            .get_export(self.pre.engine(), name)
             .context("export not found")?;
         let types::ComponentItem::ComponentInstance(ty) = ty else {
             bail!("export is not an instance")
@@ -471,7 +461,7 @@ impl<T: Host> Contract<T> {
     /// Iterate over exported UTXOs along with their names
     #[instrument(level = "trace", skip_all)]
     pub fn utxos(&self) -> impl Iterator<Item = (&str, wasmtime::Result<UtxoExport>)> {
-        let engine = self.engine();
+        let engine = self.pre.engine();
         self.ty.exports(engine).filter_map(|(name, ty)| match ty {
             types::ComponentExtern {
                 ty: types::ComponentItem::ComponentInstance(ty),
@@ -489,6 +479,7 @@ impl<T: Host> Contract<T> {
         ty: types::ComponentFunc,
     ) -> wasmtime::Result<ConstructorExport> {
         let idx = self
+            .pre
             .component()
             .get_export_index(Some(&utxo.instance_idx), name)
             .context("export not found")?;
@@ -514,7 +505,7 @@ impl<T: Host> Contract<T> {
     ) -> wasmtime::Result<ConstructorExport> {
         let types::ComponentExtern { ty, .. } = utxo
             .instance_ty
-            .get_export(self.engine(), name)
+            .get_export(self.pre.engine(), name)
             .context("export not found")?;
         let types::ComponentItem::ComponentFunc(ty) = ty else {
             bail!("export is not a function")
@@ -529,7 +520,7 @@ impl<T: Host> Contract<T> {
         utxo: &'a UtxoExport,
     ) -> impl Iterator<Item = (&'a str, wasmtime::Result<ConstructorExport>)> {
         utxo.instance_ty
-            .exports(self.engine())
+            .exports(self.pre.engine())
             .filter_map(move |(name, ty)| match ty {
                 types::ComponentExtern {
                     ty: types::ComponentItem::ComponentFunc(ty),
@@ -549,6 +540,7 @@ impl<T: Host> Contract<T> {
         ty: types::ComponentFunc,
     ) -> wasmtime::Result<MethodExport> {
         let idx = self
+            .pre
             .component()
             .get_export_index(Some(&utxo.instance_idx), name)
             .context("export not found")?;
@@ -566,7 +558,7 @@ impl<T: Host> Contract<T> {
     pub fn get_utxo_method(&self, utxo: &UtxoExport, name: &str) -> wasmtime::Result<MethodExport> {
         let types::ComponentExtern { ty, .. } = utxo
             .instance_ty
-            .get_export(self.engine(), name)
+            .get_export(self.pre.engine(), name)
             .context("export not found")?;
         let types::ComponentItem::ComponentFunc(ty) = ty else {
             bail!("export is not a function")
@@ -581,7 +573,7 @@ impl<T: Host> Contract<T> {
         utxo: &'a UtxoExport,
     ) -> impl Iterator<Item = (&'a str, wasmtime::Result<MethodExport>)> {
         utxo.instance_ty
-            .exports(self.engine())
+            .exports(self.pre.engine())
             .filter_map(move |(name, ty)| match ty {
                 types::ComponentExtern {
                     ty: types::ComponentItem::ComponentFunc(ty),
@@ -600,6 +592,7 @@ impl<T: Host> Contract<T> {
         ty: types::ComponentFunc,
     ) -> wasmtime::Result<CoordinationScriptExport> {
         let idx = self
+            .pre
             .component()
             .get_export_index(None, name)
             .context("export not found")?;
@@ -614,7 +607,7 @@ impl<T: Host> Contract<T> {
     ) -> wasmtime::Result<CoordinationScriptExport> {
         let types::ComponentExtern { ty, .. } = self
             .ty
-            .get_export(self.engine(), name)
+            .get_export(self.pre.engine(), name)
             .context("export not found")?;
         let types::ComponentItem::ComponentFunc(ty) = ty else {
             bail!("export is not a function")
@@ -627,7 +620,7 @@ impl<T: Host> Contract<T> {
     pub fn coordination_scripts(
         &self,
     ) -> impl Iterator<Item = (&str, wasmtime::Result<CoordinationScriptExport>)> {
-        let engine = self.engine();
+        let engine = self.pre.engine();
         self.ty.exports(engine).filter_map(|(name, ty)| match ty {
             types::ComponentExtern {
                 ty: types::ComponentItem::ComponentFunc(ty),
@@ -639,17 +632,7 @@ impl<T: Host> Contract<T> {
 
     /// Instantiate the contract
     #[instrument(level = "trace", skip_all)]
-    fn instantiate(&self, store: &mut Store<T>) -> wasmtime::Result<Instance> {
-        debug!("instantiating component");
-        self.pre
-            .instantiate(store)
-            .context("failed to instantiate component")
-    }
-
-    /// Same as [Self::instantiate], but async
-    #[instrument(level = "trace", skip_all)]
-    #[cfg(feature = "async")]
-    async fn instantiate_async(&self, store: &mut Store<T>) -> wasmtime::Result<Instance>
+    async fn instantiate(&self, store: &mut Store<T>) -> wasmtime::Result<Instance>
     where
         T: Send,
     {
@@ -711,29 +694,7 @@ impl<T: Host> Contract<T> {
     }
 
     #[instrument(level = "trace", skip_all)]
-    fn construct_utxo(
-        &self,
-        store: &mut Store<T>,
-        name: impl ExportLookup,
-        params: impl AsRef<[Val]>,
-    ) -> wasmtime::Result<Utxo> {
-        let instance = self.instantiate(store)?;
-        let f = instance
-            .get_func(&mut *store, name)
-            .context("failed to lookup constructor function export")?;
-        debug!("calling constructor function");
-        let mut results = [Val::Bool(false)];
-        f.call(store, params.as_ref(), &mut results)
-            .context("failed to call constructor function")?;
-        let [Val::Resource(resource)] = results else {
-            bail!("invalid return value")
-        };
-        Ok(Utxo { instance, resource })
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    #[cfg(feature = "async")]
-    async fn construct_utxo_async(
+    async fn construct_utxo(
         &self,
         store: &mut Store<T>,
         name: impl ExportLookup,
@@ -742,7 +703,7 @@ impl<T: Host> Contract<T> {
     where
         T: Send,
     {
-        let instance = self.instantiate_async(store).await?;
+        let instance = self.instantiate(store).await?;
         let f = instance
             .get_func(&mut *store, name)
             .context("failed to lookup constructor function export")?;
@@ -758,18 +719,7 @@ impl<T: Host> Contract<T> {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub fn create_utxo(
-        &self,
-        store: &mut Store<T>,
-        ConstructorExport { idx, .. }: &ConstructorExport,
-        params: impl AsRef<[Val]>,
-    ) -> wasmtime::Result<Utxo> {
-        self.construct_utxo(store, idx, params)
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    #[cfg(feature = "async")]
-    pub async fn create_utxo_async(
+    pub async fn create_utxo(
         &self,
         store: &mut Store<T>,
         ConstructorExport { idx, .. }: &ConstructorExport,
@@ -778,54 +728,25 @@ impl<T: Host> Contract<T> {
     where
         T: Send,
     {
-        self.construct_utxo_async(store, idx, params).await
+        self.construct_utxo(store, idx, params).await
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub fn load_utxo(
+    pub async fn load_utxo(
         &self,
         store: &mut Store<T>,
         UtxoStorageExport { set, .. }: &UtxoStorageExport,
         fields: impl Into<Vec<(String, Val)>>,
-    ) -> wasmtime::Result<Utxo> {
+    ) -> wasmtime::Result<Utxo>
+    where
+        T: Send,
+    {
         self.construct_utxo(store, set, [Val::Record(fields.into())])
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    #[cfg(feature = "async")]
-    pub async fn load_utxo_async(
-        &self,
-        store: &mut Store<T>,
-        UtxoStorageExport { set, .. }: &UtxoStorageExport,
-        fields: impl Into<Vec<(String, Val)>>,
-    ) -> wasmtime::Result<Utxo>
-    where
-        T: Send,
-    {
-        self.construct_utxo_async(store, set, [Val::Record(fields.into())])
             .await
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub fn call_coordination_script(
-        &self,
-        mut store: &mut Store<T>,
-        CoordinationScriptExport { idx, .. }: &CoordinationScriptExport,
-        params: impl AsRef<[Val]>,
-    ) -> wasmtime::Result<()> {
-        let instance = self.instantiate(store)?;
-        let f = instance
-            .get_func(&mut store, idx)
-            .context("failed to lookup coordination script export")?;
-        debug!("calling coordination script");
-        f.call(&mut store, params.as_ref(), &mut [])
-            .context("failed to call coordination script")?;
-        Ok(())
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    #[cfg(feature = "async")]
-    pub async fn call_coordination_script_async(
+    pub async fn call_coordination_script(
         &self,
         mut store: &mut Store<T>,
         CoordinationScriptExport { idx, .. }: &CoordinationScriptExport,
@@ -834,7 +755,7 @@ impl<T: Host> Contract<T> {
     where
         T: Send,
     {
-        let instance = self.instantiate_async(store).await?;
+        let instance = self.instantiate(store).await?;
         let f = instance
             .get_func(&mut store, idx)
             .context("failed to lookup coordination script export")?;
@@ -944,22 +865,7 @@ impl Utxo {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub fn call(
-        &self,
-        mut store: impl AsContextMut,
-        export: &MethodExport,
-        params: impl AsRef<[Val]>,
-    ) -> wasmtime::Result<Box<[Val]>> {
-        let f = self.get_function_export(&mut store, export.idx)?;
-        let mut results = vec![Val::Bool(false); export.ty.results().len()];
-        f.call(&mut store, params.as_ref(), &mut results)
-            .context("failed to call method")?;
-        Ok(results.into_boxed_slice())
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    #[cfg(feature = "async")]
-    pub async fn call_async<T: Send>(
+    pub async fn call<T: Send>(
         &self,
         mut store: impl AsContextMut<Data = T>,
         export: &MethodExport,
@@ -974,14 +880,7 @@ impl Utxo {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub fn drop(self, mut store: impl AsContextMut) -> wasmtime::Result<()> {
-        self.resource.resource_drop(&mut store)?;
-        Ok(())
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    #[cfg(feature = "async")]
-    pub async fn drop_async<T: Send>(
+    pub async fn drop<T: Send>(
         self,
         mut store: impl AsContextMut<Data = T>,
     ) -> wasmtime::Result<()> {
@@ -997,24 +896,7 @@ pub struct UtxoStorage<'a> {
 
 impl UtxoStorage<'_> {
     #[instrument(level = "trace", skip_all)]
-    pub fn get(&self, mut store: impl AsContextMut) -> wasmtime::Result<Vec<(String, Val)>> {
-        let f = self.utxo.get_function_export(&mut store, self.get)?;
-        let mut results = [Val::Bool(false); 1];
-        f.call(
-            &mut store,
-            &[Val::Resource(self.utxo.resource)],
-            &mut results,
-        )
-        .context("failed to call function")?;
-        let [Val::Record(vs)] = results else {
-            bail!("invalid return value")
-        };
-        Ok(vs)
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    #[cfg(feature = "async")]
-    pub async fn get_async<T: Send>(
+    pub async fn get<T: Send>(
         &self,
         mut store: impl AsContextMut<Data = T>,
     ) -> wasmtime::Result<Vec<(String, Val)>> {

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -5,10 +5,10 @@ use std::sync::Arc;
 use tracing::{debug, instrument};
 use wasmtime::component::{
     Component, ComponentExportIndex, ExportLookup, Func, HasSelf, Instance, InstancePre, Linker,
-    LinkerInstance, ResourceAny, ResourceType, Type, Val, types,
+    LinkerInstance, ResourceAny, ResourceTable, ResourceType, Type, Val, types,
 };
 use wasmtime::error::Context as _;
-use wasmtime::{AsContextMut, Engine, Store, bail};
+use wasmtime::{AsContextMut, Engine, Store, StoreContextMut, bail, ensure};
 
 pub mod bindings {
     wasmtime::component::bindgen!({
@@ -36,6 +36,7 @@ pub trait Host:
     + bindings::starstream::std::builtin::HostUtxo
     + bindings::starstream::std::cardano::Host
     + EventHandler
+    + UtxoHandler
     + 'static
 {
 }
@@ -45,8 +46,23 @@ impl<T> Host for T where
         + bindings::starstream::std::builtin::HostUtxo
         + bindings::starstream::std::cardano::Host
         + EventHandler
+        + UtxoHandler
         + 'static
 {
+}
+
+/// Utxo handler
+pub trait UtxoHandler: Send {
+    fn table(&mut self) -> &mut ResourceTable;
+
+    fn construct_utxo(
+        store: StoreContextMut<Self>,
+        instance: &str,
+        name: &str,
+        params: &[Val],
+    ) -> impl Future<Output = wasmtime::Result<Utxo>> + Send
+    where
+        Self: Sized;
 }
 
 /// ABI event handler
@@ -131,21 +147,69 @@ pub fn link_abi_instance<T: EventHandler>(
 
 /// Link UTXO [`types::ComponentFunc`] in a [`LinkerInstance`]
 #[instrument(level = "trace", skip_all)]
-pub fn link_utxo_function<T>(
+pub fn link_utxo_function<T: UtxoHandler>(
     linker: &mut LinkerInstance<T>,
-    _ty: types::ComponentFunc,
+    ty: types::ComponentFunc,
     instance: &str,
     name: &str,
 ) -> wasmtime::Result<()> {
     debug!(instance, name, "linking UTXO instance function");
-    linker.func_new(name, move |_store, _ty, _params, _results| {
-        bail!("calling UTXO functions/methods not supported yet")
-    })
+    let instance = Arc::<str>::from(instance);
+    let name = Arc::<str>::from(name);
+    match name.split_once(']') {
+        Some(("[static", ..)) => {
+            let (Some(Type::Own(..)), None) = ({
+                let mut result_tys = ty.results();
+                (result_tys.next(), result_tys.next())
+            }) else {
+                bail!("function does not return a single resource value")
+            };
+            linker.func_new_async(
+                &Arc::clone(&name),
+                move |mut store, _ty, params, results| {
+                    let instance = Arc::clone(&instance);
+                    let name = Arc::clone(&name);
+                    Box::new(async move {
+                        ensure!(results.len() == 1);
+                        let utxo =
+                            T::construct_utxo(store.as_context_mut(), &instance, &name, params)
+                                .await?;
+                        let utxo = store.data_mut().table().push(utxo)?;
+                        let utxo = utxo.try_into_resource_any(store)?;
+                        results[0] = Val::Resource(utxo);
+                        Ok(())
+                    })
+                },
+            )
+        }
+        Some(("[method", ..)) => {
+            let Some((_, Type::Borrow(..))) = ty.params().next() else {
+                bail!("function does not take borrowed resource type as first parameter");
+            };
+            linker.func_new_async(
+                &Arc::clone(&name),
+                move |mut store, _ty, params, results| {
+                    let name = Arc::clone(&name);
+                    Box::new(async move {
+                        let Some(Val::Resource(utxo)) = params.first() else {
+                            bail!("first parameter is not a resource")
+                        };
+                        let utxo = utxo.try_into_resource::<Utxo>(&mut store)?;
+                        let utxo = store.data_mut().table().get(&utxo).copied()?;
+                        let f = utxo.get_function_export(&mut store, &*name)?;
+                        f.call_async(&mut store, params, results).await?;
+                        Ok(())
+                    })
+                },
+            )
+        }
+        _ => bail!("unexpected UTXO instance function import `{name}` from instance `{instance}`"),
+    }
 }
 
 /// Link dynamic imported UTXO instance in a [`LinkerInstance`].
 #[instrument(level = "trace", skip_all)]
-pub fn link_utxo_instance<T>(
+pub fn link_utxo_instance<T: UtxoHandler>(
     engine: &Engine,
     linker: &mut LinkerInstance<T>,
     ty: &types::ComponentInstance,
@@ -181,7 +245,7 @@ pub fn link_utxo_instance<T>(
 
 /// Link dynamic imported instance in a [`LinkerInstance`].
 #[instrument(level = "trace", skip_all)]
-pub fn link_instance<T: EventHandler>(
+pub fn link_instance<T: Host>(
     engine: &Engine,
     linker: &mut LinkerInstance<T>,
     ty: &types::ComponentInstance,
@@ -196,7 +260,7 @@ pub fn link_instance<T: EventHandler>(
 
 /// Link dynamic imports of the contract
 #[instrument(level = "trace", skip_all)]
-pub fn link_dynamic_imports<T: EventHandler>(
+pub fn link_dynamic_imports<T: Host>(
     engine: &Engine,
     linker: &mut Linker<T>,
     ty: &types::Component,
@@ -488,7 +552,6 @@ impl<T: Host> Contract<T> {
             .component()
             .get_export_index(Some(&utxo.instance_idx), name)
             .context("export not found")?;
-
         let Some((_, Type::Borrow(resource_ty))) = ty.params().next() else {
             bail!("function does not take borrowed resource type as first parameter");
         };
@@ -540,7 +603,6 @@ impl<T: Host> Contract<T> {
             .component()
             .get_export_index(None, name)
             .context("export not found")?;
-
         Ok(CoordinationScriptExport { ty, idx })
     }
 
@@ -596,7 +658,7 @@ impl<T: Host> Contract<T> {
             use core::marker::PhantomData;
 
             use tracing::{error, trace};
-            use wasmtime::{DebugEvent, StoreContextMut};
+            use wasmtime::DebugEvent;
 
             struct DebugHandler<T>(PhantomData<fn() -> T>);
 
@@ -852,6 +914,7 @@ impl CoordinationScriptExport {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct Utxo {
     instance: Instance,
     resource: ResourceAny,

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -54,7 +54,7 @@ pub trait EventHandler {
     fn emit_event(&mut self, instance: &str, name: &str, params: &[Val]);
 }
 
-fn componentize(wasm: impl AsRef<[u8]>) -> anyhow::Result<Vec<u8>> {
+pub fn componentize(wasm: impl AsRef<[u8]>) -> anyhow::Result<Vec<u8>> {
     use anyhow::Context as _;
 
     wit_component::ComponentEncoder::default()
@@ -408,15 +408,12 @@ impl<T: Host> Contract<T> {
     #[instrument(level = "trace", skip_all)]
     pub fn utxos(&self) -> impl Iterator<Item = (&str, wasmtime::Result<UtxoExport>)> {
         let engine = self.engine();
-        self.ty.exports(engine).filter_map(|(name, ty)| {
-            let types::ComponentExtern {
+        self.ty.exports(engine).filter_map(|(name, ty)| match ty {
+            types::ComponentExtern {
                 ty: types::ComponentItem::ComponentInstance(ty),
                 ..
-            } = ty
-            else {
-                return None;
-            };
-            Some((name, self.get_utxo_typed(name, ty)))
+            } => Some((name, self.get_utxo_typed(name, ty))),
+            _ => None,
         })
     }
 
@@ -469,18 +466,14 @@ impl<T: Host> Contract<T> {
     ) -> impl Iterator<Item = (&'a str, wasmtime::Result<ConstructorExport>)> {
         utxo.instance_ty
             .exports(self.engine())
-            .filter_map(move |(name, ty)| {
-                let types::ComponentExtern {
+            .filter_map(move |(name, ty)| match ty {
+                types::ComponentExtern {
                     ty: types::ComponentItem::ComponentFunc(ty),
                     ..
-                } = ty
-                else {
-                    return None;
-                };
-                if !name.starts_with("[static]") {
-                    return None;
+                } if name.starts_with("[static]") => {
+                    Some((name, self.get_utxo_constructor_typed(utxo, name, ty)))
                 }
-                Some((name, self.get_utxo_constructor_typed(utxo, name, ty)))
+                _ => None,
             })
     }
 
@@ -526,18 +519,14 @@ impl<T: Host> Contract<T> {
     ) -> impl Iterator<Item = (&'a str, wasmtime::Result<MethodExport>)> {
         utxo.instance_ty
             .exports(self.engine())
-            .filter_map(move |(name, ty)| {
-                let types::ComponentExtern {
+            .filter_map(move |(name, ty)| match ty {
+                types::ComponentExtern {
                     ty: types::ComponentItem::ComponentFunc(ty),
                     ..
-                } = ty
-                else {
-                    return None;
-                };
-                if !name.starts_with("[method]") {
-                    return None;
+                } if name.starts_with("[method]") => {
+                    Some((name, self.get_utxo_method_typed(utxo, name, ty)))
                 }
-                Some((name, self.get_utxo_method_typed(utxo, name, ty)))
+                _ => None,
             })
     }
 
@@ -577,15 +566,12 @@ impl<T: Host> Contract<T> {
         &self,
     ) -> impl Iterator<Item = (&str, wasmtime::Result<CoordinationScriptExport>)> {
         let engine = self.engine();
-        self.ty.exports(engine).filter_map(|(name, ty)| {
-            let types::ComponentExtern {
+        self.ty.exports(engine).filter_map(|(name, ty)| match ty {
+            types::ComponentExtern {
                 ty: types::ComponentItem::ComponentFunc(ty),
                 ..
-            } = ty
-            else {
-                return None;
-            };
-            Some((name, self.get_coordination_script_typed(name, ty)))
+            } => Some((name, self.get_coordination_script_typed(name, ty))),
+            _ => None,
         })
     }
 

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -213,7 +213,7 @@ impl<'a> FromIterator<&'a (String, Val)> for ProgressStorage {
     }
 }
 
-fn get_progress_storage<T: 'static>(
+async fn get_progress_storage<T: Send + 'static>(
     store: &mut Store<T>,
     utxo: &Utxo,
     storage: &UtxoStorageExport,
@@ -221,127 +221,13 @@ fn get_progress_storage<T: 'static>(
     let storage = utxo
         .storage(storage)
         .get(store)
-        .context("failed to get storage")?;
-    Ok(storage.iter().collect())
-}
-
-#[cfg(feature = "async")]
-async fn get_progress_storage_async<T: Send + 'static>(
-    store: &mut Store<T>,
-    utxo: &Utxo,
-    storage: &UtxoStorageExport,
-) -> wasmtime::Result<ProgressStorage> {
-    let storage = utxo
-        .storage(storage)
-        .get_async(store)
         .await
         .context("failed to get storage")?;
     Ok(storage.iter().collect())
 }
 
-#[test]
-fn score_sync() -> wasmtime::Result<()> {
-    let engine = wasmtime::Engine::new(&new_wasmtime_config())?;
-    let contract =
-        Contract::new(&engine, EXAMPLE_SCORE.as_slice()).context("failed to create contract")?;
-    let ProgressUtxo {
-        storage,
-        new,
-        finish,
-        mult_mult,
-        plus_chips,
-        plus_mult,
-    } = assert_progress_utxo(&contract)?;
-
-    let utxos: [_; 5] = array::from_fn(|_| {
-        let mut store = Store::new(&engine, Ctx::default());
-        let utxo = contract
-            .create_utxo(&mut store, &new, [])
-            .expect("failed to construct UTXO");
-        (store, utxo)
-    });
-
-    for (i, (mut store, utxo)) in zip(0.., utxos) {
-        let Ctx {
-            methods, events, ..
-        } = store.data();
-        assert_eq!(methods.as_ref(), *METHODS);
-        assert_eq!(events.as_ref(), []);
-
-        let ProgressStorage {
-            chips,
-            mult,
-            r#yield,
-            yield1,
-        } = get_progress_storage(&mut store, &utxo, &storage)?;
-        assert_eq!(chips, 0);
-        assert_eq!(mult, 0);
-        assert_eq!(r#yield, 1);
-        assert_eq!(yield1, 1);
-
-        let res = utxo
-            .call(
-                &mut store,
-                &plus_chips,
-                [Val::Resource(utxo.resource()), Val::U64(i)],
-            )
-            .context("failed to call `plus-chips`")?;
-        assert!(res.is_empty());
-
-        let res = utxo
-            .call(
-                &mut store,
-                &plus_mult,
-                [Val::Resource(utxo.resource()), Val::U64(i)],
-            )
-            .context("failed to call `plus-mult`")?;
-        assert!(res.is_empty());
-
-        let res = utxo
-            .call(
-                &mut store,
-                &mult_mult,
-                [Val::Resource(utxo.resource()), Val::U64(200)],
-            )
-            .context("failed to call `mult-mult`")?;
-        assert!(res.is_empty());
-
-        let ProgressStorage {
-            chips,
-            mult,
-            r#yield,
-            yield1,
-        } = get_progress_storage(&mut store, &utxo, &storage)?;
-        assert_eq!(chips, i as i64);
-        assert_eq!(mult, (i * 2) as i64);
-        assert_eq!(r#yield, 1);
-        assert_eq!(yield1, 1);
-
-        let res = utxo
-            .call(&mut store, &finish, [Val::Resource(utxo.resource())])
-            .context("failed to call `finish`")?;
-        assert!(res.is_empty());
-
-        utxo.drop(&mut store).context("failed to drop UTXO")?;
-        let Ctx {
-            methods, events, ..
-        } = store.into_data();
-        assert_eq!(methods, *METHODS);
-        assert_eq!(
-            events,
-            [(
-                "starstream:events/score".into(),
-                "finish".into(),
-                [Val::U64(i * i * 2)].into()
-            )]
-        );
-    }
-    Ok(())
-}
-
-#[cfg(feature = "async")]
 #[tokio::test]
-async fn score_async() -> wasmtime::Result<()> {
+async fn score() -> wasmtime::Result<()> {
     let engine = wasmtime::Engine::new(&new_wasmtime_config())?;
     let contract =
         Contract::new(&engine, EXAMPLE_SCORE.as_slice()).context("failed to create contract")?;
@@ -358,7 +244,7 @@ async fn score_async() -> wasmtime::Result<()> {
         let mut store = Store::new(&engine, Ctx::default());
         async {
             contract
-                .create_utxo_async(&mut store, &new, [])
+                .create_utxo(&mut store, &new, [])
                 .await
                 .map(|utxo| (store, utxo))
         }
@@ -378,14 +264,14 @@ async fn score_async() -> wasmtime::Result<()> {
             mult,
             r#yield,
             yield1,
-        } = get_progress_storage_async(&mut store, &utxo, &storage).await?;
+        } = get_progress_storage(&mut store, &utxo, &storage).await?;
         assert_eq!(chips, 0);
         assert_eq!(mult, 0);
         assert_eq!(r#yield, 1);
         assert_eq!(yield1, 1);
 
         let res = utxo
-            .call_async(
+            .call(
                 &mut store,
                 &plus_chips,
                 [Val::Resource(utxo.resource()), Val::U64(i)],
@@ -395,7 +281,7 @@ async fn score_async() -> wasmtime::Result<()> {
         assert!(res.is_empty());
 
         let res = utxo
-            .call_async(
+            .call(
                 &mut store,
                 &plus_mult,
                 [Val::Resource(utxo.resource()), Val::U64(i)],
@@ -405,7 +291,7 @@ async fn score_async() -> wasmtime::Result<()> {
         assert!(res.is_empty());
 
         let res = utxo
-            .call_async(
+            .call(
                 &mut store,
                 &mult_mult,
                 [Val::Resource(utxo.resource()), Val::U64(200)],
@@ -419,21 +305,19 @@ async fn score_async() -> wasmtime::Result<()> {
             mult,
             r#yield,
             yield1,
-        } = get_progress_storage_async(&mut store, &utxo, &storage).await?;
+        } = get_progress_storage(&mut store, &utxo, &storage).await?;
         assert_eq!(chips, i as i64);
         assert_eq!(mult, (i * 2) as i64);
         assert_eq!(r#yield, 1);
         assert_eq!(yield1, 1);
 
         let res = utxo
-            .call_async(&mut store, &finish, [Val::Resource(utxo.resource())])
+            .call(&mut store, &finish, [Val::Resource(utxo.resource())])
             .await
             .context("failed to call `finish`")?;
         assert!(res.is_empty());
 
-        utxo.drop_async(&mut store)
-            .await
-            .context("failed to drop UTXO")?;
+        utxo.drop(&mut store).await.context("failed to drop UTXO")?;
         let Ctx {
             methods, events, ..
         } = store.into_data();

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -7,11 +7,11 @@ use std::sync::LazyLock;
 use sha2::{Digest as _, Sha256};
 use starstream_compiler::{TypecheckOptions, parse_program, typecheck_program};
 use starstream_runtime_next::{
-    ConstructorExport, Contract, EventHandler, Host, MethodExport, Utxo, UtxoStorageExport,
-    bindings, new_wasmtime_config,
+    ConstructorExport, Contract, EventHandler, Host, MethodExport, Utxo, UtxoHandler,
+    UtxoStorageExport, bindings, new_wasmtime_config,
 };
 use starstream_to_wasm::compile;
-use wasmtime::component::{Resource, Val};
+use wasmtime::component::{Resource, ResourceTable, Val};
 use wasmtime::error::Context as _;
 use wasmtime::{Store, bail};
 
@@ -39,8 +39,9 @@ fn compile_contract(source: &str) -> Vec<u8> {
 static EXAMPLE_SCORE: LazyLock<Vec<u8>> =
     LazyLock::new(|| compile_contract(include_str!("../../examples/score.star")));
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 struct Ctx {
+    table: ResourceTable,
     methods: Vec<(u64, u64, u64, u64)>,
     events: Vec<(String, String, Box<[Val]>)>,
 }
@@ -72,6 +73,24 @@ impl EventHandler for Ctx {
     fn emit_event(&mut self, instance: &str, name: &str, params: &[Val]) {
         self.events
             .push((instance.into(), name.into(), params.into()));
+    }
+}
+
+impl UtxoHandler for Ctx {
+    fn table(&mut self) -> &mut ResourceTable {
+        &mut self.table
+    }
+
+    async fn construct_utxo(
+        _store: wasmtime::StoreContextMut<'_, Self>,
+        _instance: &str,
+        _name: &str,
+        _params: &[Val],
+    ) -> wasmtime::Result<Utxo>
+    where
+        Self: Sized,
+    {
+        bail!("UTXO construction not supported yet")
     }
 }
 
@@ -243,7 +262,9 @@ fn score_sync() -> wasmtime::Result<()> {
     });
 
     for (i, (mut store, utxo)) in zip(0.., utxos) {
-        let Ctx { methods, events } = store.data();
+        let Ctx {
+            methods, events, ..
+        } = store.data();
         assert_eq!(methods.as_ref(), *METHODS);
         assert_eq!(events.as_ref(), []);
 
@@ -302,7 +323,9 @@ fn score_sync() -> wasmtime::Result<()> {
         assert!(res.is_empty());
 
         utxo.drop(&mut store).context("failed to drop UTXO")?;
-        let Ctx { methods, events } = store.into_data();
+        let Ctx {
+            methods, events, ..
+        } = store.into_data();
         assert_eq!(methods, *METHODS);
         assert_eq!(
             events,
@@ -344,7 +367,9 @@ async fn score_async() -> wasmtime::Result<()> {
         tokio::try_join!(utxo0, utxo1, utxo2, utxo3, utxo4).context("failed to construct UTXOs")?;
 
     for (i, (mut store, utxo)) in zip(0.., [utxo0, utxo1, utxo2, utxo3, utxo4]) {
-        let Ctx { methods, events } = store.data();
+        let Ctx {
+            methods, events, ..
+        } = store.data();
         assert_eq!(methods.as_ref(), *METHODS);
         assert_eq!(events.as_ref(), []);
 
@@ -409,7 +434,9 @@ async fn score_async() -> wasmtime::Result<()> {
         utxo.drop_async(&mut store)
             .await
             .context("failed to drop UTXO")?;
-        let Ctx { methods, events } = store.into_data();
+        let Ctx {
+            methods, events, ..
+        } = store.into_data();
         assert_eq!(methods, *METHODS);
         assert_eq!(
             events,


### PR DESCRIPTION
This adds an implementation of imported (from coordination scripts) UTXO constructors and methods.
I cannot test this yet due to https://github.com/LFDT-Nightstream/Starstream/issues/165, but this should be mostly there.

To avoid significant churn and maintenance burden, I've also removed the `async` feature from the runtime, this means:
- the runtime will always require an async executor
- #142 will need to be reworked after merging this PR - my hoping was that it would get merged at an earlier point in time and then we'd switch to async with JSPI with a smaller scoped PR, but that did not work out, so we'll just have to rework it and deal with the added complexity in the new frontend PR - I'll move that PR back to draft.

I've also removed the deref impl on the contract to avoid confusion (e.g. there'd be `instantiate` and `instantiate_async` methods available, whereas only the former is correct)

`componentize` is now exported by the runtime, since users of this crate (like the mock ledger) will rely on Wizer to snapshot Utxo state (via https://docs.wasmtime.dev/api/wasmtime_wizer/index.html) and for that to work they will need to ensure core modules produced by the compiler are componentized before doing the instrumentation.

Note that there is currently no support for downcasts, mostly due to lack of specification and I did not want to just make something up, filed https://github.com/LFDT-Nightstream/Starstream/issues/175