### PR TITLE
feat(rt-next): update to new WIT shape

### DIFF
--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -3,12 +3,13 @@ use std::sync::Arc;
 use tracing::{debug, instrument};
 use wasmtime::component::{
     Component, ComponentExportIndex, ExportLookup, Func, HasSelf, Instance, InstancePre, Linker,
-    LinkerInstance, ResourceAny, ResourceTable, ResourceType, Type, Val, types,
+    LinkerInstance, Resource, ResourceAny, ResourceTable, ResourceType, Type, Val, types,
 };
 use wasmtime::error::Context as _;
 use wasmtime::{AsContextMut, Engine, StoreContextMut, bail, ensure};
 
 pub mod bindings {
+    // NOTE: `starstream:std/utxo-context` bindings are hand-written
     wasmtime::component::bindgen!({
         path: "../starstream-to-wasm/wit",
         inline: "
@@ -23,15 +24,50 @@ pub mod bindings {
             "starstream:std/builtin.utxo": crate::Utxo,
         },
         imports: {
-            "starstream:std/builtin.implements-method": tracing | trappable,
-            default: tracing,
+            default: tracing | trappable,
         }
     });
 }
 
+pub trait ResourceView {
+    fn table(&mut self) -> &mut ResourceTable;
+}
+
+impl<T: ResourceView> ResourceView for &mut T {
+    fn table(&mut self) -> &mut ResourceTable {
+        T::table(self)
+    }
+}
+
+/// Utxo handler
+pub trait UtxoHandler: ResourceView + Send + Sized {
+    type Context;
+
+    fn construct_utxo(
+        store: StoreContextMut<Self>,
+        instance: &Arc<str>,
+        name: &Arc<str>,
+        params: &[Val],
+    ) -> impl Future<Output = wasmtime::Result<Utxo>> + Send;
+
+    fn implements_method(
+        store: StoreContextMut<Self>,
+        cx: Resource<Self::Context>,
+        hash: (u64, u64, u64, u64),
+    ) -> wasmtime::Result<()>;
+
+    fn resume(store: StoreContextMut<Self>, cx: Resource<Self::Context>) -> wasmtime::Result<()>;
+
+    fn drop(store: StoreContextMut<Self>, cx: Resource<Self::Context>) -> wasmtime::Result<()>;
+}
+
+/// ABI event handler
+pub trait EventHandler {
+    fn emit_event(&mut self, instance: &str, name: &str, params: &[Val]);
+}
+
 pub trait Host:
     bindings::starstream::std::builtin::Host
-    + bindings::starstream::std::builtin::HostUtxo
     + bindings::starstream::std::cardano::Host
     + EventHandler
     + UtxoHandler
@@ -41,31 +77,11 @@ pub trait Host:
 
 impl<T> Host for T where
     T: bindings::starstream::std::builtin::Host
-        + bindings::starstream::std::builtin::HostUtxo
         + bindings::starstream::std::cardano::Host
         + EventHandler
         + UtxoHandler
         + 'static
 {
-}
-
-/// Utxo handler
-pub trait UtxoHandler: Send {
-    fn table(&mut self) -> &mut ResourceTable;
-
-    fn construct_utxo(
-        store: StoreContextMut<Self>,
-        instance: &Arc<str>,
-        name: &Arc<str>,
-        params: &[Val],
-    ) -> impl Future<Output = wasmtime::Result<Utxo>> + Send
-    where
-        Self: Sized;
-}
-
-/// ABI event handler
-pub trait EventHandler {
-    fn emit_event(&mut self, instance: &str, name: &str, params: &[Val]);
 }
 
 pub fn componentize(wasm: impl AsRef<[u8]>) -> anyhow::Result<Vec<u8>> {
@@ -256,6 +272,20 @@ pub fn link_instance<T: Host>(
     }
 }
 
