### PR TITLE
Fix bugs and incompleteness in try-with syntax

### DIFF
--- a/docs/errors/E0041.md
+++ b/docs/errors/E0041.md
@@ -1,0 +1,25 @@
+# E0040: With requires effect
+
+You used the `with` statement naming a function that isn't an `effect`.
+
+## Example
+
+```starstream
+fn an_ordinary_function() { ... }
+// later...
+try { ... }
+with an_ordinary_function() { ... }
+```
+
+## How to fix
+
+Only use `with` statements with `effect`s:
+
+```starstream
+abi MyAbi {
+    effect an_effect();
+}
+// later...
+try { ... }
+with an_effect() { ... }
+```

--- a/starstream-compiler/src/typecheck/builtins.rs
+++ b/starstream-compiler/src/typecheck/builtins.rs
@@ -284,7 +284,7 @@ fn register_std_cardano(cardano: &mut Namespace, next_name_id: &mut NameId) {
                 params: vec![],
                 param_spans: vec![],
                 result: Type::int(),
-                callee: Some(StaticFunction::Named(next_name_id.clone())),
+                callee: Some(StaticFunction::Named(next_name_id.fresh())),
             }),
         ),
     );
@@ -300,7 +300,7 @@ fn register_std_cardano(cardano: &mut Namespace, next_name_id: &mut NameId) {
                 params: vec![],
                 param_spans: vec![],
                 result: Type::int(),
-                callee: Some(StaticFunction::Named(next_name_id.clone())),
+                callee: Some(StaticFunction::Named(next_name_id.fresh())),
             }),
         ),
     );

