### PR TITLE
refactor: remove `trace` feature, helpers, expose `Arc<str>`

### DIFF
--- a/starstream-runtime-next/Cargo.toml
+++ b/starstream-runtime-next/Cargo.toml
@@ -8,7 +8,6 @@ repository.workspace = true
 license.workspace = true
 
 [features]
-trace = ["wasmtime/debug"]
 wasmtime-custom-fiber = ["wasmtime/custom-fiber"]
 wasmtime-custom-virtual-memory = ["wasmtime/custom-virtual-memory"]
 

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -55,8 +55,8 @@ pub trait UtxoHandler: Send {
 
     fn construct_utxo(
         store: StoreContextMut<Self>,
-        instance: &str,
-        name: &str,
+        instance: &Arc<str>,
+        name: &Arc<str>,
         params: &[Val],
     ) -> impl Future<Output = wasmtime::Result<Utxo>> + Send
     where
@@ -851,6 +851,11 @@ pub struct Utxo {
 }
 
 impl Utxo {
+    #[must_use]
+    pub fn instance(&self) -> Instance {
+        self.instance
+    }
+
     #[must_use]
     pub fn resource(&self) -> ResourceAny {
         self.resource

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -6,7 +6,7 @@ use wasmtime::component::{
     LinkerInstance, ResourceAny, ResourceTable, ResourceType, Type, Val, types,
 };
 use wasmtime::error::Context as _;
-use wasmtime::{AsContextMut, Engine, Store, StoreContextMut, bail, ensure};
+use wasmtime::{AsContextMut, Engine, StoreContextMut, bail, ensure};
 
 pub mod bindings {
     wasmtime::component::bindgen!({
@@ -291,74 +291,6 @@ pub fn link_dynamic_imports<T: Host>(
         }
     }
     Ok(())
-}
-
-#[must_use]
-pub fn new_wasmtime_config() -> wasmtime::Config {
-    let mut config = wasmtime::Config::new();
-    config.wasm_component_model(true);
-    #[cfg(feature = "trace")]
-    config.guest_debug(true);
-    config
-}
-
-pub fn new_wasmtime_store<T: Send>(engine: &Engine, data: T) -> wasmtime::Result<Store<T>> {
-    let mut store = wasmtime::Store::new(engine, data);
-
-    // TODO: Replace this by proper tracing
-    #[cfg(feature = "trace")]
-    {
-        use core::marker::PhantomData;
-
-        use tracing::{error, trace};
-        use wasmtime::DebugEvent;
-
-        struct DebugHandler<T>(PhantomData<fn() -> T>);
-
-        impl<T> Clone for DebugHandler<T> {
-            fn clone(&self) -> Self {
-                Self(PhantomData)
-            }
-        }
-
-        impl<T: Send + 'static> wasmtime::DebugHandler for DebugHandler<T> {
-            type Data = T;
-
-            async fn handle(
-                &self,
-                mut store: StoreContextMut<'_, Self::Data>,
-                event: DebugEvent<'_>,
-            ) {
-                match event {
-                    DebugEvent::Breakpoint => {
-                        let frames: Vec<_> = store.debug_exit_frames().collect();
-                        for frame in frames {
-                            match frame.wasm_function_index_and_pc(&mut store) {
-                                Ok(Some((f, pc))) => debug!(?f, ?pc, "frame"),
-                                Ok(None) => trace!("skip trampoline frame"),
-                                Err(err) => error!(?err),
-                            }
-                        }
-                    }
-                    DebugEvent::HostcallError(..)
-                    | DebugEvent::Exception(..)
-                    | DebugEvent::Trap(..)
-                    | DebugEvent::EpochYield => {}
-                }
-            }
-        }
-
-        store.set_debug_handler(DebugHandler::<T>(PhantomData));
-        {
-            let Some(mut bp) = store.edit_breakpoints() else {
-                bail!("invalid engine config")
-            };
-            bp.single_step(true)
-                .context("failed to enable single-step debugging")?;
-        }
-    }
-
-    Ok(store)
 }
 
 /// Compiled, pre-instantiated Starstream contract

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -692,6 +692,7 @@ impl<T: Host> Contract<T> {
         mut store: impl AsContextMut<Data = T>,
         CoordinationScriptExport { idx, .. }: &CoordinationScriptExport,
         params: impl AsRef<[Val]>,
+        mut results: impl AsMut<[Val]>,
     ) -> wasmtime::Result<()>
     where
         T: Send,
@@ -701,7 +702,7 @@ impl<T: Host> Contract<T> {
             .get_func(store.as_context_mut(), idx)
             .context("failed to lookup coordination script export")?;
         debug!("calling coordination script");
-        f.call_async(store, params.as_ref(), &mut [])
+        f.call_async(store, params.as_ref(), results.as_mut())
             .await
             .context("failed to call coordination script")?;
         Ok(())
@@ -816,13 +817,13 @@ impl Utxo {
         mut store: impl AsContextMut<Data = T>,
         export: &MethodExport,
         params: impl AsRef<[Val]>,
-    ) -> wasmtime::Result<Box<[Val]>> {
+        mut results: impl AsMut<[Val]>,
+    ) -> wasmtime::Result<()> {
         let f = self.get_function_export(&mut store, export.idx)?;
-        let mut results = vec![Val::Bool(false); export.ty.results().len()];
-        f.call_async(&mut store, params.as_ref(), &mut results)
+        f.call_async(&mut store, params.as_ref(), results.as_mut())
             .await
             .context("failed to call method")?;
-        Ok(results.into_boxed_slice())
+        Ok(())
     }
 
     #[instrument(level = "trace", skip_all)]

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -2,7 +2,7 @@ use core::array;
 use core::iter::zip;
 
 use std::collections::BTreeMap;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use sha2::{Digest as _, Sha256};
 use starstream_compiler::{TypecheckOptions, parse_program, typecheck_program};
@@ -85,14 +85,14 @@ impl UtxoHandler for Ctx {
 
     async fn construct_utxo(
         store: wasmtime::StoreContextMut<'_, Self>,
-        instance: &str,
-        name: &str,
+        instance: &Arc<str>,
+        name: &Arc<str>,
         params: &[Val],
     ) -> wasmtime::Result<Utxo>
     where
         Self: Sized,
     {
-        match (instance, name) {
+        match (instance.as_ref(), name.as_ref()) {
             ("score-progress", "[static]utxo.new") => {
                 let Ctx { contract, ty, .. } = store.data();
                 let contract = contract.clone();

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -8,7 +8,7 @@ use sha2::{Digest as _, Sha256};
 use starstream_compiler::{TypecheckOptions, parse_program, typecheck_program};
 use starstream_runtime_next::{
     ConstructorExport, Contract, CoordinationScriptExport, EventHandler, Host, MethodExport, Utxo,
-    UtxoHandler, UtxoStorageExport, bindings, new_wasmtime_config, new_wasmtime_store,
+    UtxoHandler, UtxoStorageExport, bindings,
 };
 use starstream_to_wasm::compile;
 use wasmtime::component::{Resource, ResourceTable, Val};
@@ -253,13 +253,13 @@ async fn get_progress_storage<T: Send + 'static>(
 
 #[tokio::test]
 async fn score() -> wasmtime::Result<()> {
-    let engine = wasmtime::Engine::new(&new_wasmtime_config())?;
+    let engine = wasmtime::Engine::default();
     let contract =
         Contract::new(&engine, EXAMPLE_SCORE.as_slice()).context("failed to create contract")?;
     let ty = assert_progress_utxo(&contract)?;
 
     let [utxo0, utxo1, utxo2, utxo3, utxo4] = array::from_fn(|_| async {
-        let mut store = new_wasmtime_store(
+        let mut store = wasmtime::Store::new(
             &engine,
             Ctx {
                 contract: contract.clone(),
@@ -268,7 +268,7 @@ async fn score() -> wasmtime::Result<()> {
                 methods: Vec::default(),
                 events: Vec::default(),
             },
-        )?;
+        );
         contract
             .create_utxo(&mut store, &ty.new, [])
             .await
@@ -361,7 +361,7 @@ async fn score() -> wasmtime::Result<()> {
         );
     }
 
-    let mut store = new_wasmtime_store(
+    let mut store = wasmtime::Store::new(
         &engine,
         Ctx {
             contract: contract.clone(),
@@ -370,7 +370,7 @@ async fn score() -> wasmtime::Result<()> {
             methods: Vec::default(),
             events: Vec::default(),
         },
-    )?;
+    );
     contract
         .call_coordination_script(&mut store, &ty.example, [])
         .await

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -295,35 +295,32 @@ async fn score() -> wasmtime::Result<()> {
         assert_eq!(r#yield, 1);
         assert_eq!(yield1, 1);
 
-        let res = utxo
-            .call(
-                &mut store,
-                &ty.plus_chips,
-                [Val::Resource(utxo.resource()), Val::U64(i)],
-            )
-            .await
-            .context("failed to call `plus-chips`")?;
-        assert!(res.is_empty());
+        utxo.call(
+            &mut store,
+            &ty.plus_chips,
+            [Val::Resource(utxo.resource()), Val::U64(i)],
+            [],
+        )
+        .await
+        .context("failed to call `plus-chips`")?;
 
-        let res = utxo
-            .call(
-                &mut store,
-                &ty.plus_mult,
-                [Val::Resource(utxo.resource()), Val::U64(i)],
-            )
-            .await
-            .context("failed to call `plus-mult`")?;
-        assert!(res.is_empty());
+        utxo.call(
+            &mut store,
+            &ty.plus_mult,
+            [Val::Resource(utxo.resource()), Val::U64(i)],
+            [],
+        )
+        .await
+        .context("failed to call `plus-mult`")?;
 
-        let res = utxo
-            .call(
-                &mut store,
-                &ty.mult_mult,
-                [Val::Resource(utxo.resource()), Val::U64(200)],
-            )
-            .await
-            .context("failed to call `mult-mult`")?;
-        assert!(res.is_empty());
+        utxo.call(
+            &mut store,
+            &ty.mult_mult,
+            [Val::Resource(utxo.resource()), Val::U64(200)],
+            [],
+        )
+        .await
+        .context("failed to call `mult-mult`")?;
 
         let ProgressStorage {
             chips,
@@ -336,11 +333,9 @@ async fn score() -> wasmtime::Result<()> {
         assert_eq!(r#yield, 1);
         assert_eq!(yield1, 1);
 
-        let res = utxo
-            .call(&mut store, &ty.finish, [Val::Resource(utxo.resource())])
+        utxo.call(&mut store, &ty.finish, [Val::Resource(utxo.resource())], [])
             .await
             .context("failed to call `finish`")?;
-        assert!(res.is_empty());
 
         utxo.drop(&mut store).await.context("failed to drop UTXO")?;
         let Ctx {
@@ -372,7 +367,7 @@ async fn score() -> wasmtime::Result<()> {
         },
     );
     contract
-        .call_coordination_script(&mut store, &ty.example, [])
+        .call_coordination_script(&mut store, &ty.example, [], [])
         .await
         .context("failed to call `example` coordination script")?;
     let ctx = store.data_mut();


### PR DESCRIPTION
- Remove `trace` feature
- Remove redundant Wasmtime helpers
- Expose `Arc<str>` in the public API (this is something required by the ledger)
- Add support for coordination script and method results

refs https://github.com/LFDT-Nightstream/Starstream/pull/178#discussion_r3673380850

The intention is that the embedder of `starstream-runtime-next` constructs their own `wasmtime::Store`, e.g. via `wasmtime::Store::new`. Tracing, if enabled, is then configured on *that store* managed by the embedder.