+pub fn link_utxo_context<T: UtxoHandler>(linker: &mut LinkerInstance<T>) -> wasmtime::Result<()> {
+    linker.func_wrap(
+        "[method]utxo-context.implements-method",
+        |store, (cx, hash)| T::implements_method(store, cx, hash),
+    )?;
+    linker.func_wrap("[method]utxo-context.resume", |store, (cx,)| {
+        T::resume(store, cx)
+    })?;
+    linker.func_wrap("[resource-drop]utxo-context", |store, (cx,)| {
+        T::drop(store, cx)
+    })?;
+    Ok(())
+}
+
 /// Link dynamic imports of the contract
 #[instrument(level = "trace", skip_all)]
 pub fn link_dynamic_imports<T: Host>(
@@ -264,8 +294,14 @@ pub fn link_dynamic_imports<T: Host>(
     ty: &types::Component,
 ) -> wasmtime::Result<()> {
     for (name, types::ComponentExtern { ty, .. }) in ty.imports(engine) {
-        if let Some(("starstream:std", ..)) = name.split_once('/') {
-            debug!(?name, "skipping builtin instance import");
+        if let Some(("starstream:std", interface)) = name.split_once('/') {
+            let mut linker = linker
+                .instance("utxo-context")
+                .context("failed to instantiate `utxo-context` in the linker")?;
+            match interface {
+                "utxo-context" => link_utxo_context(&mut linker)?,
+                _ => debug!(?name, "skipping builtin instance import"),
+            };
             continue;
         }
         match ty {

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, LazyLock};
 use sha2::{Digest as _, Sha256};
 use starstream_compiler::{TypecheckOptions, parse_program, typecheck_program};
 use starstream_runtime_next::{
-    ConstructorExport, Contract, CoordinationScriptExport, EventHandler, Host, MethodExport, Utxo,
-    UtxoHandler, UtxoStorageExport, bindings,
+    ConstructorExport, Contract, CoordinationScriptExport, EventHandler, Host, MethodExport,
+    ResourceView, Utxo, UtxoHandler, UtxoStorageExport, bindings,
 };
 use starstream_to_wasm::compile;
 use wasmtime::component::{Resource, ResourceTable, Val};
@@ -44,13 +44,24 @@ struct Ctx {
     ty: ProgressUtxo,
 
     table: ResourceTable,
-    methods: Vec<(u64, u64, u64, u64)>,
     events: Vec<(String, String, Box<[Val]>)>,
+
+    utxo_cx: Option<UtxoCtx>,
+}
+
+pub struct UtxoCtx {
+    methods: Vec<(u64, u64, u64, u64)>,
+}
+
+impl ResourceView for Ctx {
+    fn table(&mut self) -> &mut ResourceTable {
+        &mut self.table
+    }
 }
 
 impl bindings::starstream::std::builtin::Host for Ctx {
-    fn implements_method(&mut self, hash: (u64, u64, u64, u64)) -> wasmtime::Result<()> {
-        self.methods.push(hash);
+    // TODO: Remove this function
+    fn implements_method(&mut self, _hash: (u64, u64, u64, u64)) -> wasmtime::Result<()> {
         Ok(())
     }
 }
@@ -62,12 +73,12 @@ impl bindings::starstream::std::builtin::HostUtxo for Ctx {
 }
 
 impl bindings::starstream::std::cardano::Host for Ctx {
-    fn block_height(&mut self) -> i64 {
-        0
+    fn block_height(&mut self) -> wasmtime::Result<i64> {
+        Ok(0)
     }
 
-    fn current_slot(&mut self) -> i64 {
-        0
+    fn current_slot(&mut self) -> wasmtime::Result<i64> {
+        Ok(0)
     }
 }
 
@@ -79,9 +90,7 @@ impl EventHandler for Ctx {
 }
 
 impl UtxoHandler for Ctx {
-    fn table(&mut self) -> &mut ResourceTable {
-        &mut self.table
-    }
+    type Context = UtxoCtx;
 
     async fn construct_utxo(
         mut store: wasmtime::StoreContextMut<'_, Self>,
@@ -102,6 +111,35 @@ impl UtxoHandler for Ctx {
             }
             _ => panic!("unexpected UTXO constructor call `{instance}#{name}`"),
         }
+    }
+
+    fn resume(
+        mut store: wasmtime::StoreContextMut<'_, Self>,
+        cx: Resource<UtxoCtx>,
+    ) -> wasmtime::Result<()> {
+        let _cx = store.data_mut().table.get_mut(&cx)?;
+        // TODO: handle resume
+        Ok(())
+    }
+
+    fn implements_method(
+        mut store: wasmtime::StoreContextMut<'_, Self>,
+        cx: Resource<UtxoCtx>,
+        hash: (u64, u64, u64, u64),
+    ) -> wasmtime::Result<()> {
+        let cx = store.data_mut().table.get_mut(&cx)?;
+        cx.methods.push(hash);
+        Ok(())
+    }
+
+    fn drop(
+        mut store: wasmtime::StoreContextMut<'_, Self>,
+        cx: Resource<UtxoCtx>,
+    ) -> wasmtime::Result<()> {
+        let data = store.data_mut();
+        let cx = data.table.delete(cx)?;
+        assert!(data.utxo_cx.replace(cx).is_none());
+        Ok(())
     }
 }
 
@@ -252,6 +290,7 @@ async fn get_progress_storage<T: Send + 'static>(
     Ok(storage.iter().collect())
 }
 
+#[ignore = "compiler does not support the new WIT shape yet"]
 #[tokio::test]
 async fn score() -> wasmtime::Result<()> {
     let engine = wasmtime::Engine::default();
@@ -266,7 +305,7 @@ async fn score() -> wasmtime::Result<()> {
                 contract: contract.clone(),
                 ty: ty.clone(),
                 table: ResourceTable::default(),
-                methods: Vec::default(),
+                utxo_cx: None,
                 events: Vec::default(),
             },
         );
@@ -281,10 +320,10 @@ async fn score() -> wasmtime::Result<()> {
 
     for (i, (mut store, utxo)) in zip(0.., [utxo0, utxo1, utxo2, utxo3, utxo4]) {
         let Ctx {
-            methods, events, ..
+            events, utxo_cx, ..
         } = store.data();
-        assert_eq!(methods.as_ref(), *METHODS);
         assert_eq!(events.as_ref(), []);
+        assert!(utxo_cx.is_none());
 
         let ProgressStorage {
             chips,
@@ -342,12 +381,14 @@ async fn score() -> wasmtime::Result<()> {
         utxo.drop(&mut store).await.context("failed to drop UTXO")?;
         let Ctx {
             table,
-            methods,
             events,
+            utxo_cx,
             ..
         } = store.into_data();
         assert!(table.is_empty());
-        assert_eq!(methods, *METHODS);
+        assert!(utxo_cx.is_none());
+        // TODO: Assert methods on the context
+        //assert_eq!(methods, *METHODS);
         assert_eq!(
             events,
             [(
@@ -356,6 +397,7 @@ async fn score() -> wasmtime::Result<()> {
                 [Val::U64(i * i * 2)].into()
             )]
         );
+        assert!(utxo_cx.is_none());
     }
 
     let mut store = wasmtime::Store::new(
@@ -364,8 +406,8 @@ async fn score() -> wasmtime::Result<()> {
             contract: contract.clone(),
             ty: ty.clone(),
             table: ResourceTable::default(),
-            methods: Vec::default(),
             events: Vec::default(),
+            utxo_cx: None,
         },
     );
     let instance = contract
@@ -376,16 +418,17 @@ async fn score() -> wasmtime::Result<()> {
         .call_coordination_script(&mut store, &ty.example, [], [])
         .await
         .context("failed to call `example` coordination script")?;
-    let ctx = store.data_mut();
+    let data = store.data_mut();
     let utxo = {
-        let mut resources = ctx.table.iter_mut();
+        let mut resources = data.table.iter_mut();
         match (resources.next(), resources.next()) {
             (Some(utxo), None) => utxo,
             _ => bail!("unexpected resources in table"),
         }
     };
-    assert_eq!(ctx.methods.as_slice(), *METHODS);
-    assert!(ctx.events.is_empty());
+    let UtxoCtx { methods } = data.utxo_cx.take().context("UTXO context missing")?;
+    assert_eq!(methods.as_slice(), *METHODS);
+    assert!(data.events.is_empty());
     let utxo = utxo
         .downcast_mut::<Utxo>()
         .context("failed to downcast UTXO")


### PR DESCRIPTION
Update the runtime for the WIT shape in #180 . `implements-method` stub will need to be removed from the unit test binding implementation once #180 is rebased on top of this PR, no other changes should be necessary.
The test itself is ignored, since the compiler has not been updated to target the new WIT. Once compiler change lands, the unit test will still need to be updated to actually pass the `utxo-context`