--- a/starstream-compiler/src/typecheck/env.rs
+++ b/starstream-compiler/src/typecheck/env.rs
@@ -260,21 +260,21 @@ impl Namespace {
     /// Import like `import * from ...`
     pub fn import_all_from(&mut self, other: &Namespace) -> Result<(), TypeError> {
         for (k, v) in &other.namespaces {
-            self.add_child(k.to_owned()).import_all_from(&v)?;
+            self.add_child(k.to_owned()).import_all_from(v)?;
         }
         for (k, v) in &other.constants {
             if let Some(old) = self.constants.insert(k.to_owned(), v.clone()) {
-                return Err(collision(&k, v.span, old.span));
+                return Err(collision(k, v.span, old.span));
             }
         }
         for (k, v) in &other.struct_constructors {
             if let Some(old) = self.struct_constructors.insert(k.to_owned(), v.clone()) {
-                return Err(collision(&k, v.span, old.span));
+                return Err(collision(k, v.span, old.span));
             }
         }
         for (k, v) in &other.types {
             if let Some(old) = self.types.insert(k.to_owned(), v.clone()) {
-                return Err(collision(&k, v.span, old.span));
+                return Err(collision(k, v.span, old.span));
             }
         }
         Ok(())
@@ -299,10 +299,10 @@ impl Namespace {
     }
 
     pub fn get_abi(&self, name: &Identifier) -> Result<&Arc<AbiType>, TypeError> {
-        if let Some(type_entry) = self.types.get(name.as_str()) {
-            if let Type::Abi(abi) = &type_entry.ty {
-                return Ok(abi);
-            }
+        if let Some(type_entry) = self.types.get(name.as_str())
+            && let Type::Abi(abi) = &type_entry.ty
+        {
+            return Ok(abi);
         }
         Err(TypeError::new(
             TypeErrorKind::UnknownAbi {

--- a/starstream-compiler/src/typecheck/errors.rs
+++ b/starstream-compiler/src/typecheck/errors.rs
@@ -253,7 +253,11 @@ pub enum TypeErrorKind {
         needed_keyword: FunctionKind,
         wrong_keyword: FunctionKind,
     },
-    // E0041 was RuntimeWithoutKeyword, replaced with EmitRaiseRuntimeNeeded
+    /// `with` blocks must handle effects, not other types of functions.
+    WithRequiresEffect {
+        function_name: String,
+        wrong_keyword: FunctionKind,
+    },
     /// Writing or initializing a public binding requires explicit disclosure of private data.
     ExplicitDisclosureRequiredForPublicBinding {
         variable_name: String,
@@ -362,7 +366,7 @@ impl TypeErrorKind {
             TypeErrorKind::EmitRaiseRuntimeUnneeded { .. } => error_code!(E0038),
             TypeErrorKind::EmitRaiseRuntimeNeeded { .. } => error_code!(E0039),
             TypeErrorKind::EmitRaiseRuntimeMismatch { .. } => error_code!(E0040),
-            // E0041 removed
+            TypeErrorKind::WithRequiresEffect { .. } => error_code!(E0041),
             TypeErrorKind::WrongGenericArity { .. } => error_code!(E0042),
             TypeErrorKind::ReturnTypeNotAllowed => error_code!(E0043),
             TypeErrorKind::LiteralOutOfRange { .. } => error_code!(E0044),
@@ -692,7 +696,17 @@ impl fmt::Display for TypeErrorKind {
                     function_name,
                 )
             }
-            // E0041 removed
+            TypeErrorKind::WithRequiresEffect {
+                function_name,
+                wrong_keyword,
+            } => {
+                write!(
+                    f,
+                    "`with` statement requires `effect`, not `{} {}`",
+                    wrong_keyword.declaration_keyword(),
+                    function_name
+                )
+            }
             TypeErrorKind::ExplicitDisclosureRequiredForPublicBinding { variable_name } => {
                 write!(
                     f,

--- a/starstream-compiler/src/typecheck/errors.rs
+++ b/starstream-compiler/src/typecheck/errors.rs
@@ -13,30 +13,32 @@ use super::diagnostic::{DiagnosticCore, to_source_span};
 #[derive(Debug, Error)]
 #[error("{kind}")]
 pub struct TypeError {
-    pub kind: TypeErrorKind,
-    core: DiagnosticCore,
+    // Boxed to keep TypeError small (clippy::result_large_err).
+    pub kind: Box<TypeErrorKind>,
+    core: Box<DiagnosticCore>,
 }
 
 impl TypeError {
     pub fn new(kind: TypeErrorKind, span: Span) -> Self {
         Self {
-            kind,
-            core: DiagnosticCore::new(span),
+            kind: Box::new(kind),
+            core: Box::new(DiagnosticCore::new(span)),
         }
     }
 
     pub fn with_secondary(mut self, span: Span, message: impl Into<String>) -> Self {
-        self.core = self.core.with_secondary(span, message);
+        // TODO: use [Box::map] when stabilized: https://github.com/rust-lang/rust/issues/144419
+        self.core = Box::new(self.core.with_secondary(span, message));
         self
     }
 
     pub fn with_primary_message(mut self, message: impl Into<String>) -> Self {
-        self.core = self.core.with_primary_message(message);
+        self.core = Box::new(self.core.with_primary_message(message));
         self
     }
 
     pub fn with_help(mut self, help: impl Into<String>) -> Self {
-        self.core = self.core.with_help(help);
+        self.core = Box::new(self.core.with_help(help));
         self
     }
 
@@ -70,7 +72,7 @@ impl Diagnostic for TypeError {
             expected,
             param_span: Some(span),
             ..
-        } = &self.kind
+        } = &*self.kind
         {
             labels.push(LabeledSpan::new_with_span(
                 Some(format!(

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -2269,12 +2269,12 @@ impl Inferencer {
                     children.extend(trace);
                     let (_, unit_trace) = self.unify(
                         Type::Unit,
-                        subject.ty().clone(),
+                        block.ty().clone(),
                         ctx.return_span,
-                        subject.tail_span(),
+                        block.tail_span(),
                         TypeErrorKind::GeneralMismatch {
                             expected: Type::Unit,
-                            found: self.apply_for_display(subject.ty()),
+                            found: self.apply_for_display(block.ty()),
                         },
                     )?;
                     children.push(unit_trace);

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -90,7 +90,7 @@ pub fn typecheck_program(
 
     // Pass 1: register imports
     env.root
-        .import_all_from(&inferencer.builtins.prelude())
+        .import_all_from(inferencer.builtins.prelude())
         .unwrap();
     if let Err(error) =
         inferencer.register_imports(&mut env, &program.definitions, &Default::default())
@@ -154,7 +154,7 @@ pub fn typecheck_program(
         Vec::new()
     };
 
-    let generic_types = Inferencer::build_generic_type_defs(&inferencer.builtins.prelude());
+    let generic_types = Inferencer::build_generic_type_defs(inferencer.builtins.prelude());
     let warnings = inferencer.warnings;
 
     Ok(TypecheckSuccess {
@@ -229,7 +229,7 @@ pub fn typecheck_modules(
 
         // Pass 1: register imports
         env.root
-            .import_all_from(&inferencer.builtins.prelude())
+            .import_all_from(inferencer.builtins.prelude())
             .unwrap();
         let resolved_imports = resolve_path_imports(graph, module_id, &module_exports);
         if let Err(error) =
@@ -321,7 +321,7 @@ pub fn typecheck_modules(
         inferencer.apply_substitutions_program(typed_program);
     }
 
-    let generic_types = Inferencer::build_generic_type_defs(&inferencer.builtins.prelude());
+    let generic_types = Inferencer::build_generic_type_defs(inferencer.builtins.prelude());
 
     let mut modules: Vec<TypedModule> = Vec::with_capacity(graph.modules().len());
     for source_module in graph.modules() {
@@ -1147,7 +1147,7 @@ impl Inferencer {
                         .collect::<Result<Vec<_>, _>>()?;
 
                     // Assert that the signature sets match
-                    let abi_info = env.root.get_abi(&abi)?;
+                    let abi_info = env.root.get_abi(abi)?;
                     self.check_abi_impl(abi, abi_info, &parts)?;
 
                     let abi = Type::Abi(abi_info.clone());
@@ -1270,7 +1270,7 @@ impl Inferencer {
 
                     // Assert that the signature sets match. `Token` resolves to
                     // the built-in ABI; other names must be user-declared ABIs.
-                    let abi_info = env.root.get_abi(&abi)?;
+                    let abi_info = env.root.get_abi(abi)?;
                     self.check_abi_impl(abi, abi_info, &parts)?;
 
                     let abi = Type::Abi(abi_info.clone());
@@ -2953,7 +2953,7 @@ impl Inferencer {
                                 }
                             }
 
-                            let abi = env.root.get_abi(&abi_name)?.clone();
+                            let abi = env.root.get_abi(abi_name)?.clone();
                             let var_name_str = name.name.clone();
                             let abi_name_str = abi_name.name.clone();
 
@@ -3198,7 +3198,7 @@ impl Inferencer {
                 // TODO: assert that this utxo impls each abi named
                 let abis = abis
                     .iter()
-                    .map(|abi| Ok(env.root.get_abi(&abi)?.clone()))
+                    .map(|abi| Ok(env.root.get_abi(abi)?.clone()))
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok((
                     Spanned::new(

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -2250,18 +2250,25 @@ impl Inferencer {
                             TypeErrorKind::NotAFunction {
                                 found: self.apply_for_display(&ty),
                             },
-                            name.first().unwrap().span,
+                            name.last().unwrap().span,
                         ));
                     };
-                    // TODO: enforce that it's an effect?
-
+                    if func.kind != FunctionKind::Raise {
+                        return Err(TypeError::new(
+                            TypeErrorKind::WithRequiresEffect {
+                                function_name: name.last().unwrap().to_string(),
+                                wrong_keyword: func.kind,
+                            },
+                            name.last().unwrap().span,
+                        ));
+                    }
                     if func.params.len() != patterns.len() {
                         return Err(TypeError::new(
                             TypeErrorKind::ArityMismatch {
                                 expected: func.params.len(),
                                 found: patterns.len(),
                             },
-                            name.first().unwrap().span,
+                            name.last().unwrap().span,
                         ));
                     }
 

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -2245,7 +2245,14 @@ impl Inferencer {
                 for (name, patterns, block) in effects {
                     env.push_scope();
                     let (ty, _) = self.lookup_name(env, name)?;
-                    let Type::Function(func) = ty else { panic!() };
+                    let Type::Function(func) = ty else {
+                        return Err(TypeError::new(
+                            TypeErrorKind::NotAFunction {
+                                found: self.apply_for_display(&ty),
+                            },
+                            name.first().unwrap().span,
+                        ));
+                    };
                     // TODO: enforce that it's an effect?
 
                     if func.params.len() != patterns.len() {

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -2071,12 +2071,15 @@ impl Compiler {
                     *bb = usize::MAX;
                     break;
                 }
-                TypedStatement::TryWith {
-                    subject,
-                    effects: _,
-                } => {
+                TypedStatement::TryWith { subject, effects } => {
                     self.visit_block_drop(func, bb, &(parent, &locals), subject)?;
                     // TODO: actually emit effect handler blocks
+                    if let Some(first) = effects.first() {
+                        return Err(self.push_error(
+                            first.0.last().unwrap().span,
+                            "TODO: effect handlers not yet implemented",
+                        ));
+                    }
                 }
             }
         }

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -1584,32 +1584,29 @@ impl Compiler {
         // Utxos declared in a file have an "exported" half and an "imported" half
         // since calls need to go through the runtime.
         for part in &utxo.parts {
-            match part {
-                TypedUtxoPart::Function(function) => {
-                    if let Some(FunctionExport::UtxoMain) = function.export {
-                        let mut params = Vec::with_capacity(16);
-                        for p in &function.params {
-                            _ = self.star_to_core_types(
-                                p.name.span_or(function.name.span()),
-                                &mut params,
-                                &p.ty,
-                            );
-                        }
-
-                        // Don't use declared result (always Unit). The imported version returns a handle.
-                        let mut results = Vec::with_capacity(1);
-                        _ = self.star_to_core_types(function.name.span(), &mut results, &utxo.ty);
-
-                        let wit_name = format!(
-                            "[static]{resource_name}.{}",
-                            to_kebab_case(function.name.as_str())
-                        );
-                        let ty = self.add_core_func_type(&FuncType::new(params, results));
-                        let idx = self.import_function(&interface_name, &wit_name, ty);
-                        self.callables.insert(function.id, idx);
-                    }
+            if let TypedUtxoPart::Function(function) = part
+                && let Some(FunctionExport::UtxoMain) = function.export
+            {
+                let mut params = Vec::with_capacity(16);
+                for p in &function.params {
+                    _ = self.star_to_core_types(
+                        p.name.span_or(function.name.span()),
+                        &mut params,
+                        &p.ty,
+                    );
                 }
-                _ => {}
+
+                // Don't use declared result (always Unit). The imported version returns a handle.
+                let mut results = Vec::with_capacity(1);
+                _ = self.star_to_core_types(function.name.span(), &mut results, &utxo.ty);
+
+                let wit_name = format!(
+                    "[static]{resource_name}.{}",
+                    to_kebab_case(function.name.as_str())
+                );
+                let ty = self.add_core_func_type(&FuncType::new(params, results));
+                let idx = self.import_function(&interface_name, &wit_name, ty);
+                self.callables.insert(function.id, idx);
             }
         }
     }

--- a/starstream-to-wasm/tests/snapshots/inputs@add.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@add.star.snap
@@ -123,7 +123,7 @@ TypedProgram {
                     name: "add",
                     span: 10..13,
                 },
-                id: NameId(2),
+                id: NameId(4),
                 params: [
                     TypedFunctionParam {
                         public: false,

--- a/starstream-to-wasm/tests/snapshots/inputs@blockheight.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@blockheight.star.snap
@@ -244,7 +244,7 @@ TypedProgram {
                     name: "reexport",
                     span: 63..71,
                 },
-                id: NameId(2),
+                id: NameId(4),
                 params: [],
                 return_type: Int(
                     I64,
@@ -354,7 +354,7 @@ TypedProgram {
                     name: "second",
                     span: 149..155,
                 },
-                id: NameId(3),
+                id: NameId(5),
                 params: [],
                 return_type: Int(
                     I64,
@@ -381,7 +381,7 @@ TypedProgram {
                                                     ),
                                                     callee: Some(
                                                         Named(
-                                                            NameId(2),
+                                                            NameId(4),
                                                         ),
                                                     ),
                                                 },

--- a/starstream-to-wasm/tests/snapshots/inputs@effect_raise.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@effect_raise.star.snap
@@ -316,65 +316,11 @@ TypedProgram {
 }
 
 ==== Core WebAssembly ====
-(module
-  (type (;0;) (func))
-  (import "starstream:effects/foo" "hello" (func (;0;) (type 0)))
-  (import "starstream:events/foo" "goodbye" (func (;1;) (type 0)))
-  (export "main" (func 2))
-  (func (;2;) (type 0)
-    (call 0)
-  )
-  (@custom "component-type"
-    (component
-      (@custom "wit-component-encoding" "\04\00")
-      (type (;0;)
-        (component
-          (type (;0;)
-            (component
-              (type (;0;) (func))
-              (export (;0;) "main" (func (type 0)))
-              (type (;1;)
-                (instance
-                  (type (;0;) (func))
-                  (export (;0;) "hello" (func (type 0)))
-                )
-              )
-              (import "starstream:effects/foo" (instance (;0;) (type 1)))
-              (type (;2;)
-                (instance
-                  (type (;0;) (func))
-                  (export (;0;) "goodbye" (func (type 0)))
-                )
-              )
-              (import "starstream:events/foo" (instance (;1;) (type 2)))
-            )
-          )
-          (export (;0;) "my-namespace:my-package/my-world" (component (type 0)))
-        )
-      )
-      (export (;1;) "x" (type 0))
-    )
-  )
-)
-
-==== WIT ====
-package root:component;
-
-world root {
-  import starstream:effects/foo;
-  import starstream:events/foo;
-
-  export main: func();
-}
-package starstream:effects {
-  interface foo {
-    hello: func();
-  }
-}
-
-
-package starstream:events {
-  interface foo {
-    goodbye: func();
-  }
-}
+  x TODO: effect handlers not yet implemented
+    ,-[9:12]
+  8 |         raise Hello();
+  9 |     } with Hello() {
+    :            ^^|^^
+    :              `-- TODO: effect handlers not yet implemented
+ 10 |         emit Goodbye();
+    `----

--- a/starstream-to-wasm/tests/snapshots/inputs@effect_raise.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@effect_raise.star.snap
@@ -170,7 +170,7 @@ TypedProgram {
                                 name: "Hello",
                                 span: 21..26,
                             },
-                            id: NameId(2),
+                            id: NameId(4),
                             params: [],
                             return_type: Unit,
                         },
@@ -181,7 +181,7 @@ TypedProgram {
                                 name: "Goodbye",
                                 span: 40..47,
                             },
-                            id: NameId(3),
+                            id: NameId(5),
                             params: [],
                         },
                     ),
@@ -197,7 +197,7 @@ TypedProgram {
                     name: "main",
                     span: 64..68,
                 },
-                id: NameId(4),
+                id: NameId(6),
                 params: [],
                 return_type: Unit,
                 body: TypedBlock {
@@ -221,7 +221,7 @@ TypedProgram {
                                                                     result: Unit,
                                                                     callee: Some(
                                                                         Named(
-                                                                            NameId(2),
+                                                                            NameId(4),
                                                                         ),
                                                                     ),
                                                                 },
@@ -276,7 +276,7 @@ TypedProgram {
                                                                             result: Unit,
                                                                             callee: Some(
                                                                                 Named(
-                                                                                    NameId(3),
+                                                                                    NameId(5),
                                                                                 ),
                                                                             ),
                                                                         },

--- a/starstream-to-wasm/tests/snapshots/inputs@empty.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@empty.star.snap
@@ -49,7 +49,7 @@ TypedProgram {
                     name: "main",
                     span: 22..26,
                 },
-                id: NameId(2),
+                id: NameId(4),
                 params: [],
                 return_type: Unit,
                 body: TypedBlock {

--- a/starstream-to-wasm/tests/snapshots/inputs@enum.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@enum.star.snap
@@ -349,7 +349,7 @@ TypedProgram {
                     name: "accepts_foo",
                     span: 46..57,
                 },
-                id: NameId(2),
+                id: NameId(4),
                 params: [
                     TypedFunctionParam {
                         public: false,
@@ -401,7 +401,7 @@ TypedProgram {
                     name: "get_bar",
                     span: 83..90,
                 },
-                id: NameId(3),
+                id: NameId(5),
                 params: [],
                 return_type: Unit,
                 body: TypedBlock {
@@ -451,7 +451,7 @@ TypedProgram {
                                                         result: Unit,
                                                         callee: Some(
                                                             Named(
-                                                                NameId(2),
+                                                                NameId(4),
                                                             ),
                                                         ),
                                                     },
@@ -596,7 +596,7 @@ TypedProgram {
                     name: "get_baz",
                     span: 141..148,
                 },
-                id: NameId(4),
+                id: NameId(6),
                 params: [],
                 return_type: Unit,
                 body: TypedBlock {
@@ -646,7 +646,7 @@ TypedProgram {
                                                         result: Unit,
                                                         callee: Some(
                                                             Named(
-                                                                NameId(2),
+                                                                NameId(4),
                                                             ),
                                                         ),
                                                     },

--- a/starstream-to-wasm/tests/snapshots/inputs@events.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@events.star.snap
@@ -99,7 +99,7 @@ TypedProgram {
                                 name: "Hello",
                                 span: 20..25,
                             },
-                            id: NameId(2),
+                            id: NameId(4),
                             params: [],
                         },
                     ),
@@ -115,7 +115,7 @@ TypedProgram {
                     name: "main",
                     span: 42..46,
                 },
-                id: NameId(3),
+                id: NameId(5),
                 params: [],
                 return_type: Unit,
                 body: TypedBlock {
@@ -136,7 +136,7 @@ TypedProgram {
                                                         result: Unit,
                                                         callee: Some(
                                                             Named(
-                                                                NameId(2),
+                                                                NameId(4),
                                                             ),
                                                         ),
                                                     },

--- a/starstream-to-wasm/tests/snapshots/inputs@if_elseif_else.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@if_elseif_else.star.snap
@@ -172,7 +172,7 @@ TypedProgram {
                     name: "main",
                     span: 10..14,
                 },
-                id: NameId(2),
+                id: NameId(4),
                 params: [],
                 return_type: Unit,
                 body: TypedBlock {

--- a/starstream-to-wasm/tests/snapshots/inputs@if_expression.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@if_expression.star.snap
@@ -167,7 +167,7 @@ TypedProgram {
                     name: "main",
                     span: 10..14,
                 },
-                id: NameId(2),
+                id: NameId(4),
                 params: [],
                 return_type: Int(
                     I64,

--- a/starstream-to-wasm/tests/snapshots/inputs@integer_radix.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@integer_radix.star.snap
@@ -284,7 +284,7 @@ TypedProgram {
                     name: "main",
                     span: 10..14,
                 },
-                id: NameId(2),
+                id: NameId(4),
                 params: [],
                 return_type: Int(
                     I64,

--- a/starstream-to-wasm/tests/snapshots/inputs@match_expression.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@match_expression.star.snap
@@ -1385,7 +1385,7 @@ TypedProgram {
                     name: "match_foo",
                     span: 131..140,
                 },
-                id: NameId(2),
+                id: NameId(4),
                 params: [
                     TypedFunctionParam {
                         public: false,
@@ -1770,7 +1770,7 @@ TypedProgram {
                     name: "match_with_wildcard",
                     span: 398..417,
                 },
-                id: NameId(3),
+                id: NameId(5),
                 params: [
                     TypedFunctionParam {
                         public: false,
@@ -2026,7 +2026,7 @@ TypedProgram {
                     name: "match_literal",
                     span: 555..568,
                 },
-                id: NameId(4),
+                id: NameId(6),
                 params: [
                     TypedFunctionParam {
                         public: false,
@@ -2222,7 +2222,7 @@ TypedProgram {
                     name: "match_point",
                     span: 751..762,
                 },
-                id: NameId(5),
+                id: NameId(7),
                 params: [
                     TypedFunctionParam {
                         public: false,
@@ -2465,7 +2465,7 @@ TypedProgram {
                     name: "get_bar",
                     span: 927..934,
                 },
-                id: NameId(6),
+                id: NameId(8),
                 params: [],
                 return_type: Unit,
                 body: TypedBlock {
@@ -2561,7 +2561,7 @@ TypedProgram {
                                                         ),
                                                         callee: Some(
                                                             Named(
-                                                                NameId(2),
+                                                                NameId(4),
                                                             ),
                                                         ),
                                                     },

--- a/starstream-to-wasm/tests/snapshots/inputs@multiple_functions.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@multiple_functions.star.snap
@@ -223,7 +223,7 @@ TypedProgram {
                     name: "main",
                     span: 3..7,
                 },
-                id: NameId(2),
+                id: NameId(4),
                 params: [],
                 return_type: Unit,
                 body: TypedBlock {
@@ -307,7 +307,7 @@ TypedProgram {
                     name: "compute",
                     span: 106..113,
                 },
-                id: NameId(3),
+                id: NameId(5),
                 params: [],
                 return_type: Int(
                     I64,

--- a/starstream-to-wasm/tests/snapshots/inputs@option_result.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@option_result.star.snap
@@ -932,7 +932,7 @@ TypedProgram {
                     name: "make_some",
                     span: 3..12,
                 },
-                id: NameId(2),
+                id: NameId(4),
                 params: [],
                 return_type: Enum(
                     EnumType {
@@ -1080,7 +1080,7 @@ TypedProgram {
                     name: "make_none",
                     span: 59..68,
                 },
-                id: NameId(3),
+                id: NameId(5),
                 params: [],
                 return_type: Enum(
                     EnumType {
@@ -1168,7 +1168,7 @@ TypedProgram {
                     name: "unwrap_option",
                     span: 111..124,
                 },
-                id: NameId(4),
+                id: NameId(6),
                 params: [
                     TypedFunctionParam {
                         public: false,
@@ -1353,7 +1353,7 @@ TypedProgram {
                     name: "make_ok",
                     span: 285..292,
                 },
-                id: NameId(5),
+                id: NameId(7),
                 params: [],
                 return_type: Enum(
                     EnumType {
@@ -1514,7 +1514,7 @@ TypedProgram {
                     name: "make_err",
                     span: 343..351,
                 },
-                id: NameId(6),
+                id: NameId(8),
                 params: [],
                 return_type: Enum(
                     EnumType {
@@ -1668,7 +1668,7 @@ TypedProgram {
                     name: "unwrap_result",
                     span: 406..419,
                 },
-                id: NameId(7),
+                id: NameId(9),
                 params: [
                     TypedFunctionParam {
                         public: false,
@@ -1953,7 +1953,7 @@ TypedProgram {
                     name: "run",
                     span: 631..634,
                 },
-                id: NameId(8),
+                id: NameId(10),
                 params: [
                     TypedFunctionParam {
                         public: false,
@@ -2092,7 +2092,7 @@ TypedProgram {
                                                         ),
                                                         callee: Some(
                                                             Named(
-                                                                NameId(4),
+                                                                NameId(6),
                                                             ),
                                                         ),
                                                     },
@@ -2175,7 +2175,7 @@ TypedProgram {
                                                                         ),
                                                                         callee: Some(
                                                                             Named(
-                                                                                NameId(2),
+                                                                                NameId(4),
                                                                             ),
                                                                         ),
                                                                     },
@@ -2257,7 +2257,7 @@ TypedProgram {
                                                         ),
                                                         callee: Some(
                                                             Named(
-                                                                NameId(7),
+                                                                NameId(9),
                                                             ),
                                                         ),
                                                     },
@@ -2350,7 +2350,7 @@ TypedProgram {
                                                                         ),
                                                                         callee: Some(
                                                                             Named(
-                                                                                NameId(5),
+                                                                                NameId(7),
                                                                             ),
                                                                         ),
                                                                     },

--- a/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
@@ -660,7 +660,7 @@ TypedProgram {
                                 result: Unit,
                                 callee: Some(
                                     Named(
-                                        NameId(2),
+                                        NameId(4),
                                     ),
                                 ),
                             },
@@ -687,7 +687,7 @@ TypedProgram {
                                 result: Unit,
                                 callee: Some(
                                     Named(
-                                        NameId(3),
+                                        NameId(5),
                                     ),
                                 ),
                             },
@@ -714,7 +714,7 @@ TypedProgram {
                                 result: Unit,
                                 callee: Some(
                                     Named(
-                                        NameId(4),
+                                        NameId(6),
                                     ),
                                 ),
                             },
@@ -735,7 +735,7 @@ TypedProgram {
                                 result: Unit,
                                 callee: Some(
                                     Named(
-                                        NameId(5),
+                                        NameId(7),
                                     ),
                                 ),
                             },
@@ -747,7 +747,7 @@ TypedProgram {
                                 name: "Finish",
                                 span: 132..138,
                             },
-                            id: NameId(6),
+                            id: NameId(8),
                             params: [
                                 TypedFunctionParam {
                                     public: false,
@@ -803,7 +803,7 @@ TypedProgram {
                                 name: "new",
                                 span: 263..266,
                             },
-                            id: NameId(7),
+                            id: NameId(9),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -840,7 +840,7 @@ TypedProgram {
                                                                         result: Unit,
                                                                         callee: Some(
                                                                             Named(
-                                                                                NameId(2),
+                                                                                NameId(4),
                                                                             ),
                                                                         ),
                                                                     },
@@ -865,7 +865,7 @@ TypedProgram {
                                                                         result: Unit,
                                                                         callee: Some(
                                                                             Named(
-                                                                                NameId(3),
+                                                                                NameId(5),
                                                                             ),
                                                                         ),
                                                                     },
@@ -890,7 +890,7 @@ TypedProgram {
                                                                         result: Unit,
                                                                         callee: Some(
                                                                             Named(
-                                                                                NameId(4),
+                                                                                NameId(6),
                                                                             ),
                                                                         ),
                                                                     },
@@ -909,7 +909,7 @@ TypedProgram {
                                                                         result: Unit,
                                                                         callee: Some(
                                                                             Named(
-                                                                                NameId(5),
+                                                                                NameId(7),
                                                                             ),
                                                                         ),
                                                                     },
@@ -944,7 +944,7 @@ TypedProgram {
                                                                     result: Unit,
                                                                     callee: Some(
                                                                         Named(
-                                                                            NameId(6),
+                                                                            NameId(8),
                                                                         ),
                                                                     ),
                                                                 },
@@ -1049,7 +1049,7 @@ TypedProgram {
                                             result: Unit,
                                             callee: Some(
                                                 Named(
-                                                    NameId(2),
+                                                    NameId(4),
                                                 ),
                                             ),
                                         },
@@ -1074,7 +1074,7 @@ TypedProgram {
                                             result: Unit,
                                             callee: Some(
                                                 Named(
-                                                    NameId(3),
+                                                    NameId(5),
                                                 ),
                                             ),
                                         },
@@ -1099,7 +1099,7 @@ TypedProgram {
                                             result: Unit,
                                             callee: Some(
                                                 Named(
-                                                    NameId(4),
+                                                    NameId(6),
                                                 ),
                                             ),
                                         },
@@ -1118,7 +1118,7 @@ TypedProgram {
                                             result: Unit,
                                             callee: Some(
                                                 Named(
-                                                    NameId(5),
+                                                    NameId(7),
                                                 ),
                                             ),
                                         },
@@ -1133,7 +1133,7 @@ TypedProgram {
                                     name: "plus_chips",
                                     span: 362..372,
                                 },
-                                id: NameId(8),
+                                id: NameId(10),
                                 params: [
                                     TypedFunctionParam {
                                         public: true,
@@ -1210,7 +1210,7 @@ TypedProgram {
                                     name: "plus_mult",
                                     span: 449..458,
                                 },
-                                id: NameId(9),
+                                id: NameId(11),
                                 params: [
                                     TypedFunctionParam {
                                         public: true,
@@ -1287,7 +1287,7 @@ TypedProgram {
                                     name: "mult_mult",
                                     span: 531..540,
                                 },
-                                id: NameId(10),
+                                id: NameId(12),
                                 params: [
                                     TypedFunctionParam {
                                         public: true,
@@ -1391,7 +1391,7 @@ TypedProgram {
                                     name: "finish",
                                     span: 625..631,
                                 },
-                                id: NameId(11),
+                                id: NameId(13),
                                 params: [],
                                 return_type: Unit,
                                 body: TypedBlock {
@@ -1418,7 +1418,7 @@ TypedProgram {
                     name: "example",
                     span: 685..692,
                 },
-                id: NameId(12),
+                id: NameId(14),
                 params: [],
                 return_type: Unit,
                 body: TypedBlock {
@@ -1449,7 +1449,7 @@ TypedProgram {
                                                         ),
                                                         callee: Some(
                                                             Named(
-                                                                NameId(7),
+                                                                NameId(9),
                                                             ),
                                                         ),
                                                     },

--- a/starstream-to-wasm/tests/snapshots/inputs@struct_param.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@struct_param.star.snap
@@ -226,7 +226,7 @@ TypedProgram {
                     name: "total_value",
                     span: 60..71,
                 },
-                id: NameId(2),
+                id: NameId(4),
                 params: [
                     TypedFunctionParam {
                         public: false,

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
@@ -193,7 +193,7 @@ TypedProgram {
                                 name: "mint",
                                 span: 85..89,
                             },
-                            id: NameId(2),
+                            id: NameId(4),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -290,7 +290,7 @@ TypedProgram {
                                     name: "attach",
                                     span: 148..154,
                                 },
-                                id: NameId(3),
+                                id: NameId(5),
                                 params: [
                                     TypedFunctionParam {
                                         public: false,
@@ -313,7 +313,7 @@ TypedProgram {
                                     name: "detach",
                                     span: 180..186,
                                 },
-                                id: NameId(4),
+                                id: NameId(6),
                                 params: [
                                     TypedFunctionParam {
                                         public: false,

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
@@ -276,7 +276,7 @@ TypedProgram {
                                 name: "mint",
                                 span: 76..80,
                             },
-                            id: NameId(2),
+                            id: NameId(4),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -345,7 +345,7 @@ TypedProgram {
                                 name: "burn",
                                 span: 130..134,
                             },
-                            id: NameId(3),
+                            id: NameId(5),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -470,7 +470,7 @@ TypedProgram {
                                     name: "attach",
                                     span: 200..206,
                                 },
-                                id: NameId(4),
+                                id: NameId(6),
                                 params: [
                                     TypedFunctionParam {
                                         public: false,
@@ -493,7 +493,7 @@ TypedProgram {
                                     name: "detach",
                                     span: 232..238,
                                 },
-                                id: NameId(5),
+                                id: NameId(7),
                                 params: [
                                     TypedFunctionParam {
                                         public: false,

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
@@ -153,7 +153,7 @@ TypedProgram {
                                 name: "HelloEvent",
                                 span: 23..33,
                             },
-                            id: NameId(2),
+                            id: NameId(4),
                             params: [],
                         },
                     ),
@@ -174,7 +174,7 @@ TypedProgram {
                                 name: "private_fn",
                                 span: 61..71,
                             },
-                            id: NameId(4),
+                            id: NameId(6),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -195,7 +195,7 @@ TypedProgram {
                                                                     result: Unit,
                                                                     callee: Some(
                                                                         Named(
-                                                                            NameId(2),
+                                                                            NameId(4),
                                                                         ),
                                                                     ),
                                                                 },
@@ -234,7 +234,7 @@ TypedProgram {
                                 name: "hello_utxo",
                                 span: 121..131,
                             },
-                            id: NameId(3),
+                            id: NameId(5),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -255,7 +255,7 @@ TypedProgram {
                                                                     result: Unit,
                                                                     callee: Some(
                                                                         Named(
-                                                                            NameId(4),
+                                                                            NameId(6),
                                                                         ),
                                                                     ),
                                                                 },

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
@@ -135,7 +135,7 @@ TypedProgram {
                                 ),
                                 callee: Some(
                                     Named(
-                                        NameId(2),
+                                        NameId(4),
                                     ),
                                 ),
                             },
@@ -176,7 +176,7 @@ TypedProgram {
                                             ),
                                             callee: Some(
                                                 Named(
-                                                    NameId(2),
+                                                    NameId(4),
                                                 ),
                                             ),
                                         },
@@ -191,7 +191,7 @@ TypedProgram {
                                     name: "hello",
                                     span: 80..85,
                                 },
-                                id: NameId(3),
+                                id: NameId(5),
                                 params: [],
                                 return_type: Int(
                                     I32,

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
@@ -110,7 +110,7 @@ TypedProgram {
                                 name: "HelloEvent",
                                 span: 23..33,
                             },
-                            id: NameId(2),
+                            id: NameId(4),
                             params: [],
                         },
                     ),
@@ -133,7 +133,7 @@ TypedProgram {
                                 name: "hello_utxo",
                                 span: 66..76,
                             },
-                            id: NameId(3),
+                            id: NameId(5),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -154,7 +154,7 @@ TypedProgram {
                                                                     result: Unit,
                                                                     callee: Some(
                                                                         Named(
-                                                                            NameId(2),
+                                                                            NameId(4),
                                                                         ),
                                                                     ),
                                                                 },

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
@@ -226,7 +226,7 @@ TypedProgram {
                                 name: "increment",
                                 span: 109..118,
                             },
-                            id: NameId(2),
+                            id: NameId(4),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -295,7 +295,7 @@ TypedProgram {
                                 name: "increment_mult",
                                 span: 172..186,
                             },
-                            id: NameId(3),
+                            id: NameId(5),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
@@ -104,7 +104,7 @@ TypedProgram {
                     name: "script_accepts_utxos",
                     span: 28..48,
                 },
-                id: NameId(2),
+                id: NameId(4),
                 params: [
                     TypedFunctionParam {
                         public: false,

--- a/starstream-to-wasm/tests/snapshots/inputs@while_simple.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@while_simple.star.snap
@@ -162,7 +162,7 @@ TypedProgram {
                     name: "main",
                     span: 10..14,
                 },
-                id: NameId(2),
+                id: NameId(4),
                 params: [],
                 return_type: Unit,
                 body: TypedBlock {

--- a/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
@@ -159,7 +159,7 @@ TypedProgram {
                                 result: Unit,
                                 callee: Some(
                                     Named(
-                                        NameId(2),
+                                        NameId(4),
                                     ),
                                 ),
                             },
@@ -184,7 +184,7 @@ TypedProgram {
                                 name: "hello_utxo",
                                 span: 53..63,
                             },
-                            id: NameId(3),
+                            id: NameId(5),
                             params: [
                                 TypedFunctionParam {
                                     public: false,
@@ -226,7 +226,7 @@ TypedProgram {
                                                                         result: Unit,
                                                                         callee: Some(
                                                                             Named(
-                                                                                NameId(2),
+                                                                                NameId(4),
                                                                             ),
                                                                         ),
                                                                     },
@@ -267,7 +267,7 @@ TypedProgram {
                                             result: Unit,
                                             callee: Some(
                                                 Named(
-                                                    NameId(2),
+                                                    NameId(4),
                                                 ),
                                             ),
                                         },
@@ -282,7 +282,7 @@ TypedProgram {
                                     name: "foo",
                                     span: 126..129,
                                 },
-                                id: NameId(4),
+                                id: NameId(6),
                                 params: [],
                                 return_type: Unit,
                                 body: TypedBlock {


### PR DESCRIPTION
From #173:
* Fix try-with unifying unit with the `try` block repeatedly, instead of with each `with` block, allowing `with { 5 }` to pass.
* Error instead of panicking if `with foo` is used when `foo` is not a function.
* Error instead of passing if `with foo` is used when `foo` is a non-effect function.

From #189:
* Fix `register_std_cardano` using `.clone()` instead of `.fresh()`.
  * Maybe we should give prelude types their own ID space (negative numbers?) to avoid snapshot churn?

Also fix Clippy lints in `starstream-compiler` and `starstream-to-wasm`.