### PR TITLE
Compile calls to Utxo methods

### DIFF
--- a/starstream-compiler/src/docs.rs
+++ b/starstream-compiler/src/docs.rs
@@ -2,12 +2,9 @@
 
 use serde::Serialize;
 use starstream_types::{
-    CommentMap,
+    CommentMap, EnumVariantKind,
     ast::{Definition, EnumDef, Program, StructDef},
-    typed_ast::{
-        TypedDefinition, TypedEnumDef, TypedEnumVariantPayload, TypedFunctionDef, TypedProgram,
-        TypedStructDef,
-    },
+    typed_ast::{TypedDefinition, TypedEnumDef, TypedFunctionDef, TypedProgram, TypedStructDef},
     types::Type,
 };
 
@@ -63,11 +60,11 @@ impl From<&Type> for TypeRef {
             Type::Unit => TypeRef::Primitive("()".to_string()),
             Type::Var(id) => TypeRef::Primitive(id.to_string()),
             Type::Record(r) => TypeRef::Struct {
-                name: r.name.clone(),
+                name: r.name.to_string(),
                 kind: TypeKind::Struct,
             },
             Type::Enum(e) => TypeRef::Enum {
-                name: e.name.clone(),
+                name: e.name.to_string(),
                 kind: TypeKind::Enum,
             },
             Type::Tuple(types) => TypeRef::Tuple {
@@ -232,9 +229,10 @@ fn struct_doc(
     field_docs: Vec<Option<String>>,
 ) -> StructDoc {
     StructDoc {
-        name: s.name.name.clone(),
+        name: s.ty.name.to_string(),
         doc,
         fields: s
+            .ty
             .fields
             .iter()
             .zip(field_docs.into_iter().chain(std::iter::repeat(None)))
@@ -249,21 +247,22 @@ fn struct_doc(
 
 fn enum_doc(e: &TypedEnumDef, doc: Option<String>, variant_docs: Vec<Option<String>>) -> EnumDoc {
     EnumDoc {
-        name: e.name.name.clone(),
+        name: e.ty.name.to_string(),
         doc,
         variants: e
+            .ty
             .variants
             .iter()
             .zip(variant_docs.into_iter().chain(std::iter::repeat(None)))
             .map(|(v, doc)| VariantDoc {
                 name: v.name.name.clone(),
                 doc,
-                payload: match &v.payload {
-                    TypedEnumVariantPayload::Unit => VariantPayload::Unit("unit".to_string()),
-                    TypedEnumVariantPayload::Tuple(types) => VariantPayload::Tuple {
+                payload: match &v.kind {
+                    EnumVariantKind::Unit => VariantPayload::Unit("unit".to_string()),
+                    EnumVariantKind::Tuple(types) => VariantPayload::Tuple {
                         tuple: types.iter().map(TypeRef::from).collect(),
                     },
-                    TypedEnumVariantPayload::Struct(fields) => VariantPayload::Struct {
+                    EnumVariantKind::Struct(fields) => VariantPayload::Struct {
                         fields: fields
                             .iter()
                             .map(|f| FieldDoc {

--- a/starstream-compiler/src/docs.rs
+++ b/starstream-compiler/src/docs.rs
@@ -82,16 +82,16 @@ impl From<&Type> for TypeRef {
                 name: "Utxo".to_owned(),
                 kind: TypeKind::Resource,
             },
-            Type::UtxoNamed(name) => TypeRef::Resource {
-                name: name.to_owned(),
+            Type::Utxo(utxo) => TypeRef::Resource {
+                name: utxo.name.to_owned(),
                 kind: TypeKind::Resource,
             },
             Type::TokenAny => TypeRef::Resource {
                 name: "Token".to_owned(),
                 kind: TypeKind::Resource,
             },
-            Type::TokenNamed(name) => TypeRef::Resource {
-                name: name.to_owned(),
+            Type::Token(token) => TypeRef::Resource {
+                name: token.name.to_owned(),
                 kind: TypeKind::Resource,
             },
             Type::Abi(abi) => TypeRef::Resource {

--- a/starstream-compiler/src/lib.rs
+++ b/starstream-compiler/src/lib.rs
@@ -7,6 +7,7 @@ pub mod docs;
 pub mod formatter;
 pub mod module_graph;
 pub mod parser;
+mod pointer_map;
 pub mod typecheck;
 
 pub use docs::{DocsOutput, generate_docs};

--- a/starstream-compiler/src/pointer_map.rs
+++ b/starstream-compiler/src/pointer_map.rs
@@ -16,6 +16,11 @@ impl<V> Default for PointerMap<V> {
 
 impl<V> PointerMap<V> {
     #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    #[inline]
     pub fn insert<T>(&mut self, k: *const T, v: V) -> Option<V> {
         self.inner.insert(k as usize, v)
     }

--- a/starstream-compiler/src/pointer_map.rs
+++ b/starstream-compiler/src/pointer_map.rs
@@ -1,0 +1,37 @@
+use std::collections::{HashMap, hash_map::Entry};
+
+/// Helper for concisely mapping AST nodes to cached data by their address.
+pub struct PointerMap<V> {
+    inner: HashMap<usize, V>,
+}
+
+impl<V> Default for PointerMap<V> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+}
+
+impl<V> PointerMap<V> {
+    #[inline]
+    pub fn insert<T>(&mut self, k: *const T, v: V) -> Option<V> {
+        self.inner.insert(k as usize, v)
+    }
+
+    #[inline]
+    pub fn get<T>(&self, k: *const T) -> Option<&V> {
+        self.inner.get(&(k as usize))
+    }
+
+    #[inline]
+    pub fn entry<T>(&mut self, k: *const T) -> Entry<'_, usize, V> {
+        self.inner.entry(k as usize)
+    }
+
+    #[inline]
+    pub fn remove<T>(&mut self, k: *const T) -> Option<V> {
+        self.inner.remove(&(k as usize))
+    }
+}

--- a/starstream-compiler/src/typecheck/builtins.rs
+++ b/starstream-compiler/src/typecheck/builtins.rs
@@ -160,17 +160,20 @@ fn register_prelude(
     // `impl Token { ... }` block is checked against. It declares
     // `attach(Utxo) -> ()` and `detach(Utxo) -> ()`. User code may not
     // redeclare `abi Token` (guarded in `register_abi`).
-    let mut method = |name: &str| TypedAbiMethodDecl {
-        name: Identifier::new(name, DUMMY_SPAN),
-        ty: Arc::new(FunctionType {
-            kind: FunctionKind::Normal,
-            name_span: DUMMY_SPAN,
-            params: vec![Type::UtxoAny],
-            param_spans: vec![DUMMY_SPAN],
-            result: Type::Unit,
-            callee: Some(StaticFunction::Named(next_name_id.fresh())),
-        }),
-        span: DUMMY_SPAN,
+    let mut method = |name: &str| {
+        let id = next_name_id.fresh();
+        TypedAbiMethodDecl {
+            name: Identifier::new(name, DUMMY_SPAN),
+            id,
+            ty: Arc::new(FunctionType {
+                kind: FunctionKind::Normal,
+                name_span: DUMMY_SPAN,
+                params: vec![Type::UtxoAny],
+                param_spans: vec![DUMMY_SPAN],
+                result: Type::Unit,
+                callee: Some(StaticFunction::Named(id)),
+            }),
+        }
     };
     prelude.types.insert(
         "Token".to_owned(),
@@ -194,13 +197,13 @@ fn register_prelude_enum(
     let type_variants: Vec<EnumVariantType> = variants
         .iter()
         .map(|(vname, kind)| EnumVariantType {
-            name: vname.to_string(),
+            name: Identifier::anon(*vname),
             kind: kind.clone(),
         })
         .collect();
 
     let ty = Type::from(EnumType {
-        name: name.to_owned(),
+        name: Identifier::anon(name),
         variants: type_variants,
         type_args: vec![],
     });

--- a/starstream-compiler/src/typecheck/env.rs
+++ b/starstream-compiler/src/typecheck/env.rs
@@ -365,9 +365,9 @@ fn free_type_vars_type(ty: &Type, out: &mut HashSet<TypeVarId>) {
         | Type::Bool
         | Type::Unit
         | Type::UtxoAny
-        | Type::UtxoNamed(_)
+        | Type::Utxo(_)
         | Type::TokenAny
-        | Type::TokenNamed(_)
+        | Type::Token(_)
         | Type::Abi(_) => {}
     }
 }

--- a/starstream-compiler/src/typecheck/env.rs
+++ b/starstream-compiler/src/typecheck/env.rs
@@ -187,7 +187,7 @@ impl Namespace {
 
     pub fn insert_constant(&mut self, name: &Identifier, v: ConstantInfo) -> Result<(), TypeError> {
         if let Some(old) = self.constants.insert(name.to_string(), v) {
-            return Err(collision(name.as_str(), name.span, old.span));
+            return Err(collision2(name.as_str(), name.span, old.span));
         }
         Ok(())
     }
@@ -264,7 +264,7 @@ impl Namespace {
         }
         for (k, v) in &other.constants {
             if let Some(old) = self.constants.insert(k.to_owned(), v.clone()) {
-                return Err(collision(&k, v.span, old.span));
+                return Err(collision2(&k, v.span, old.span));
             }
         }
         for (k, v) in &other.struct_constructors {
@@ -316,6 +316,16 @@ impl Namespace {
 fn collision(name: &str, span: Span, prev: Span) -> TypeError {
     TypeError::new(
         TypeErrorKind::TypeAlreadyDefined {
+            name: name.to_string(),
+        },
+        span,
+    )
+    .with_secondary(prev, "previously defined here")
+}
+
+fn collision2(name: &str, span: Span, prev: Span) -> TypeError {
+    TypeError::new(
+        TypeErrorKind::FunctionAlreadyDefined {
             name: name.to_string(),
         },
         span,

--- a/starstream-compiler/src/typecheck/exhaustiveness.rs
+++ b/starstream-compiler/src/typecheck/exhaustiveness.rs
@@ -109,9 +109,9 @@ impl CtorSet {
                 };
                 CtorInfo {
                     ctor: Ctor::EnumVariant {
-                        enum_name: enum_type.name.clone(),
+                        enum_name: enum_type.name.to_string(),
                         variant_index: index,
-                        variant_name: variant.name.clone(),
+                        variant_name: variant.name.to_string(),
                     },
                     arity,
                     field_types,
@@ -127,7 +127,7 @@ impl CtorSet {
         Self {
             ctors: vec![CtorInfo {
                 ctor: Ctor::Record {
-                    record_name: record_type.name.clone(),
+                    record_name: record_type.name.to_string(),
                 },
                 arity: record_type.fields.len(),
                 field_types,
@@ -623,9 +623,9 @@ pub fn lower_pattern(pattern: &TypedPattern, ty: &Type) -> SimplePat {
                         .variants
                         .iter()
                         .enumerate()
-                        .find(|(_, v)| v.name == last_name.as_str())
+                        .find(|(_, v)| v.name.as_str() == last_name.as_str())
                         .map(|(i, v)| (i, v.clone()))
-                        .unwrap_or((0, EnumVariantType::unit(last_name.as_str())));
+                        .unwrap_or((0, EnumVariantType::unit(last_name.clone())));
 
                     // Get field order from the type definition
                     let type_fields = match &variant_info.kind {
@@ -666,9 +666,9 @@ pub fn lower_pattern(pattern: &TypedPattern, ty: &Type) -> SimplePat {
                         .variants
                         .iter()
                         .enumerate()
-                        .find(|(_, v)| v.name == last_name.as_str())
+                        .find(|(_, v)| v.name.as_str() == last_name.as_str())
                         .map(|(i, v)| (i, v.clone()))
-                        .unwrap_or((0, EnumVariantType::unit(last_name.as_str())));
+                        .unwrap_or((0, EnumVariantType::unit(last_name.clone())));
 
                     let field_types = match &variant_info.kind {
                         EnumVariantKind::Tuple(types) => types.clone(),
@@ -845,18 +845,20 @@ fn merge_spans(a: Span, b: Span) -> Span {
 
 #[cfg(test)]
 mod tests {
+    use starstream_types::Identifier;
+
     use super::*;
 
     fn make_enum_type(name: &str, variants: Vec<(&str, usize)>) -> Type {
         Type::from(EnumType {
-            name: name.to_string(),
+            name: Identifier::anon(name),
             variants: variants
                 .into_iter()
                 .map(|(vname, arity)| {
                     if arity == 0 {
-                        EnumVariantType::unit(vname)
+                        EnumVariantType::unit(Identifier::anon(vname))
                     } else {
-                        EnumVariantType::tuple(vname, vec![Type::int(); arity])
+                        EnumVariantType::tuple(Identifier::anon(vname), vec![Type::int(); arity])
                     }
                 })
                 .collect(),

--- a/starstream-compiler/src/typecheck/exhaustiveness.rs
+++ b/starstream-compiler/src/typecheck/exhaustiveness.rs
@@ -81,11 +81,9 @@ impl CtorSet {
             // We represent this as an empty constructor set.
             Type::Int(_) | Type::Unit | Type::Var(_) => Some(Self::infinite()),
             Type::Function { .. } | Type::Tuple(_) => Some(Self::infinite()),
-            Type::UtxoAny
-            | Type::UtxoNamed(_)
-            | Type::TokenAny
-            | Type::TokenNamed(_)
-            | Type::Abi(_) => Some(Self::infinite()),
+            Type::UtxoAny | Type::Utxo(_) | Type::TokenAny | Type::Token(_) | Type::Abi(_) => {
+                Some(Self::infinite())
+            }
         }
     }
 

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -1168,9 +1168,11 @@ impl Inferencer {
                     // Assert that the signature sets match
                     let abi_info = env.root.get_abi(&abi)?;
                     self.check_abi_impl(abi, abi_info, &parts)?;
-
-                    let abi = Type::Abi(abi_info.clone());
-                    TypedUtxoPart::AbiImpl { abi, span, parts }
+                    TypedUtxoPart::AbiImpl {
+                        abi: abi_info.clone(),
+                        span,
+                        parts,
+                    }
                 }
             });
         }
@@ -3692,7 +3694,10 @@ impl Inferencer {
                     span: _,
                     parts,
                 } => {
-                    *abi = self.apply(abi);
+                    let Type::Abi(new_abi) = self.apply(&Type::Abi(abi.clone())) else {
+                        unreachable!()
+                    };
+                    *abi = new_abi;
                     for part in parts {
                         self.apply_function(part);
                     }

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -524,7 +524,6 @@ impl Inferencer {
         env: &mut TypeEnv,
         definitions: &[Spanned<Definition>],
     ) -> Result<(TypedProgram, Vec<InferenceTree>), Vec<TypeError>> {
-        let mut typed_definitions = Vec::with_capacity(definitions.len());
         let mut traces = Vec::with_capacity(definitions.len());
         let mut errors = Vec::new();
 
@@ -536,7 +535,10 @@ impl Inferencer {
         // Register definitions.
         for definition in definitions {
             match &definition.node {
-                Definition::Contract => {}
+                Definition::Contract => {
+                    self.typed_definitions
+                        .insert(&definition.node, TypedDefinition::Contract);
+                }
                 Definition::Import(_) => {}
                 Definition::Struct(def) => match self.register_struct(env, def) {
                     Ok(def2) => {
@@ -600,12 +602,17 @@ impl Inferencer {
             }
         }
 
-        // Collect typed AST.
-        for definition in definitions {
-            typed_definitions.extend(self.typed_definitions.remove(&definition.node));
-        }
-
         if errors.is_empty() {
+            // Collect typed AST.
+            let mut typed_definitions = Vec::with_capacity(definitions.len());
+            for definition in definitions {
+                match self.typed_definitions.remove(&definition.node) {
+                    Some(def) => typed_definitions.push(def),
+                    None => panic!("missing TypedDefinition for {:?}", definition.node),
+                }
+            }
+            assert!(self.typed_definitions.is_empty());
+
             Ok((
                 TypedProgram {
                     definitions: typed_definitions,

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -9,9 +9,9 @@ use std::{
 use starstream_types::{
     AbiDef, AbiPart, AbiType, Arguments, DUMMY_SPAN, EffectDef, EventDef, FunctionExport,
     FunctionKind, FunctionType, GenericTypeDef, IfCondition, NameId, Scheme, ScopedName, Span,
-    Spanned, StaticFunction, TokenDef, TokenGlobal, TokenPart, Type, TypeParam, TypeVarId,
-    TypedEffectDef, TypedImportItem, TypedTokenDef, TypedTokenGlobal, TypedTokenPart, TypedUtxoDef,
-    TypedUtxoGlobal, TypedUtxoPart, UtxoDef, UtxoGlobal, UtxoPart,
+    Spanned, StaticFunction, TokenDef, TokenGlobal, TokenPart, TokenType, Type, TypeParam,
+    TypeVarId, TypedEffectDef, TypedImportItem, TypedTokenDef, TypedTokenGlobal, TypedTokenPart,
+    TypedUtxoDef, TypedUtxoGlobal, TypedUtxoPart, UtxoDef, UtxoGlobal, UtxoPart, UtxoType,
     ast::{
         BinaryOp, Block, Definition, EnumDef, EnumVariantPayload, Expr, FunctionDef, Identifier,
         ImportDef, ImportItems, ImportSource, IntegerLiteral, Literal, Pattern, Program, Statement,
@@ -864,7 +864,9 @@ impl Inferencer {
     }
 
     fn register_utxo(&mut self, env: &mut TypeEnv, def: &UtxoDef) -> Result<(), TypeError> {
-        let ty = Type::UtxoNamed(def.name.to_string());
+        let ty = Type::Utxo(Arc::new(UtxoType {
+            name: def.name.to_string(),
+        }));
         env.root.insert_type(
             &def.name,
             TypeEntry {
@@ -907,7 +909,9 @@ impl Inferencer {
     }
 
     fn register_token(&mut self, env: &mut TypeEnv, def: &TokenDef) -> Result<(), TypeError> {
-        let ty = Type::TokenNamed(def.name.to_string());
+        let ty = Type::Token(Arc::new(TokenType {
+            name: def.name.to_string(),
+        }));
         env.root.insert_type(
             &def.name,
             TypeEntry {
@@ -1161,7 +1165,7 @@ impl Inferencer {
         let Some(ty) = env.root.types.get(def.name.as_str()) else {
             unreachable!()
         };
-        assert!(matches!(ty.ty, Type::UtxoNamed(_)));
+        assert!(matches!(ty.ty, Type::Utxo(_)));
         Ok((
             TypedUtxoDef {
                 name: def.name.clone(),
@@ -1284,7 +1288,7 @@ impl Inferencer {
         let Some(ty) = env.root.types.get(def.name.as_str()) else {
             unreachable!()
         };
-        assert!(matches!(ty.ty, Type::TokenNamed(_)));
+        assert!(matches!(ty.ty, Type::Token(_)));
         Ok((
             TypedTokenDef {
                 name: def.name.clone(),
@@ -2927,7 +2931,7 @@ impl Inferencer {
                             let var_ty = self.apply(&binding.scheme.ty);
 
                             match &var_ty {
-                                Type::UtxoAny | Type::UtxoNamed(_) => {}
+                                Type::UtxoAny | Type::Utxo(_) => {}
                                 _ => {
                                     return Err(TypeError::new(
                                         TypeErrorKind::IsCheckRequiresUtxo {
@@ -4628,9 +4632,9 @@ fn substitute_type(
         Type::Bool => Type::Bool,
         Type::Unit => Type::Unit,
         Type::UtxoAny => Type::UtxoAny,
-        Type::UtxoNamed(id) => Type::UtxoNamed(id.clone()),
+        Type::Utxo(id) => Type::Utxo(id.clone()),
         Type::TokenAny => Type::TokenAny,
-        Type::TokenNamed(id) => Type::TokenNamed(id.clone()),
+        Type::Token(id) => Type::Token(id.clone()),
         Type::Abi(name) => Type::Abi(name.clone()),
     }
 }
@@ -4673,9 +4677,9 @@ fn occurs_in(var: TypeVarId, ty: &Type, mapping: &HashMap<TypeVarId, Type>) -> b
         | Type::Bool
         | Type::Unit
         | Type::UtxoAny
-        | Type::UtxoNamed(_)
+        | Type::Utxo(_)
         | Type::TokenAny
-        | Type::TokenNamed(_)
+        | Type::Token(_)
         | Type::Abi(_) => false,
     }
 }
@@ -4730,9 +4734,9 @@ fn collect_free_type_vars(ty: &Type, set: &mut HashSet<TypeVarId>) {
         | Type::Bool
         | Type::Unit
         | Type::UtxoAny
-        | Type::UtxoNamed(_)
+        | Type::Utxo(_)
         | Type::TokenAny
-        | Type::TokenNamed(_)
+        | Type::Token(_)
         | Type::Abi(_) => {}
     }
 }

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -4188,9 +4188,11 @@ impl Inferencer {
                 Ok((Type::Enum(ls), children, "Unify-Enum"))
             }
             // Utxo and Token types are nominal and only unify with themselves.
+            (Type::UtxoAny, Type::UtxoAny) => Ok((Type::UtxoAny, Vec::new(), "Unify-Const")),
             (Type::Utxo(left), Type::Utxo(right)) if Arc::as_ptr(&left) == Arc::as_ptr(&right) => {
                 Ok((Type::Utxo(left), Vec::new(), "Unify-Const"))
             }
+            (Type::TokenAny, Type::TokenAny) => Ok((Type::UtxoAny, Vec::new(), "Unify-Const")),
             (Type::Token(left), Type::Token(right))
                 if Arc::as_ptr(&left) == Arc::as_ptr(&right) =>
             {
@@ -4478,9 +4480,11 @@ impl Inferencer {
                 }
                 (Type::Enum(ls), enum_children, "Unify-Enum")
             }
+            (Type::UtxoAny, Type::UtxoAny) => (Type::UtxoAny, Vec::new(), "Unify-Const"),
             (Type::Utxo(left), Type::Utxo(right)) if Arc::as_ptr(&left) == Arc::as_ptr(&right) => {
                 (Type::Utxo(left), Vec::new(), "Unify-Const")
             }
+            (Type::TokenAny, Type::TokenAny) => (Type::TokenAny, Vec::new(), "Unify-Const"),
             (Type::Token(left), Type::Token(right))
                 if Arc::as_ptr(&left) == Arc::as_ptr(&right) =>
             {

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -4091,28 +4091,15 @@ impl Inferencer {
         right: Type,
     ) -> Result<(Type, Vec<InferenceTree>, &'static str), ()> {
         match (left, right) {
+            (Type::Unit, Type::Unit) => Ok((Type::Unit, Vec::new(), "Unify-Const")),
+            (Type::Bool, Type::Bool) => Ok((Type::Bool, Vec::new(), "Unify-Const")),
             (Type::Int(w1), Type::Int(w2)) if w1 == w2 => {
                 Ok((Type::Int(w1), Vec::new(), "Unify-Const"))
-            }
-            (Type::Bool, Type::Bool) => Ok((Type::Bool, Vec::new(), "Unify-Const")),
-            (Type::Unit, Type::Unit) => Ok((Type::Unit, Vec::new(), "Unify-Const")),
-            (Type::Tuple(left), Type::Tuple(right))
-                if Arc::as_ptr(&left) == Arc::as_ptr(&right) =>
-            {
-                Ok((Type::Tuple(left), vec![], "Unify-Tuple-Identity"))
-            }
-            (Type::Tuple(ls), Type::Tuple(rs)) if ls.len() == rs.len() => {
-                let mut children = Vec::new();
-                for (l, r) in ls.iter().zip(rs.iter()) {
-                    let (_, child, _) = self.unify_inner(l.clone(), r.clone())?;
-                    children.extend(child);
-                }
-                Ok((Type::Tuple(ls), children, "Unify-Tuple"))
             }
             (Type::Function(left), Type::Function(right))
                 if Arc::as_ptr(&left) == Arc::as_ptr(&right) =>
             {
-                Ok((Type::Function(left), vec![], "Unify-Arrow-Identity"))
+                Ok((Type::Function(left), vec![], "Unify-Const"))
             }
             (Type::Function(left), Type::Function(right))
                 if left.params.len() == right.params.len() && left.kind == right.kind =>
@@ -4142,12 +4129,25 @@ impl Inferencer {
                     "Unify-Arrow",
                 ))
             }
+            (Type::Tuple(left), Type::Tuple(right))
+                if Arc::as_ptr(&left) == Arc::as_ptr(&right) =>
+            {
+                Ok((Type::Tuple(left), vec![], "Unify-Const"))
+            }
+            (Type::Tuple(ls), Type::Tuple(rs)) if ls.len() == rs.len() => {
+                let mut children = Vec::new();
+                for (l, r) in ls.iter().zip(rs.iter()) {
+                    let (_, child, _) = self.unify_inner(l.clone(), r.clone())?;
+                    children.extend(child);
+                }
+                Ok((Type::Tuple(ls), children, "Unify-Tuple"))
+            }
             // Records unify structurally: names are aliases, but fields must
             // line up in declaration order, matching `unify` below.
             (Type::Record(left), Type::Record(right))
                 if Arc::as_ptr(&left) == Arc::as_ptr(&right) =>
             {
-                Ok((Type::Record(left), vec![], "Unify-Record-Identity"))
+                Ok((Type::Record(left), vec![], "Unify-Const"))
             }
             (Type::Record(ls), Type::Record(rs)) if ls.fields.len() == rs.fields.len() => {
                 let mut children = Vec::new();
@@ -4163,7 +4163,7 @@ impl Inferencer {
             // Enums likewise unify by shape, not name, with variants compared
             // in declaration order.
             (Type::Enum(left), Type::Enum(right)) if Arc::as_ptr(&left) == Arc::as_ptr(&right) => {
-                Ok((Type::Enum(left), vec![], "Unify-Enum-Identity"))
+                Ok((Type::Enum(left), vec![], "Unify-Const"))
             }
             (Type::Enum(ls), Type::Enum(rs)) if ls.variants.len() == rs.variants.len() => {
                 let mut children = Vec::new();
@@ -4196,6 +4196,19 @@ impl Inferencer {
                     }
                 }
                 Ok((Type::Enum(ls), children, "Unify-Enum"))
+            }
+            // Utxo and Token types are nominal and only unify with themselves.
+            (Type::Utxo(left), Type::Utxo(right)) if Arc::as_ptr(&left) == Arc::as_ptr(&right) => {
+                Ok((Type::Utxo(left), Vec::new(), "Unify-Const"))
+            }
+            (Type::Token(left), Type::Token(right))
+                if Arc::as_ptr(&left) == Arc::as_ptr(&right) =>
+            {
+                Ok((Type::Token(left), Vec::new(), "Unify-Const"))
+            }
+            // TODO: structural unification for Abi types
+            (Type::Abi(left), Type::Abi(right)) if Arc::as_ptr(&left) == Arc::as_ptr(&right) => {
+                Ok((Type::Abi(left), Vec::new(), "Unify-Const"))
             }
             (Type::Var(id), ty) => {
                 if ty == Type::Var(id) {
@@ -4247,7 +4260,6 @@ impl Inferencer {
                 self.subst.insert(id, ty.clone());
                 Ok((ty, Vec::new(), "Unify-Var"))
             }
-            (Type::Abi(l), Type::Abi(r)) if l == r => Ok((Type::Abi(l), Vec::new(), "Unify-Const")),
             _ => Err(()),
         }
     }
@@ -4272,37 +4284,15 @@ impl Inferencer {
         };
 
         let (result_ty, children, rule) = match (left, right) {
+            (Type::Unit, Type::Unit) => (Type::Unit, Vec::new(), "Unify-Const"),
+            (Type::Bool, Type::Bool) => (Type::Bool, Vec::new(), "Unify-Const"),
             (Type::Int(w1), Type::Int(w2)) if w1 == w2 => {
                 (Type::Int(w1), Vec::new(), "Unify-Const")
-            }
-            (Type::Bool, Type::Bool) => (Type::Bool, Vec::new(), "Unify-Const"),
-            (Type::Unit, Type::Unit) => (Type::Unit, Vec::new(), "Unify-Const"),
-            (Type::Tuple(ls), Type::Tuple(rs)) => {
-                if ls.len() != rs.len() {
-                    return Err(TypeError::new(error_kind, left_span)
-                        .with_secondary(right_span, "type mismatch"));
-                }
-
-                let mut tuple_children = Vec::new();
-                for (l, r) in ls.iter().zip(rs.iter()) {
-                    let (_, child) = self.unify(
-                        l.clone(),
-                        r.clone(),
-                        left_span,
-                        right_span,
-                        TypeErrorKind::GeneralMismatch {
-                            expected: l.clone(),
-                            found: r.clone(),
-                        },
-                    )?;
-                    tuple_children.push(child);
-                }
-                (Type::Tuple(ls), tuple_children, "Unify-Tuple")
             }
             (Type::Function(left), Type::Function(right))
                 if Arc::as_ptr(&left) == Arc::as_ptr(&right) =>
             {
-                (Type::Function(left), Vec::new(), "Unify-Arrow-Identity")
+                (Type::Function(left), Vec::new(), "Unify-Const")
             }
             (Type::Function(left), Type::Function(right)) => {
                 if left.params.len() != right.params.len() {
@@ -4358,10 +4348,37 @@ impl Inferencer {
                     "Unify-Arrow",
                 )
             }
+            (Type::Tuple(left), Type::Tuple(right))
+                if Arc::as_ptr(&left) == Arc::as_ptr(&right) =>
+            {
+                (Type::Tuple(left), Vec::new(), "Unify-Const")
+            }
+            (Type::Tuple(ls), Type::Tuple(rs)) => {
+                if ls.len() != rs.len() {
+                    return Err(TypeError::new(error_kind, left_span)
+                        .with_secondary(right_span, "type mismatch"));
+                }
+
+                let mut tuple_children = Vec::new();
+                for (l, r) in ls.iter().zip(rs.iter()) {
+                    let (_, child) = self.unify(
+                        l.clone(),
+                        r.clone(),
+                        left_span,
+                        right_span,
+                        TypeErrorKind::GeneralMismatch {
+                            expected: l.clone(),
+                            found: r.clone(),
+                        },
+                    )?;
+                    tuple_children.push(child);
+                }
+                (Type::Tuple(ls), tuple_children, "Unify-Tuple")
+            }
             (Type::Record(left), Type::Record(right))
                 if Arc::as_ptr(&left) == Arc::as_ptr(&right) =>
             {
-                (Type::Record(left), Vec::new(), "Unify-Record-Identity")
+                (Type::Record(left), Vec::new(), "Unify-Const")
             }
             (Type::Record(ls), Type::Record(rs)) => {
                 if ls.fields.len() != rs.fields.len()
@@ -4392,7 +4409,7 @@ impl Inferencer {
                 (Type::Record(ls), record_children, "Unify-Record")
             }
             (Type::Enum(left), Type::Enum(right)) if Arc::as_ptr(&left) == Arc::as_ptr(&right) => {
-                (Type::Enum(left), Vec::new(), "Unify-Enum-Identity")
+                (Type::Enum(left), Vec::new(), "Unify-Const")
             }
             (Type::Enum(ls), Type::Enum(rs)) => {
                 if ls.variants.len() != rs.variants.len()
@@ -4470,6 +4487,17 @@ impl Inferencer {
                     }
                 }
                 (Type::Enum(ls), enum_children, "Unify-Enum")
+            }
+            (Type::Utxo(left), Type::Utxo(right)) if Arc::as_ptr(&left) == Arc::as_ptr(&right) => {
+                (Type::Utxo(left), Vec::new(), "Unify-Const")
+            }
+            (Type::Token(left), Type::Token(right))
+                if Arc::as_ptr(&left) == Arc::as_ptr(&right) =>
+            {
+                (Type::Token(left), Vec::new(), "Unify-Const")
+            }
+            (Type::Abi(left), Type::Abi(right)) if Arc::as_ptr(&left) == Arc::as_ptr(&right) => {
+                (Type::Abi(left), Vec::new(), "Unify-Const")
             }
             (Type::Var(id), ty) => {
                 self.bind(id, ty.clone(), left_span, right_span, error_kind.clone())?;

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -34,7 +34,7 @@ use super::{
     tree::InferenceTree,
     warnings::{TypeWarning, TypeWarningKind},
 };
-use crate::{ModuleId, formatter};
+use crate::{ModuleId, formatter, pointer_map::PointerMap};
 
 /// Optional settings that control type-checker behavior.
 #[derive(Clone, Debug, Default)]
@@ -393,8 +393,8 @@ struct Inferencer {
 
     /// Name ID assignment.
     next_name_id: NameId,
-    function_names: HashMap<usize, NameId>,
-    import_lists: HashMap<usize, Vec<TypedImportItem>>,
+    function_names: PointerMap<NameId>,
+    import_lists: PointerMap<Vec<TypedImportItem>>,
 
     /// Stack of linearity trackers for `if x is Abi` blocks (supports nesting).
     abi_call_trackers: Vec<AbiCallTracker>,
@@ -542,8 +542,7 @@ impl Inferencer {
                 }
 
                 // Memorize the [TypedImportItem]s for later.
-                self.import_lists
-                    .insert(import as *const _ as usize, typed_items);
+                self.import_lists.insert(import, typed_items);
             }
         }
         Ok(())
@@ -593,7 +592,7 @@ impl Inferencer {
                         None => Type::Unit,
                     };
                     let id = self.next_name_id.fresh();
-                    self.function_names.insert(method as *const _ as usize, id);
+                    self.function_names.insert(method, id);
                     let ty = Arc::new(FunctionType {
                         kind: FunctionKind::Normal,
                         name_span: method.name.span,
@@ -634,7 +633,7 @@ impl Inferencer {
             param_spans.push(param.ty.name_span());
         }
         let id = self.next_name_id.fresh();
-        self.function_names.insert(event as *const _ as usize, id);
+        self.function_names.insert(event, id);
         env.root.insert_constant(
             &event.name,
             ConstantInfo::new(
@@ -665,7 +664,7 @@ impl Inferencer {
             None => Type::Unit,
         };
         let id = self.next_name_id.fresh();
-        self.function_names.insert(effect as *const _ as usize, id);
+        self.function_names.insert(effect, id);
         env.root.insert_constant(
             &effect.name,
             ConstantInfo::new(
@@ -1001,10 +1000,7 @@ impl Inferencer {
 
     fn build_typed_import(&mut self, def: &ImportDef) -> TypedImportDef {
         TypedImportDef {
-            items: self
-                .import_lists
-                .remove(&(def as *const _ as usize))
-                .unwrap(),
+            items: self.import_lists.remove(def).unwrap(),
             from: def.from.clone(),
         }
     }
@@ -1041,10 +1037,7 @@ impl Inferencer {
 
                     typed_parts.push(TypedAbiPart::Event(TypedEventDef {
                         name: event.name.clone(),
-                        id: *self
-                            .function_names
-                            .get(&(event as *const _ as usize))
-                            .unwrap(),
+                        id: *self.function_names.get(event).unwrap(),
                         params,
                     }));
                 }
@@ -1075,10 +1068,7 @@ impl Inferencer {
 
                     typed_parts.push(TypedAbiPart::Effect(TypedEffectDef {
                         name: effect.name.clone(),
-                        id: *self
-                            .function_names
-                            .get(&(effect as *const _ as usize))
-                            .unwrap(),
+                        id: *self.function_names.get(effect).unwrap(),
                         params,
                         return_type: func.result.clone(),
                     }));
@@ -1819,7 +1809,7 @@ impl Inferencer {
             .collect::<Vec<_>>();
         let id = *self
             .function_names
-            .entry(function as *const _ as usize)
+            .entry(function)
             .or_insert_with(|| self.next_name_id.fresh());
         Ok(FunctionType {
             params: param_types.clone(),
@@ -1920,10 +1910,7 @@ impl Inferencer {
             TypedFunctionDef {
                 export: function.export.clone(),
                 name: function.name.clone(),
-                id: *self
-                    .function_names
-                    .get(&(function as *const _ as usize))
-                    .unwrap(),
+                id: *self.function_names.get(function).unwrap(),
                 params: typed_params,
                 return_type: ctx.expected_return,
                 body: typed_body,

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -10,19 +10,19 @@ use starstream_types::{
     AbiDef, AbiPart, AbiType, Arguments, DUMMY_SPAN, EffectDef, EventDef, FunctionExport,
     FunctionKind, FunctionType, GenericTypeDef, IfCondition, NameId, Scheme, ScopedName, Span,
     Spanned, StaticFunction, TokenDef, TokenGlobal, TokenPart, TokenType, Type, TypeParam,
-    TypeVarId, TypedEffectDef, TypedImportItem, TypedTokenDef, TypedTokenGlobal, TypedTokenPart,
-    TypedUtxoDef, TypedUtxoGlobal, TypedUtxoPart, UtxoDef, UtxoGlobal, UtxoPart, UtxoType,
+    TypeVarId, TypedAbiMethodDecl, TypedImportItem, TypedTokenDef, TypedTokenGlobal,
+    TypedTokenPart, TypedUtxoDef, TypedUtxoGlobal, TypedUtxoPart, UtxoDef, UtxoGlobal, UtxoPart,
+    UtxoType,
     ast::{
         BinaryOp, Block, Definition, EnumDef, EnumVariantPayload, Expr, FunctionDef, Identifier,
-        ImportDef, ImportItems, ImportSource, IntegerLiteral, Literal, Pattern, Program, Statement,
-        StructDef, TypeAnnotation, UnaryOp,
+        ImportItems, ImportSource, IntegerLiteral, Literal, Pattern, Program, Statement, StructDef,
+        TypeAnnotation, UnaryOp,
     },
     typed_ast::{
-        TypedAbiDef, TypedAbiMethodDecl, TypedAbiPart, TypedBlock, TypedDefinition, TypedEnumDef,
-        TypedEnumVariant, TypedEnumVariantPayload, TypedEventDef, TypedExpr, TypedExprKind,
+        TypedAbiDef, TypedBlock, TypedDefinition, TypedEnumDef, TypedExpr, TypedExprKind,
         TypedFunctionDef, TypedFunctionParam, TypedIfCondition, TypedImportDef, TypedMatchArm,
-        TypedPattern, TypedProgram, TypedStatement, TypedStructDef, TypedStructField,
-        TypedStructFieldInitializer, TypedStructPatternField,
+        TypedPattern, TypedProgram, TypedStatement, TypedStructDef, TypedStructFieldInitializer,
+        TypedStructPatternField,
     },
     types::{EnumType, EnumVariantKind, EnumVariantType, RecordFieldType, RecordType},
 };
@@ -101,36 +101,17 @@ pub fn typecheck_program(
         });
     }
 
-    // Pass 2: register definition names
-    if let Err(error) = inferencer.register_definitions(&mut env, &program.definitions) {
-        return Err(TypecheckFailure {
-            errors: vec![error],
-            warnings: inferencer.warnings,
-        });
-    }
-
-    // Pass 3: infer definitions
-    let mut typed_definitions = Vec::with_capacity(program.definitions.len());
-    let mut definition_traces = Vec::with_capacity(program.definitions.len());
-
-    let mut errors = Vec::new();
-    for definition in &program.definitions {
-        match inferencer.infer_definition(&mut env, &definition.node) {
-            Ok((typed_definition, trace)) => {
-                typed_definitions.push(typed_definition);
-                definition_traces.push(trace);
-            }
-            Err(error) => {
-                errors.push(error);
-            }
+    // Pass 2: process definitions
+    let (mut program, traces) = match inferencer.process_definitions(&mut env, &program.definitions)
+    {
+        Ok(x) => x,
+        Err(errors) => {
+            return Err(TypecheckFailure {
+                errors,
+                warnings: inferencer.warnings,
+            });
         }
-    }
-    if !errors.is_empty() {
-        return Err(TypecheckFailure {
-            errors,
-            warnings: inferencer.warnings,
-        });
-    }
+    };
 
     // Default any unresolved integer type variables to i64.
     inferencer.default_int_vars();
@@ -143,13 +124,10 @@ pub fn typecheck_program(
         });
     }
 
-    let mut typed_program = TypedProgram {
-        definitions: typed_definitions,
-    };
-    inferencer.apply_substitutions_program(&mut typed_program);
+    inferencer.apply_substitutions_program(&mut program);
 
     let traces = if options.capture_traces {
-        definition_traces
+        traces
     } else {
         Vec::new()
     };
@@ -158,7 +136,7 @@ pub fn typecheck_program(
     let warnings = inferencer.warnings;
 
     Ok(TypecheckSuccess {
-        program: typed_program,
+        program,
         traces,
         generic_types,
         warnings,
@@ -239,42 +217,26 @@ pub fn typecheck_modules(
             continue;
         }
 
-        // Pass 2: register definition names
-        if let Err(error) = inferencer.register_definitions(&mut env, &module.program.definitions) {
-            all_errors.push((module_id, error));
-            continue;
-        }
-
-        // Pass 3: infer definitions
-        let mut typed_definitions = Vec::with_capacity(module.program.definitions.len());
-        let mut module_failed = false;
-        for definition in module.program.definitions.iter() {
-            match inferencer.infer_definition(&mut env, &definition.node) {
-                Ok((typed_def, _trace)) => typed_definitions.push(typed_def),
-                Err(error) => {
-                    all_errors.push((module_id, error));
-                    module_failed = true;
+        // Pass 2: process definitions
+        let (program, _) =
+            match inferencer.process_definitions(&mut env, &module.program.definitions) {
+                Ok(x) => x,
+                Err(errors) => {
+                    // Capture a (possibly partial) export table so other modules can
+                    // continue — they may still produce useful diagnostics. But we
+                    // flag the run as failed.
+                    all_errors.extend(errors.into_iter().map(|e| (module_id, e)));
+                    module_exports.insert(module_id, Namespace::default());
+                    continue;
                 }
-            }
-        }
-
-        if module_failed {
-            // Capture a (possibly partial) export table so other modules can
-            // continue — they may still produce useful diagnostics. But we
-            // flag the run as failed.
-            module_exports.insert(module_id, Namespace::default());
-            continue;
-        }
+            };
 
         // Capture this module's exports for downstream modules.
         // TODO: exclude private items.
         let exports = env.root;
         module_exports.insert(module_id, exports);
 
-        let typed_program = TypedProgram {
-            definitions: typed_definitions,
-        };
-        typed_modules.insert(module_id, typed_program);
+        typed_modules.insert(module_id, program);
 
         // Drain warnings emitted during this module's pass.
         for warning in inferencer.warnings.drain(..) {
@@ -394,7 +356,7 @@ struct Inferencer {
     /// Name ID assignment.
     next_name_id: NameId,
     function_names: PointerMap<NameId>,
-    import_lists: PointerMap<Vec<TypedImportItem>>,
+    typed_definitions: PointerMap<TypedDefinition>,
 
     /// Stack of linearity trackers for `if x is Abi` blocks (supports nesting).
     abi_call_trackers: Vec<AbiCallTracker>,
@@ -429,7 +391,7 @@ impl Inferencer {
             builtins,
             next_name_id,
             function_names: Default::default(),
-            import_lists: Default::default(),
+            typed_definitions: Default::default(),
             warnings: Default::default(),
             abi_call_trackers: Default::default(),
         }
@@ -542,147 +504,124 @@ impl Inferencer {
                 }
 
                 // Memorize the [TypedImportItem]s for later.
-                self.import_lists.insert(import, typed_items);
+                self.typed_definitions.insert(
+                    &def.node,
+                    TypedDefinition::Import(TypedImportDef {
+                        items: typed_items,
+                        from: import.from.clone(),
+                    }),
+                );
             }
         }
         Ok(())
     }
 
     // ------------------------------------------------------------------------
-    // Second pass: register definitions
+    // Second pass: register definition names, mainly type names
 
-    fn register_definitions(
+    fn process_definitions(
         &mut self,
         env: &mut TypeEnv,
         definitions: &[Spanned<Definition>],
-    ) -> Result<(), TypeError> {
+    ) -> Result<(TypedProgram, Vec<InferenceTree>), Vec<TypeError>> {
+        let mut typed_definitions = Vec::with_capacity(definitions.len());
+        let mut traces = Vec::with_capacity(definitions.len());
+        let mut errors = Vec::new();
+
+        // TODO: Allow types to refer to later types by splitting this into three passes:
+        // 1. Preregister everything by name as a type var.
+        // 2. Register struct, enum, and ABI definitions (they only need each other's names).
+        // 3. Register function, utxo, and token definitions (they need to know ABI innards).
+
+        // Register definitions.
         for definition in definitions {
             match &definition.node {
                 Definition::Contract => {}
                 Definition::Import(_) => {}
-                Definition::Struct(def) => self.register_struct(env, def)?,
-                Definition::Enum(def) => self.register_enum(env, def)?,
-                Definition::Function(def) => self.register_function(env, def)?,
-                Definition::Utxo(def) => self.register_utxo(env, def)?,
-                Definition::Token(def) => self.register_token(env, def)?,
-                Definition::Abi(def) => self.register_abi(env, def)?,
-            }
-        }
-        Ok(())
-    }
-
-    fn register_abi(&mut self, env: &mut TypeEnv, def: &AbiDef) -> Result<(), TypeError> {
-        if def.name.name == "Token" {
-            return Err(TypeError::new(
-                TypeErrorKind::ReservedAbiName {
-                    name: def.name.name.clone(),
+                Definition::Struct(def) => match self.register_struct(env, def) {
+                    Ok(def2) => {
+                        self.typed_definitions
+                            .insert(&definition.node, TypedDefinition::Struct(def2));
+                    }
+                    Err(e) => errors.push(e),
                 },
-                def.name.span(),
-            ));
-        }
-
-        let mut methods = Vec::new();
-        for part in &def.parts {
-            match part {
-                AbiPart::Event(event) => self.register_event(env, event)?,
-                AbiPart::Effect(effect) => self.register_effect(env, effect)?,
-                AbiPart::FnDecl(method) => {
-                    let return_type = match &method.return_type {
-                        Some(ann) => self.type_from_annotation(env, ann)?,
-                        None => Type::Unit,
-                    };
-                    let id = self.next_name_id.fresh();
-                    self.function_names.insert(method, id);
-                    let ty = Arc::new(FunctionType {
-                        kind: FunctionKind::Normal,
-                        name_span: method.name.span,
-                        // TODO: recapture `pub` keyword here
-                        params: method
-                            .params
-                            .iter()
-                            .map(|p| self.type_from_annotation(env, &p.ty))
-                            .collect::<Result<Vec<_>, _>>()?,
-                        param_spans: method.params.iter().map(|p| p.name.span).collect(),
-                        result: return_type,
-                        callee: Some(StaticFunction::Named(id)),
-                    });
-                    methods.push(TypedAbiMethodDecl {
-                        name: method.name.clone(),
-                        span: method.name.span(),
-                        ty,
-                    });
-                }
+                Definition::Enum(def) => match self.register_enum(env, def) {
+                    Ok(def2) => {
+                        self.typed_definitions
+                            .insert(&definition.node, TypedDefinition::Enum(def2));
+                    }
+                    Err(e) => errors.push(e),
+                },
+                Definition::Abi(def) => match self.register_abi(env, def) {
+                    Ok(def2) => {
+                        self.typed_definitions
+                            .insert(&definition.node, TypedDefinition::Abi(def2));
+                    }
+                    Err(e) => errors.push(e),
+                },
+                Definition::Utxo(def) => errors.extend(self.register_utxo(env, def).err()),
+                Definition::Token(def) => errors.extend(self.register_token(env, def).err()),
+                Definition::Function(def) => errors.extend(self.register_function(env, def).err()),
             }
         }
-        env.root.insert_type(
-            &def.name,
-            TypeEntry::from(Type::from(AbiType {
-                name: def.name.clone(),
-                methods,
-            })),
-        )?;
-        Ok(())
-    }
 
-    fn register_event(&mut self, env: &mut TypeEnv, event: &EventDef) -> Result<(), TypeError> {
-        let mut param_types = Vec::with_capacity(event.params.len());
-        let mut param_spans = Vec::with_capacity(event.params.len());
-        for param in &event.params {
-            let ty = self.type_from_annotation(env, &param.ty)?;
-            param_types.push(ty);
-            param_spans.push(param.ty.name_span());
+        // Typecheck function bodies.
+        for definition in definitions {
+            match &definition.node {
+                Definition::Contract => {}
+                Definition::Import(_) => {}
+                Definition::Struct(_) => {}
+                Definition::Enum(_) => {}
+                Definition::Abi(_) => {}
+                Definition::Utxo(def) => match self.infer_utxo(env, def) {
+                    Ok((def2, trace)) => {
+                        self.typed_definitions
+                            .insert(&definition.node, TypedDefinition::Utxo(def2));
+                        traces.push(trace);
+                    }
+                    Err(e) => errors.push(e),
+                },
+                Definition::Token(def) => match self.infer_token(env, def) {
+                    Ok((def2, trace)) => {
+                        self.typed_definitions
+                            .insert(&definition.node, TypedDefinition::Token(def2));
+                        traces.push(trace);
+                    }
+                    Err(e) => errors.push(e),
+                },
+                Definition::Function(def) => match self.infer_function(env, def) {
+                    Ok((def2, _ty, trace)) => {
+                        self.typed_definitions
+                            .insert(&definition.node, TypedDefinition::Function(def2));
+                        traces.push(trace);
+                    }
+                    Err(e) => errors.push(e),
+                },
+            }
         }
-        let id = self.next_name_id.fresh();
-        self.function_names.insert(event, id);
-        env.root.insert_constant(
-            &event.name,
-            ConstantInfo::new(
-                event.name.span,
-                Type::from(FunctionType {
-                    kind: FunctionKind::Emit,
-                    name_span: event.name.span,
-                    params: param_types,
-                    param_spans,
-                    result: Type::Unit,
-                    callee: Some(StaticFunction::Named(id)),
-                }),
-            ),
-        )?;
-        Ok(())
-    }
 
-    fn register_effect(&mut self, env: &mut TypeEnv, effect: &EffectDef) -> Result<(), TypeError> {
-        let mut param_types = Vec::with_capacity(effect.params.len());
-        let mut param_spans = Vec::with_capacity(effect.params.len());
-        for param in &effect.params {
-            let ty = self.type_from_annotation(env, &param.ty)?;
-            param_types.push(ty);
-            param_spans.push(param.ty.name_span());
+        // Collect typed AST.
+        for definition in definitions {
+            typed_definitions.extend(self.typed_definitions.remove(&definition.node));
         }
-        let return_type = match &effect.return_type {
-            Some(ann) => self.type_from_annotation(env, ann)?,
-            None => Type::Unit,
-        };
-        let id = self.next_name_id.fresh();
-        self.function_names.insert(effect, id);
-        env.root.insert_constant(
-            &effect.name,
-            ConstantInfo::new(
-                effect.name.span,
-                Type::from(FunctionType {
-                    kind: FunctionKind::Raise,
-                    name_span: effect.name.span,
-                    params: param_types,
-                    param_spans,
-                    result: return_type,
-                    callee: Some(StaticFunction::Named(id)),
-                }),
-            ),
-        )?;
-        Ok(())
+
+        if errors.is_empty() {
+            Ok((
+                TypedProgram {
+                    definitions: typed_definitions,
+                },
+                traces,
+            ))
+        } else {
+            Err(errors)
+        }
     }
 
-    fn register_struct(&mut self, env: &mut TypeEnv, def: &StructDef) -> Result<(), TypeError> {
+    fn register_struct(
+        &mut self,
+        env: &mut TypeEnv,
+        def: &StructDef,
+    ) -> Result<TypedStructDef, TypeError> {
         let mut seen = HashMap::new();
         let mut fields = Vec::with_capacity(def.fields.len());
         for field in &def.fields {
@@ -699,20 +638,16 @@ impl Inferencer {
             }
             seen.insert(field.name.name.clone(), field.name.span());
             let ty = self.type_from_annotation(env, &field.ty)?;
-            fields.push(TypedStructField {
+            fields.push(RecordFieldType {
                 name: field.name.clone(),
                 ty,
             });
         }
-
-        let type_fields = fields
-            .iter()
-            .map(|field| RecordFieldType::new(field.name.clone(), field.ty.clone()))
-            .collect();
-        let ty = Type::from(RecordType {
-            name: def.name.to_string(),
-            fields: type_fields,
+        let record_ty = Arc::new(RecordType {
+            name: def.name.clone(),
+            fields,
         });
+        let ty = Type::from(record_ty.clone());
         env.root.insert_type(
             &def.name,
             TypeEntry {
@@ -732,10 +667,14 @@ impl Inferencer {
                 enum_variant: 0,
             },
         )?;
-        Ok(())
+        Ok(TypedStructDef { ty: record_ty })
     }
 
-    fn register_enum(&mut self, env: &mut TypeEnv, def: &EnumDef) -> Result<(), TypeError> {
+    fn register_enum(
+        &mut self,
+        env: &mut TypeEnv,
+        def: &EnumDef,
+    ) -> Result<TypedEnumDef, TypeError> {
         let mut seen = HashMap::new();
         let mut variants = Vec::with_capacity(def.variants.len());
         for variant in &def.variants {
@@ -790,13 +729,13 @@ impl Inferencer {
             };
 
             variants.push(EnumVariantType {
-                name: variant.name.to_string(),
+                name: variant.name.clone(),
                 kind,
             });
         }
 
         let enum_type = Arc::new(EnumType {
-            name: def.name.to_string(),
+            name: def.name.clone(),
             variants,
             type_args: vec![],
         });
@@ -859,7 +798,135 @@ impl Inferencer {
             }
         }
 
-        Ok(())
+        Ok(TypedEnumDef { ty: enum_type })
+    }
+
+    fn register_abi(&mut self, env: &mut TypeEnv, def: &AbiDef) -> Result<TypedAbiDef, TypeError> {
+        if def.name.name == "Token" {
+            return Err(TypeError::new(
+                TypeErrorKind::ReservedAbiName {
+                    name: def.name.name.clone(),
+                },
+                def.name.span(),
+            ));
+        }
+
+        let mut functions = Vec::new();
+        let mut methods = Vec::new();
+        for part in &def.parts {
+            match part {
+                AbiPart::Event(event) => functions.push(self.register_event(env, event)?),
+                AbiPart::Effect(effect) => functions.push(self.register_effect(env, effect)?),
+                AbiPart::FnDecl(method) => {
+                    let return_type = match &method.return_type {
+                        Some(ann) => self.type_from_annotation(env, ann)?,
+                        None => Type::Unit,
+                    };
+                    let id = self.next_name_id.fresh();
+                    self.function_names.insert(method, id);
+                    let ty = Arc::new(FunctionType {
+                        kind: FunctionKind::Normal,
+                        name_span: method.name.span,
+                        // TODO: recapture `pub` keyword here
+                        params: method
+                            .params
+                            .iter()
+                            .map(|p| self.type_from_annotation(env, &p.ty))
+                            .collect::<Result<Vec<_>, _>>()?,
+                        param_spans: method.params.iter().map(|p| p.name.span).collect(),
+                        result: return_type,
+                        callee: Some(StaticFunction::Named(id)),
+                    });
+                    let m = TypedAbiMethodDecl {
+                        name: method.name.clone(),
+                        id,
+                        ty,
+                    };
+                    functions.push(m.clone());
+                    methods.push(m);
+                }
+            }
+        }
+        let abi_ty = Arc::new(AbiType {
+            name: def.name.clone(),
+            methods,
+        });
+        env.root
+            .insert_type(&def.name, TypeEntry::from(Type::Abi(abi_ty.clone())))?;
+        Ok(TypedAbiDef {
+            ty: abi_ty,
+            functions,
+        })
+    }
+
+    fn register_event(
+        &mut self,
+        env: &mut TypeEnv,
+        event: &EventDef,
+    ) -> Result<TypedAbiMethodDecl, TypeError> {
+        let mut param_types = Vec::with_capacity(event.params.len());
+        let mut param_spans = Vec::with_capacity(event.params.len());
+        for param in &event.params {
+            let ty = self.type_from_annotation(env, &param.ty)?;
+            param_types.push(ty);
+            param_spans.push(param.ty.name_span());
+        }
+        let id = self.next_name_id.fresh();
+        self.function_names.insert(event, id);
+        let func_ty = Arc::new(FunctionType {
+            kind: FunctionKind::Emit,
+            name_span: event.name.span,
+            params: param_types,
+            param_spans,
+            result: Type::Unit,
+            callee: Some(StaticFunction::Named(id)),
+        });
+        env.root.insert_constant(
+            &event.name,
+            ConstantInfo::new(event.name.span, Type::from(func_ty.clone())),
+        )?;
+        Ok(TypedAbiMethodDecl {
+            name: event.name.clone(),
+            id,
+            ty: func_ty,
+        })
+    }
+
+    fn register_effect(
+        &mut self,
+        env: &mut TypeEnv,
+        effect: &EffectDef,
+    ) -> Result<TypedAbiMethodDecl, TypeError> {
+        let mut param_types = Vec::with_capacity(effect.params.len());
+        let mut param_spans = Vec::with_capacity(effect.params.len());
+        for param in &effect.params {
+            let ty = self.type_from_annotation(env, &param.ty)?;
+            param_types.push(ty);
+            param_spans.push(param.ty.name_span());
+        }
+        let return_type = match &effect.return_type {
+            Some(ann) => self.type_from_annotation(env, ann)?,
+            None => Type::Unit,
+        };
+        let id = self.next_name_id.fresh();
+        self.function_names.insert(effect, id);
+        let func_ty = Arc::new(FunctionType {
+            kind: FunctionKind::Raise,
+            name_span: effect.name.span,
+            params: param_types,
+            param_spans,
+            result: return_type,
+            callee: Some(StaticFunction::Named(id)),
+        });
+        env.root.insert_constant(
+            &effect.name,
+            ConstantInfo::new(effect.name.span, Type::from(func_ty.clone())),
+        )?;
+        Ok(TypedAbiMethodDecl {
+            name: effect.name.clone(),
+            id,
+            ty: func_ty,
+        })
     }
 
     fn register_utxo(&mut self, env: &mut TypeEnv, def: &UtxoDef) -> Result<(), TypeError> {
@@ -926,179 +993,14 @@ impl Inferencer {
         Ok(())
     }
 
-    fn register_function(
-        &mut self,
-        _env: &mut TypeEnv,
-        _def: &FunctionDef,
-    ) -> Result<(), TypeError> {
-        // TODO: hoist function type discovery back here, out of `infer_function`,
-        // so that code can call functions declared later in the file.
+    fn register_function(&mut self, env: &mut TypeEnv, def: &FunctionDef) -> Result<(), TypeError> {
+        let ty = Type::Function(Arc::new(self.function_def_to_type(env, def)?));
+        env.root
+            .insert_constant(&def.name, ConstantInfo::new(def.name.span, ty))?;
         Ok(())
     }
 
     // ------------------------------------------------------------------------
-
-    fn build_typed_struct(
-        &self,
-        env: &TypeEnv,
-        def: &StructDef,
-    ) -> Result<TypedStructDef, TypeError> {
-        let info = self.lookup_struct_info(env, std::slice::from_ref(&def.name))?;
-
-        let fields = info
-            .fields()
-            .iter()
-            .map(|field| TypedStructField {
-                name: field.name.clone(),
-                ty: field.ty.clone(),
-            })
-            .collect();
-
-        Ok(TypedStructDef {
-            name: def.name.clone(),
-            fields,
-            ty: info.ty.clone(),
-        })
-    }
-
-    fn build_typed_enum(&self, env: &TypeEnv, def: &EnumDef) -> Result<TypedEnumDef, TypeError> {
-        let info = env.root.types.get(&def.name.name).unwrap();
-        let Type::Enum(enum_ty) = &info.ty else {
-            unreachable!()
-        };
-        let variants = &enum_ty.variants;
-
-        let variants = variants
-            .iter()
-            .zip(&def.variants)
-            .map(|(variant, ast_variant)| TypedEnumVariant {
-                name: ast_variant.name.clone(),
-                payload: match &variant.kind {
-                    EnumVariantKind::Unit => TypedEnumVariantPayload::Unit,
-                    EnumVariantKind::Tuple(payload) => {
-                        TypedEnumVariantPayload::Tuple(payload.clone())
-                    }
-                    EnumVariantKind::Struct(fields) => TypedEnumVariantPayload::Struct(
-                        fields
-                            .iter()
-                            .map(|field| TypedStructField {
-                                name: field.name.clone(),
-                                ty: field.ty.clone(),
-                            })
-                            .collect(),
-                    ),
-                },
-            })
-            .collect();
-
-        Ok(TypedEnumDef {
-            name: def.name.clone(),
-            variants,
-            ty: info.ty.clone(),
-        })
-    }
-
-    fn build_typed_import(&mut self, def: &ImportDef) -> TypedImportDef {
-        TypedImportDef {
-            items: self.import_lists.remove(def).unwrap(),
-            from: def.from.clone(),
-        }
-    }
-
-    fn build_typed_abi(&self, env: &TypeEnv, def: &AbiDef) -> Result<TypedAbiDef, TypeError> {
-        let mut typed_parts = Vec::with_capacity(def.parts.len());
-
-        for part in &def.parts {
-            match part {
-                AbiPart::Event(event) => {
-                    let event_info = env.root.constants.get(&event.name.name).ok_or_else(|| {
-                        TypeError::new(
-                            TypeErrorKind::UnknownEvent {
-                                name: event.name.name.clone(),
-                            },
-                            event.name.span(),
-                        )
-                    })?;
-
-                    let Type::Function(func_ty) = &event_info.ty else {
-                        unreachable!()
-                    };
-
-                    let params = func_ty
-                        .params
-                        .iter()
-                        .zip(&event.params)
-                        .map(|(ty, param)| TypedFunctionParam {
-                            public: param.public,
-                            name: param.name.clone(),
-                            ty: ty.clone(),
-                        })
-                        .collect();
-
-                    typed_parts.push(TypedAbiPart::Event(TypedEventDef {
-                        name: event.name.clone(),
-                        id: *self.function_names.get(event).unwrap(),
-                        params,
-                    }));
-                }
-                AbiPart::Effect(effect) => {
-                    let info = env.root.constants.get(&effect.name.name).ok_or_else(|| {
-                        TypeError::new(
-                            TypeErrorKind::UnknownEvent {
-                                name: effect.name.name.clone(),
-                            },
-                            effect.name.span(),
-                        )
-                    })?;
-
-                    let Type::Function(func) = &info.ty else {
-                        unreachable!()
-                    };
-
-                    let params = func
-                        .params
-                        .iter()
-                        .zip(&effect.params)
-                        .map(|(ty, param)| TypedFunctionParam {
-                            public: param.public,
-                            name: param.name.clone(),
-                            ty: ty.clone(),
-                        })
-                        .collect();
-
-                    typed_parts.push(TypedAbiPart::Effect(TypedEffectDef {
-                        name: effect.name.clone(),
-                        id: *self.function_names.get(effect).unwrap(),
-                        params,
-                        return_type: func.result.clone(),
-                    }));
-                }
-                AbiPart::FnDecl(method) => {
-                    let Type::Abi(abi_info) = &env
-                        .root
-                        .types
-                        .get(&def.name.name)
-                        .expect("abi registered")
-                        .ty
-                    else {
-                        unreachable!()
-                    };
-                    let method_info = abi_info
-                        .methods
-                        .iter()
-                        .find(|m| m.name.as_str() == method.name.as_str())
-                        .expect("method registered");
-
-                    typed_parts.push(TypedAbiPart::FnDecl(method_info.clone()));
-                }
-            }
-        }
-
-        Ok(TypedAbiDef {
-            name: def.name.clone(),
-            parts: typed_parts,
-        })
-    }
 
     fn infer_utxo(
         &mut self,
@@ -1737,56 +1639,6 @@ impl Inferencer {
         }
     }
 
-    /// Type-check a top-level definition.
-    fn infer_definition(
-        &mut self,
-        env: &mut TypeEnv,
-        definition: &Definition,
-    ) -> Result<(TypedDefinition, InferenceTree), TypeError> {
-        match definition {
-            Definition::Contract => Ok((TypedDefinition::Contract, InferenceTree::default())),
-            Definition::Import(import) => {
-                let typed = self.build_typed_import(import);
-                Ok((TypedDefinition::Import(typed), InferenceTree::default()))
-            }
-            Definition::Function(function) => {
-                let (typed_function, ty, trace) = self.infer_function(env, function)?;
-
-                env.root.insert_constant(
-                    &function.name,
-                    ConstantInfo::new(function.name.span, Type::from(ty)),
-                )?;
-
-                Ok((TypedDefinition::Function(typed_function), trace))
-            }
-            Definition::Struct(def) => {
-                let typed = self.build_typed_struct(env, def)?;
-
-                Ok((TypedDefinition::Struct(typed), InferenceTree::default()))
-            }
-            Definition::Enum(def) => {
-                let typed = self.build_typed_enum(env, def)?;
-
-                Ok((TypedDefinition::Enum(typed), InferenceTree::default()))
-            }
-            Definition::Utxo(def) => {
-                let (utxo, trace) = self.infer_utxo(env, def)?;
-
-                Ok((TypedDefinition::Utxo(utxo), trace))
-            }
-            Definition::Token(def) => {
-                let (token, trace) = self.infer_token(env, def)?;
-
-                Ok((TypedDefinition::Token(token), trace))
-            }
-            Definition::Abi(def) => {
-                let typed = self.build_typed_abi(env, def)?;
-
-                Ok((TypedDefinition::Abi(typed), InferenceTree::default()))
-            }
-        }
-    }
-
     fn function_def_to_type(
         &mut self,
         env: &TypeEnv,
@@ -1830,15 +1682,6 @@ impl Inferencer {
         let return_span = function.return_span();
 
         // Insert function into environment. Happens before code so that recursion is allowed.
-        if let Some(existing) = env.get_in_current_scope(function.name.as_str()) {
-            return Err(TypeError::new(
-                TypeErrorKind::FunctionAlreadyDefined {
-                    name: function.name.to_string(),
-                },
-                function.name.span,
-            )
-            .with_secondary(existing.decl_span, "previously defined here"));
-        }
         env.insert(
             function.name.to_string(),
             Binding {

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -930,9 +930,42 @@ impl Inferencer {
     }
 
     fn register_utxo(&mut self, env: &mut TypeEnv, def: &UtxoDef) -> Result<(), TypeError> {
+        let mut yields = Vec::new();
+        let mut possible_abis = Vec::new();
+        for part in &def.parts {
+            match part {
+                UtxoPart::Function(def) => {
+                    Self::collect_yields(&mut yields, &def.body);
+                }
+                UtxoPart::AbiImpl { abi, parts } => {
+                    possible_abis.push(env.root.get_abi(&abi)?.clone());
+                    for part in parts {
+                        Self::collect_yields(&mut yields, &part.body);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut always_abis = Vec::new();
+        if let Some((first, rest)) = yields.split_first() {
+            for abi in first.iter() {
+                always_abis.push(env.root.get_abi(&abi)?.clone());
+            }
+            for &expr in rest {
+                let mut abis = Vec::new();
+                for abi in expr.iter() {
+                    abis.push(env.root.get_abi(&abi)?.clone());
+                }
+                always_abis.retain(|a| abis.contains(a));
+            }
+        }
+
         let ty = Type::Utxo(Arc::new(UtxoType {
             name: def.name.to_string(),
             id: self.next_name_id.fresh(),
+            possible_abis,
+            always_abis,
         }));
         env.root.insert_type(
             &def.name,
@@ -960,10 +993,7 @@ impl Inferencer {
                     }
                 }
                 UtxoPart::Storage(_) => {}
-                UtxoPart::AbiImpl { .. } => {
-                    // TODO: expose ABI impl functions in the namespace?
-                    // (not actually sure if we want to do this)
-                }
+                UtxoPart::AbiImpl { .. } => {}
             }
         }
 
@@ -973,6 +1003,97 @@ impl Inferencer {
             .import_all_from(&ns)?;
 
         Ok(())
+    }
+
+    fn collect_yields<'a>(dest: &mut Vec<&'a Vec<Identifier>>, block: &'a Block) {
+        for stmt in &block.statements {
+            match &stmt.node {
+                Statement::VariableDeclaration { value, .. } => {
+                    Self::collect_yields_expr(dest, &value.node);
+                }
+                Statement::Assignment { value, .. } => {
+                    Self::collect_yields_expr(dest, &value.node);
+                }
+                Statement::While { condition, body } => {
+                    Self::collect_yields_expr(dest, &condition.node);
+                    Self::collect_yields(dest, body);
+                }
+                Statement::Expression(spanned) => {
+                    Self::collect_yields_expr(dest, &spanned.node);
+                }
+                Statement::Return(spanned) => {
+                    if let Some(expr) = spanned {
+                        Self::collect_yields_expr(dest, &expr.node);
+                    }
+                }
+                Statement::Resume => {}
+                Statement::TryWith { subject, effects } => {
+                    Self::collect_yields(dest, subject);
+                    for (_, _, body) in effects {
+                        Self::collect_yields(dest, body);
+                    }
+                }
+            }
+        }
+        if let Some(tail) = &block.tail_expression {
+            Self::collect_yields_expr(dest, &tail.node);
+        }
+    }
+
+    fn collect_yields_expr<'a>(dest: &mut Vec<&'a Vec<Identifier>>, expr: &'a Expr) {
+        match expr {
+            Expr::Yield { abis } => {
+                dest.push(abis);
+            }
+            Expr::Grouping(spanned) => Self::collect_yields_expr(dest, &spanned.node),
+            Expr::ScopedName(_) => {}
+            Expr::Literal(_) => {}
+            Expr::StructConstructor { fields, .. } => {
+                for each in fields {
+                    Self::collect_yields_expr(dest, &each.value.node);
+                }
+            }
+            Expr::Emit { callee, args }
+            | Expr::Raise { callee, args }
+            | Expr::Runtime { callee, args }
+            | Expr::Call { callee, args } => {
+                Self::collect_yields_expr(dest, &callee.node);
+                for each in args {
+                    Self::collect_yields_expr(dest, &each.node);
+                }
+            }
+            Expr::Block(block) => Self::collect_yields(dest, block),
+            Expr::If {
+                branches,
+                else_branch,
+            } => {
+                for (condition, block) in branches {
+                    if let IfCondition::Bool(expr) = condition {
+                        Self::collect_yields_expr(dest, &expr.node);
+                    }
+                    Self::collect_yields(dest, block);
+                }
+                if let Some(block) = else_branch {
+                    Self::collect_yields(dest, block);
+                }
+            }
+            Expr::Match { scrutinee, arms } => {
+                Self::collect_yields_expr(dest, &scrutinee.node);
+                for arm in arms {
+                    Self::collect_yields(dest, &arm.body);
+                }
+            }
+            Expr::FieldAccess { target, .. } => {
+                Self::collect_yields_expr(dest, &target.node);
+            }
+            Expr::Disclose { expr } | Expr::Unary { expr, .. } => {
+                Self::collect_yields_expr(dest, &expr.node);
+            }
+            Expr::Binary { left, right, .. } => {
+                Self::collect_yields_expr(dest, &left.node);
+                Self::collect_yields_expr(dest, &right.node);
+            }
+        }
     }
 
     fn register_token(&mut self, env: &mut TypeEnv, def: &TokenDef) -> Result<(), TypeError> {

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -2802,6 +2802,22 @@ impl Inferencer {
                             })?;
                         Type::Function(method.ty.clone())
                     }
+                    Type::Utxo(utxo) => 'method: {
+                        for abi in &utxo.always_abis {
+                            if let Some(method) =
+                                abi.methods.iter().find(|m| m.name.as_str() == field.name)
+                            {
+                                break 'method Type::Function(method.ty.clone());
+                            }
+                        }
+                        return Err(TypeError::new(
+                            TypeErrorKind::AbiMethodNotFound {
+                                abi_name: utxo.name.to_string(),
+                                method_name: field.name.clone(),
+                            },
+                            field.span(),
+                        ));
+                    }
                     _ => {
                         return Err(TypeError::new(
                             TypeErrorKind::FieldAccessNotStruct {

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -945,7 +945,7 @@ impl Inferencer {
                     Self::collect_yields(&mut yields, &def.body);
                 }
                 UtxoPart::AbiImpl { abi, parts } => {
-                    possible_abis.push(env.root.get_abi(&abi)?.clone());
+                    possible_abis.push(env.root.get_abi(abi)?.clone());
                     for part in parts {
                         Self::collect_yields(&mut yields, &part.body);
                     }
@@ -957,12 +957,12 @@ impl Inferencer {
         let mut always_abis = Vec::new();
         if let Some((first, rest)) = yields.split_first() {
             for abi in first.iter() {
-                always_abis.push(env.root.get_abi(&abi)?.clone());
+                always_abis.push(env.root.get_abi(abi)?.clone());
             }
             for &expr in rest {
                 let mut abis = Vec::new();
                 for abi in expr.iter() {
-                    abis.push(env.root.get_abi(&abi)?.clone());
+                    abis.push(env.root.get_abi(abi)?.clone());
                 }
                 always_abis.retain(|a| abis.contains(a));
             }

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -4192,7 +4192,7 @@ impl Inferencer {
             (Type::Utxo(left), Type::Utxo(right)) if Arc::as_ptr(&left) == Arc::as_ptr(&right) => {
                 Ok((Type::Utxo(left), Vec::new(), "Unify-Const"))
             }
-            (Type::TokenAny, Type::TokenAny) => Ok((Type::UtxoAny, Vec::new(), "Unify-Const")),
+            (Type::TokenAny, Type::TokenAny) => Ok((Type::TokenAny, Vec::new(), "Unify-Const")),
             (Type::Token(left), Type::Token(right))
                 if Arc::as_ptr(&left) == Arc::as_ptr(&right) =>
             {

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -1182,12 +1182,14 @@ impl Inferencer {
         let Some(ty) = env.root.types.get(def.name.as_str()) else {
             unreachable!()
         };
-        assert!(matches!(ty.ty, Type::Utxo(_)));
+        let Type::Utxo(utxo_ty) = &ty.ty else {
+            unreachable!()
+        };
         Ok((
             TypedUtxoDef {
                 name: def.name.clone(),
                 parts,
-                ty: ty.ty.clone(),
+                ty: utxo_ty.clone(),
             },
             self.make_trace("T-Utxo", None, Some(def.name.to_string()), None, || traces),
         ))

--- a/starstream-compiler/src/typecheck/infer.rs
+++ b/starstream-compiler/src/typecheck/infer.rs
@@ -866,6 +866,7 @@ impl Inferencer {
     fn register_utxo(&mut self, env: &mut TypeEnv, def: &UtxoDef) -> Result<(), TypeError> {
         let ty = Type::Utxo(Arc::new(UtxoType {
             name: def.name.to_string(),
+            id: self.next_name_id.fresh(),
         }));
         env.root.insert_type(
             &def.name,
@@ -911,6 +912,7 @@ impl Inferencer {
     fn register_token(&mut self, env: &mut TypeEnv, def: &TokenDef) -> Result<(), TypeError> {
         let ty = Type::Token(Arc::new(TokenType {
             name: def.name.to_string(),
+            id: self.next_name_id.fresh(),
         }));
         env.root.insert_type(
             &def.name,

--- a/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__unknown_type_annotation_error.snap
+++ b/starstream-compiler/src/typecheck/snapshots/starstream_compiler__typecheck__tests__unknown_type_annotation_error.snap
@@ -10,3 +10,11 @@ E0011 (https://starstream.nightstream.dev/errors/E0011)
    :                 ^^^^^^^
  2 |     value;
    `----
+E0011 (https://starstream.nightstream.dev/errors/E0011)
+
+  x unknown type annotation `Missing`
+   ,-[test.star:1:17]
+ 1 | fn takes(value: Missing) {
+   :                 ^^^^^^^
+ 2 |     value;
+   `----

--- a/starstream-language-server/src/document.rs
+++ b/starstream-language-server/src/document.rs
@@ -2171,8 +2171,8 @@ impl DocumentState {
                         .filter_map(|function| self.function_symbol(function))
                         .collect::<Vec<_>>();
                     children.push(DocumentSymbol {
-                        name: abi.compact_display().to_string(),
-                        detail: Some(abi.to_string()),
+                        name: Type::Abi(abi.clone()).compact_display().to_string(),
+                        detail: Some(Type::Abi(abi.clone()).to_string()),
                         kind: SymbolKind::INTERFACE,
                         tags: None,
                         #[allow(deprecated)]

--- a/starstream-language-server/src/document.rs
+++ b/starstream-language-server/src/document.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use ropey::Rope;
-use starstream_types::TypedEnumVariantPayload;
+use starstream_types::FunctionKind;
 use tower_lsp_server::lsp_types::{
     DocumentSymbol, DocumentSymbolResponse, Hover, HoverContents, Location, MarkupContent,
     MarkupKind, Position, Range, SymbolKind, TextEdit, Uri,
@@ -24,9 +24,9 @@ use starstream_types::{
     TypedTokenPart, TypedUtxoDef, TypedUtxoPart,
     ast::{self as untyped_ast, Program, TypeAnnotation},
     typed_ast::{
-        TypedAbiDef, TypedAbiPart, TypedBlock, TypedDefinition, TypedEnumDef, TypedExpr,
-        TypedExprKind, TypedFunctionDef, TypedIfCondition, TypedImportDef, TypedMatchArm,
-        TypedPattern, TypedProgram, TypedStatement, TypedStructDef, TypedStructFieldInitializer,
+        TypedAbiDef, TypedBlock, TypedDefinition, TypedEnumDef, TypedExpr, TypedExprKind,
+        TypedFunctionDef, TypedIfCondition, TypedImportDef, TypedMatchArm, TypedPattern,
+        TypedProgram, TypedStatement, TypedStructDef, TypedStructFieldInitializer,
     },
     types::{EnumType, EnumVariantKind, Type},
 };
@@ -585,7 +585,7 @@ impl DocumentState {
                 for variant in &e.variants {
                     if matches!(variant.kind, EnumVariantKind::Unit) {
                         self.enum_variant_infos.insert(
-                            EnumVariantKey::new(name, &variant.name),
+                            EnumVariantKey::new(name, variant.name.as_str()),
                             EnumVariantPayloadInfo::Unit,
                         );
                     }
@@ -662,51 +662,54 @@ impl DocumentState {
         source: &str,
         doc: Option<String>,
     ) {
-        if let Some(span) = definition.name.opt_span() {
+        if let Some(span) = definition.ty.name.opt_span() {
             self.definition_entries.push(DefinitionEntry {
                 usage: span,
                 target: span,
             });
 
             self.type_definitions
-                .insert(definition.name.name.clone(), span);
+                .insert(definition.ty.name.to_string(), span);
 
-            self.add_hover_span_with_doc(span, &definition.ty, doc.clone());
+            let ty = Type::Record(definition.ty.clone());
+            self.add_hover_span_with_doc(span, &ty, doc.clone());
 
             self.struct_type_index.push(StructTypeEntry {
-                name: definition.name.name.clone(),
-                ty: definition.ty.clone(),
+                name: definition.ty.name.to_string(),
+                ty,
             });
         }
 
         // Store doc comment for type annotation hover
         if let Some(d) = doc {
-            self.struct_docs.insert(definition.name.name.clone(), d);
+            self.struct_docs.insert(definition.ty.name.to_string(), d);
         }
 
-        self.struct_types
-            .insert(definition.name.name.clone(), definition.ty.clone());
+        self.struct_types.insert(
+            definition.ty.name.to_string(),
+            Type::Record(definition.ty.clone()),
+        );
 
         {
             let entry = self
                 .struct_field_definitions
-                .entry(definition.name.name.clone())
+                .entry(definition.ty.name.to_string())
                 .or_default();
             let type_entry = self
                 .struct_field_types
-                .entry(definition.name.name.clone())
+                .entry(definition.ty.name.to_string())
                 .or_default();
-            for field in &definition.fields {
+            for field in &definition.ty.fields {
                 if let Some(span) = field.name.opt_span() {
-                    entry.insert(field.name.name.clone(), span);
+                    entry.insert(field.name.to_string(), span);
                 }
-                type_entry.insert(field.name.name.clone(), field.ty.clone());
+                type_entry.insert(field.name.to_string(), field.ty.clone());
             }
         }
 
         // Extract field-level doc comments using untyped AST spans
         let untyped_fields = untyped.map(|u| &u.fields[..]).unwrap_or(&[]);
-        for (field, untyped_field) in definition.fields.iter().zip(untyped_fields.iter()) {
+        for (field, untyped_field) in definition.ty.fields.iter().zip(untyped_fields.iter()) {
             let field_doc = self.comment_map.doc_comments(untyped_field.span, source);
             if let Some(span) = field.name.opt_span() {
                 self.add_hover_span_with_doc(span, &field.ty, field_doc.clone());
@@ -714,9 +717,9 @@ impl DocumentState {
                 // Store field doc for use at field access sites
                 if let Some(doc) = field_doc {
                     self.struct_field_docs
-                        .entry(definition.name.name.clone())
+                        .entry(definition.ty.name.to_string())
                         .or_default()
-                        .insert(field.name.name.clone(), doc);
+                        .insert(field.name.to_string(), doc);
                 }
             }
         }
@@ -729,66 +732,69 @@ impl DocumentState {
         source: &str,
         doc: Option<String>,
     ) {
-        if let Some(span) = definition.name.opt_span() {
+        if let Some(span) = definition.ty.name.opt_span() {
             self.definition_entries.push(DefinitionEntry {
                 usage: span,
                 target: span,
             });
 
             self.type_definitions
-                .insert(definition.name.name.clone(), span);
+                .insert(definition.ty.name.to_string(), span);
 
-            self.add_hover_span_with_doc(span, &definition.ty, doc.clone());
+            self.add_hover_span_with_doc(span, &Type::Enum(definition.ty.clone()), doc.clone());
         }
 
         // Store doc comment for type annotation hover
         if let Some(d) = doc {
-            self.enum_docs.insert(definition.name.name.clone(), d);
+            self.enum_docs.insert(definition.ty.name.to_string(), d);
         }
 
-        self.enum_types
-            .insert(definition.name.name.clone(), definition.ty.clone());
+        self.enum_types.insert(
+            definition.ty.name.to_string(),
+            Type::Enum(definition.ty.clone()),
+        );
 
         {
             let entry = self
                 .enum_variant_definitions
-                .entry(definition.name.name.clone())
+                .entry(definition.ty.name.to_string())
                 .or_default();
 
             entry.clear();
 
-            for variant in &definition.variants {
+            for variant in &definition.ty.variants {
                 if let Some(span) = variant.name.opt_span() {
                     self.definition_entries.push(DefinitionEntry {
                         usage: span,
                         target: span,
                     });
 
-                    entry.insert(variant.name.name.clone(), span);
+                    entry.insert(variant.name.to_string(), span);
                 }
             }
         }
 
         // Extract variant-level doc comments using untyped AST spans
         let untyped_variants = untyped.map(|u| &u.variants[..]).unwrap_or(&[]);
-        for (variant, untyped_variant) in definition.variants.iter().zip(untyped_variants.iter()) {
+        for (variant, untyped_variant) in definition.ty.variants.iter().zip(untyped_variants.iter())
+        {
             let variant_doc = self.comment_map.doc_comments(untyped_variant.span, source);
-            let key = EnumVariantKey::new(&definition.name.name, &variant.name.name);
+            let key = EnumVariantKey::new(definition.ty.name.as_str(), variant.name.as_str());
 
-            let info = match &variant.payload {
-                TypedEnumVariantPayload::Unit => {
+            let info = match &variant.kind {
+                EnumVariantKind::Unit => {
                     self.enum_variant_field_definitions.remove(&key);
                     EnumVariantPayloadInfo::Unit
                 }
-                TypedEnumVariantPayload::Tuple(types) => {
+                EnumVariantKind::Tuple(types) => {
                     self.enum_variant_field_definitions.remove(&key);
                     EnumVariantPayloadInfo::Tuple(types.clone())
                 }
-                TypedEnumVariantPayload::Struct(fields) => {
+                EnumVariantKind::Struct(fields) => {
                     let info = EnumVariantPayloadInfo::Struct(
                         fields
                             .iter()
-                            .map(|field| (field.name.name.clone(), field.ty.clone()))
+                            .map(|field| (field.name.to_string(), field.ty.clone()))
                             .collect(),
                     );
                     let mut field_hovers = Vec::new();
@@ -800,7 +806,7 @@ impl DocumentState {
                         def_entry.clear();
                         for field in fields {
                             if let Some(span) = field.name.opt_span() {
-                                def_entry.insert(field.name.name.clone(), span);
+                                def_entry.insert(field.name.to_string(), span);
                                 field_hovers.push((span, field.ty.clone()));
                             }
                         }
@@ -823,7 +829,7 @@ impl DocumentState {
                 self.add_hover_label_with_doc(
                     span,
                     format_enum_variant_hover_from_info(
-                        &definition.name.name,
+                        definition.ty.name.as_str(),
                         &variant.name.name,
                         &info,
                     ),
@@ -840,7 +846,7 @@ impl DocumentState {
                     let global = scopes.first_mut().unwrap();
                     for var in vars {
                         if let Some(span) = var.name.opt_span() {
-                            global.insert(var.name.name.clone(), span);
+                            global.insert(var.name.to_string(), span);
                             self.definition_entries.push(DefinitionEntry {
                                 usage: span,
                                 target: span,
@@ -876,7 +882,7 @@ impl DocumentState {
                     let global = scopes.first_mut().unwrap();
                     for var in vars {
                         if let Some(span) = var.name.opt_span() {
-                            global.insert(var.name.name.clone(), span);
+                            global.insert(var.name.to_string(), span);
                             self.definition_entries.push(DefinitionEntry {
                                 usage: span,
                                 target: span,
@@ -908,54 +914,54 @@ impl DocumentState {
         source: &str,
         doc: Option<String>,
     ) {
-        if let Some(span) = definition.name.opt_span() {
+        if let Some(span) = definition.ty.name.opt_span() {
             self.definition_entries.push(DefinitionEntry {
                 usage: span,
                 target: span,
             });
 
             // Add hover for ABI name with doc comment
-            self.add_hover_label_with_doc(span, format!("abi {}", definition.name.name), doc);
+            self.add_hover_label_with_doc(span, format!("abi {}", definition.ty.name), doc);
         }
 
-        for part in &definition.parts {
-            match part {
-                TypedAbiPart::Event(event) => {
-                    if let Some(span) = event.name.opt_span() {
+        for part in &definition.functions {
+            match part.ty.kind {
+                FunctionKind::Emit => {
+                    if let Some(span) = part.name.opt_span() {
                         self.definition_entries.push(DefinitionEntry {
                             usage: span,
                             target: span,
                         });
 
-                        self.add_hover_label(span, format!("event {}", event.name.name));
+                        self.add_hover_label(span, format!("event {}", part.name));
                     }
                 }
-                TypedAbiPart::Effect(effect) => {
-                    if let Some(span) = effect.name.opt_span() {
+                FunctionKind::Raise => {
+                    if let Some(span) = part.name.opt_span() {
                         self.definition_entries.push(DefinitionEntry {
                             usage: span,
                             target: span,
                         });
 
-                        self.add_hover_label(span, format!("effect {}", effect.name.name));
+                        self.add_hover_label(span, format!("effect {}", part.name));
                     }
                 }
-                TypedAbiPart::FnDecl(decl) => {
-                    let method_doc = self.comment_map.doc_comments(decl.span, source);
+                FunctionKind::Normal => {
+                    let method_doc = self.comment_map.doc_comments(part.name.span, source);
 
                     let label = format!(
                         "fn {}{}",
-                        decl.name,
-                        Type::Function(decl.ty.clone()).compact_display()
+                        part.name,
+                        Type::Function(part.ty.clone()).compact_display()
                     );
 
                     // Store for field access hover on narrowed ABI variables
                     self.abi_method_info
-                        .entry(definition.name.name.clone())
+                        .entry(definition.ty.name.to_string())
                         .or_default()
-                        .insert(decl.name.name.clone(), (label.clone(), method_doc.clone()));
+                        .insert(part.name.to_string(), (label.clone(), method_doc.clone()));
 
-                    if let Some(span) = decl.name.opt_span() {
+                    if let Some(span) = part.name.opt_span() {
                         self.definition_entries.push(DefinitionEntry {
                             usage: span,
                             target: span,
@@ -964,6 +970,7 @@ impl DocumentState {
                         self.add_hover_label_with_doc(span, label, method_doc);
                     }
                 }
+                FunctionKind::Runtime => unreachable!(),
             }
         }
     }
@@ -976,7 +983,7 @@ impl DocumentState {
     ) {
         if let Some(span) = function.name.opt_span() {
             self.function_definitions
-                .insert(function.name.name.clone(), span);
+                .insert(function.name.to_string(), span);
 
             self.definition_entries.push(DefinitionEntry {
                 usage: span,
@@ -999,7 +1006,7 @@ impl DocumentState {
             // Store the doc for call-site lookups
             if let Some(d) = doc {
                 self.function_docs
-                    .insert(function.name.name.clone(), (signature, d));
+                    .insert(function.name.to_string(), (signature, d));
             }
         }
 
@@ -1008,7 +1015,7 @@ impl DocumentState {
         if let Some(scope) = scopes.last_mut() {
             for param in &function.params {
                 if let Some(span) = param.name.opt_span() {
-                    scope.insert(param.name.name.clone(), span);
+                    scope.insert(param.name.to_string(), span);
 
                     self.definition_entries.push(DefinitionEntry {
                         usage: span,
@@ -1046,7 +1053,7 @@ impl DocumentState {
                     });
 
                     if let Some(scope) = scopes.last_mut() {
-                        scope.insert(name.name.clone(), span);
+                        scope.insert(name.to_string(), span);
                     }
                 }
 
@@ -1882,7 +1889,7 @@ impl DocumentState {
         let Type::Enum(enum_type) = &def.ty else {
             return None;
         };
-        format_variant_with_params(&enum_type.name, enum_type, variant_name, &params)
+        format_variant_with_params(enum_type.name.as_str(), enum_type, variant_name, &params)
     }
 
     /// Extract variant label from a concrete `Type::Enum` value.
@@ -1890,7 +1897,10 @@ impl DocumentState {
         let Type::Enum(enum_type) = ty else {
             return None;
         };
-        let variant = enum_type.variants.iter().find(|v| v.name == variant_name)?;
+        let variant = enum_type
+            .variants
+            .iter()
+            .find(|v| v.name.as_str() == variant_name)?;
         let info = match &variant.kind {
             EnumVariantKind::Unit => EnumVariantPayloadInfo::Unit,
             EnumVariantKind::Tuple(types) => EnumVariantPayloadInfo::Tuple(types.clone()),
@@ -1902,7 +1912,7 @@ impl DocumentState {
             ),
         };
         Some(format_enum_variant_hover_from_info(
-            &enum_type.name,
+            enum_type.name.as_str(),
             variant_name,
             &info,
         ))
@@ -1913,7 +1923,10 @@ impl DocumentState {
         let Type::Enum(enum_type) = ty else {
             return None;
         };
-        let variant = enum_type.variants.iter().find(|v| v.name == variant_name)?;
+        let variant = enum_type
+            .variants
+            .iter()
+            .find(|v| v.name.as_str() == variant_name)?;
         match &variant.kind {
             EnumVariantKind::Tuple(types) => Some(types.clone()),
             _ => None,
@@ -2006,7 +2019,7 @@ impl DocumentState {
 
         #[allow(deprecated)]
         let symbol = DocumentSymbol {
-            name: function.name.name.clone(),
+            name: function.name.to_string(),
             detail: None,
             kind: SymbolKind::FUNCTION,
             tags: None,
@@ -2020,13 +2033,13 @@ impl DocumentState {
     }
 
     fn struct_symbol(&self, definition: &TypedStructDef) -> Option<DocumentSymbol> {
-        let name_span = definition.name.opt_span()?;
+        let name_span = definition.ty.name.opt_span()?;
         let mut children = Vec::new();
-        for field in &definition.fields {
+        for field in &definition.ty.fields {
             if let Some(span) = field.name.opt_span() {
                 #[allow(deprecated)]
                 let child = DocumentSymbol {
-                    name: field.name.name.clone(),
+                    name: field.name.to_string(),
                     detail: Some(field.ty.to_string()),
                     kind: SymbolKind::FIELD,
                     tags: None,
@@ -2041,8 +2054,8 @@ impl DocumentState {
 
         #[allow(deprecated)]
         let symbol = DocumentSymbol {
-            name: definition.name.name.clone(),
-            detail: Some(definition.ty.to_string()),
+            name: definition.ty.name.to_string(),
+            detail: Some(Type::Record(definition.ty.clone()).to_string()),
             kind: SymbolKind::STRUCT,
             tags: None,
             deprecated: None,
@@ -2059,13 +2072,13 @@ impl DocumentState {
     }
 
     fn enum_symbol(&self, definition: &TypedEnumDef) -> Option<DocumentSymbol> {
-        let name_span = definition.name.opt_span()?;
+        let name_span = definition.ty.name.opt_span()?;
         let mut children = Vec::new();
-        for variant in &definition.variants {
+        for variant in &definition.ty.variants {
             if let Some(span) = variant.name.opt_span() {
-                let detail = match &variant.payload {
-                    TypedEnumVariantPayload::Unit => None,
-                    TypedEnumVariantPayload::Tuple(types) => {
+                let detail = match &variant.kind {
+                    EnumVariantKind::Unit => None,
+                    EnumVariantKind::Tuple(types) => {
                         if types.is_empty() {
                             Some("()".to_string())
                         } else {
@@ -2078,7 +2091,7 @@ impl DocumentState {
                             )
                         }
                     }
-                    TypedEnumVariantPayload::Struct(fields) => {
+                    EnumVariantKind::Struct(fields) => {
                         if fields.is_empty() {
                             Some("{ }".to_string())
                         } else {
@@ -2094,7 +2107,7 @@ impl DocumentState {
                 };
                 #[allow(deprecated)]
                 let child = DocumentSymbol {
-                    name: variant.name.name.clone(),
+                    name: variant.name.to_string(),
                     detail,
                     kind: SymbolKind::ENUM_MEMBER,
                     tags: None,
@@ -2109,8 +2122,8 @@ impl DocumentState {
 
         #[allow(deprecated)]
         let symbol = DocumentSymbol {
-            name: definition.name.name.clone(),
-            detail: Some(definition.ty.to_string()),
+            name: definition.ty.name.to_string(),
+            detail: Some(Type::Enum(definition.ty.clone()).to_string()),
             kind: SymbolKind::ENUM,
             tags: None,
             deprecated: None,
@@ -2136,7 +2149,7 @@ impl DocumentState {
                         if let Some(span) = var.name.opt_span() {
                             #[allow(deprecated)]
                             let child = DocumentSymbol {
-                                name: var.name.name.clone(),
+                                name: var.name.to_string(),
                                 detail: Some(var.ty.to_string()),
                                 kind: SymbolKind::ENUM_MEMBER,
                                 tags: None,
@@ -2174,7 +2187,7 @@ impl DocumentState {
 
         #[allow(deprecated)]
         let symbol = DocumentSymbol {
-            name: definition.name.name.clone(),
+            name: definition.name.to_string(),
             detail: None,
             kind: SymbolKind::CLASS,
             tags: None,
@@ -2201,7 +2214,7 @@ impl DocumentState {
                         if let Some(span) = var.name.opt_span() {
                             #[allow(deprecated)]
                             let child = DocumentSymbol {
-                                name: var.name.name.clone(),
+                                name: var.name.to_string(),
                                 detail: Some(var.ty.to_string()),
                                 kind: SymbolKind::ENUM_MEMBER,
                                 tags: None,
@@ -2239,7 +2252,7 @@ impl DocumentState {
 
         #[allow(deprecated)]
         let symbol = DocumentSymbol {
-            name: definition.name.name.clone(),
+            name: definition.name.to_string(),
             detail: None,
             kind: SymbolKind::CLASS,
             tags: None,
@@ -2257,17 +2270,19 @@ impl DocumentState {
     }
 
     fn abi_symbol(&self, definition: &TypedAbiDef) -> Option<DocumentSymbol> {
-        let name_span = definition.name.opt_span()?;
+        let name_span = definition.ty.name.opt_span()?;
         let mut children = Vec::new();
 
-        for part in &definition.parts {
-            match part {
-                TypedAbiPart::Event(event) => {
-                    if let Some(span) = event.name.opt_span() {
-                        let params = event
+        for part in &definition.functions {
+            match part.ty.kind {
+                FunctionKind::Emit => {
+                    if let Some(span) = part.name.opt_span() {
+                        // TODO: restore parameter names here
+                        let params = part
+                            .ty
                             .params
                             .iter()
-                            .map(|p| format!("{}: {}", p.name.name, p.ty))
+                            .map(|p| p.to_string())
                             .collect::<Vec<_>>()
                             .join(", ");
 
@@ -2275,7 +2290,7 @@ impl DocumentState {
 
                         #[allow(deprecated)]
                         let child = DocumentSymbol {
-                            name: event.name.name.clone(),
+                            name: part.name.to_string(),
                             detail,
                             kind: SymbolKind::EVENT,
                             tags: None,
@@ -2288,16 +2303,18 @@ impl DocumentState {
                         children.push(child);
                     }
                 }
-                TypedAbiPart::Effect(effect) => {
-                    if let Some(span) = effect.name.opt_span() {
-                        let params = effect
+                FunctionKind::Raise => {
+                    if let Some(span) = part.name.opt_span() {
+                        // TODO: restore parameter names here
+                        let params = part
+                            .ty
                             .params
                             .iter()
-                            .map(|p| format!("{}: {}", p.name.name, p.ty))
+                            .map(|p| p.to_string())
                             .collect::<Vec<_>>()
                             .join(", ");
 
-                        let ret = match &effect.return_type {
+                        let ret = match &part.ty.result {
                             Type::Unit => String::new(),
                             ty => format!(" -> {ty}"),
                         };
@@ -2306,7 +2323,7 @@ impl DocumentState {
 
                         #[allow(deprecated)]
                         let child = DocumentSymbol {
-                            name: effect.name.name.clone(),
+                            name: part.name.to_string(),
                             detail,
                             kind: SymbolKind::EVENT,
                             tags: None,
@@ -2319,17 +2336,17 @@ impl DocumentState {
                         children.push(child);
                     }
                 }
-                TypedAbiPart::FnDecl(decl) => {
-                    if let Some(span) = decl.name.opt_span() {
+                FunctionKind::Normal => {
+                    if let Some(span) = part.name.opt_span() {
                         let detail = Some(
-                            Type::Function(decl.ty.clone())
+                            Type::Function(part.ty.clone())
                                 .compact_display()
                                 .to_string(),
                         );
 
                         #[allow(deprecated)]
                         let child = DocumentSymbol {
-                            name: decl.name.name.clone(),
+                            name: part.name.to_string(),
                             detail,
                             kind: SymbolKind::METHOD,
                             tags: None,
@@ -2342,12 +2359,13 @@ impl DocumentState {
                         children.push(child);
                     }
                 }
+                FunctionKind::Runtime => unreachable!(),
             }
         }
 
         #[allow(deprecated)]
         let symbol = DocumentSymbol {
-            name: definition.name.name.clone(),
+            name: definition.ty.name.to_string(),
             detail: None,
             kind: SymbolKind::INTERFACE,
             tags: None,
@@ -2479,7 +2497,7 @@ fn format_variant_with_params(
     variant_name: &str,
     params: &HashMap<TypeVarId, String>,
 ) -> Option<String> {
-    let variant = enum_type.variants.iter().find(|v| v.name == variant_name)?;
+    let variant = enum_type.get_variant(variant_name)?;
     Some(match &variant.kind {
         EnumVariantKind::Unit => format!("{enum_name}::{variant_name}"),
         EnumVariantKind::Tuple(types) => {

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -1582,7 +1582,7 @@ impl Compiler {
             ty,
         );
         self.resource_abi_fns
-            .insert(utxo.ty.clone(), (new_fn, drop_fn));
+            .insert(Type::Utxo(utxo.ty.clone()), (new_fn, drop_fn));
 
         // Utxos declared in a file have an "exported" half and an "imported" half
         // since calls need to go through the runtime.
@@ -1601,7 +1601,11 @@ impl Compiler {
 
                         // Don't use declared result (always Unit). The imported version returns a handle.
                         let mut results = Vec::with_capacity(1);
-                        _ = self.star_to_core_types(function.name.span(), &mut results, &utxo.ty);
+                        _ = self.star_to_core_types(
+                            function.name.span(),
+                            &mut results,
+                            &Type::Utxo(utxo.ty.clone()),
+                        );
 
                         let wit_name = format!(
                             "[static]{resource_name}.{}",
@@ -1630,7 +1634,10 @@ impl Compiler {
         );
         self.resources.insert(utxo.name.to_string(), resource);
 
-        let (resource_new_fn, _resource_drop_fn) = *self.resource_abi_fns.get(&utxo.ty).unwrap();
+        let (resource_new_fn, _resource_drop_fn) = *self
+            .resource_abi_fns
+            .get(&Type::Utxo(utxo.ty.clone()))
+            .unwrap();
 
         // Reserve the ID for the `resume;` function for this Utxo.
         let yield_start = self.yield_id;
@@ -1695,14 +1702,15 @@ impl Compiler {
                     parts,
                 } => {
                     _ = abi; // TODO: generate cast functions
+                    let this = Type::Utxo(utxo.ty.clone());
                     for function in parts {
                         let core = self.visit_function(
-                            Some(&utxo.ty),
+                            Some(&this),
                             function,
                             &(&() as &dyn Locals, &utxo_storage),
                         );
                         let sig = self.star_to_component_signature(
-                            Some(&utxo.ty),
+                            Some(&this),
                             &function.params,
                             &function.return_type,
                         );
@@ -1731,7 +1739,7 @@ impl Compiler {
         let end_global = self.globals.len();
         self.generate_storage_exports(
             &utxo.name,
-            &utxo.ty,
+            &Type::Utxo(utxo.ty.clone()),
             &mut iface,
             &interface_name,
             self.yield_global

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -9,12 +9,12 @@ use miette::{Diagnostic, LabeledSpan};
 use sha2::Digest;
 use starstream_types::{
     BinaryOp, EnumType, EnumVariantKind, FunctionExport, IntWidth, Literal, Span, Spanned,
-    StaticFunction, Type, TypedAbiDef, TypedAbiPart, TypedBlock, TypedDefinition, TypedEnumDef,
-    TypedExpr, TypedExprKind, TypedFunctionDef, TypedFunctionParam, TypedIfCondition,
-    TypedImportDef, TypedMatchArm, TypedPattern, TypedProgram, TypedStatement, TypedStructDef,
-    TypedTokenDef, TypedTokenPart, TypedUtxoDef, TypedUtxoPart, UnaryOp, ast::Identifier,
+    StaticFunction, Type, TypedAbiDef, TypedBlock, TypedDefinition, TypedEnumDef, TypedExpr,
+    TypedExprKind, TypedFunctionDef, TypedFunctionParam, TypedIfCondition, TypedImportDef,
+    TypedMatchArm, TypedPattern, TypedProgram, TypedStatement, TypedStructDef, TypedTokenDef,
+    TypedTokenPart, TypedUtxoDef, TypedUtxoPart, UnaryOp, ast::Identifier,
 };
-use starstream_types::{ImportSource, NameId};
+use starstream_types::{FunctionKind, ImportSource, NameId};
 use thiserror::Error;
 use wasm_encoder::{
     BlockType, CodeSection, Component, ComponentExportKind, ComponentExportSection, ComponentType,
@@ -1039,7 +1039,7 @@ impl Compiler {
                     .iter()
                     .map(|v| {
                         (
-                            to_kebab_case(&v.name),
+                            to_kebab_case(v.name.as_str()),
                             match &v.kind {
                                 EnumVariantKind::Unit => None,
                                 EnumVariantKind::Tuple(fields) => {
@@ -1388,18 +1388,18 @@ impl Compiler {
     }
 
     fn visit_abi(&mut self, def: &TypedAbiDef) {
-        for part in &def.parts {
-            match part {
-                TypedAbiPart::Event(event) => {
+        for part in &def.functions {
+            match part.ty.kind {
+                FunctionKind::Emit => {
                     let mut core_params = Vec::with_capacity(16);
-                    let span = event.name.span();
-                    for p in &event.params {
-                        _ = self.star_to_core_types(span, &mut core_params, &p.ty);
+                    let span = part.ty.name_span;
+                    for p in &part.ty.params {
+                        _ = self.star_to_core_types(span, &mut core_params, p);
                     }
 
                     let interface =
-                        format!("starstream:events/{}", to_kebab_case(def.name.as_str()));
-                    let kebab = to_kebab_case(event.name.as_str());
+                        format!("starstream:events/{}", to_kebab_case(def.ty.name.as_str()));
+                    let kebab = to_kebab_case(part.name.as_str());
 
                     // Core import
                     let core_fn_ty = self.add_core_func_type(&FuncType::new(
@@ -1407,13 +1407,14 @@ impl Compiler {
                         std::iter::empty(),
                     ));
                     let func = self.import_function(&interface, &kebab, core_fn_ty);
-                    self.callables.insert(event.id, func);
+                    self.callables.insert(part.id, func);
 
                     // Component import
-                    let comp_params = event
+                    let comp_params = part
+                        .ty
                         .params
                         .iter()
-                        .filter_map(|p| self.star_to_component_type(&p.ty).map(|t| ("x", t)))
+                        .filter_map(|p| self.star_to_component_type(p).map(|t| ("x", t)))
                         .collect::<Vec<_>>();
                     let comp_result = None;
                     let iface = self.imported_interfaces.entry(interface).or_default();
@@ -1423,18 +1424,18 @@ impl Compiler {
                         .inner
                         .export(&kebab, ComponentTypeRef::Func(comp_fn_ty));
                 }
-                TypedAbiPart::Effect(effect) => {
+                FunctionKind::Raise => {
                     let mut core_params = Vec::with_capacity(16);
-                    let span = effect.name.span();
-                    for p in &effect.params {
-                        _ = self.star_to_core_types(span, &mut core_params, &p.ty);
+                    let span = part.name.span();
+                    for p in &part.ty.params {
+                        _ = self.star_to_core_types(span, &mut core_params, p);
                     }
                     let mut core_results = Vec::new();
-                    _ = self.star_to_core_types(span, &mut core_results, &effect.return_type);
+                    _ = self.star_to_core_types(span, &mut core_results, &part.ty.result);
 
                     let interface =
-                        format!("starstream:effects/{}", to_kebab_case(def.name.as_str()));
-                    let kebab = to_kebab_case(effect.name.as_str());
+                        format!("starstream:effects/{}", to_kebab_case(def.ty.name.as_str()));
+                    let kebab = to_kebab_case(part.name.as_str());
 
                     // Core import
                     let core_fn_ty = self.add_core_func_type(&FuncType::new(
@@ -1442,15 +1443,16 @@ impl Compiler {
                         core_results,
                     ));
                     let func = self.import_function(&interface, &kebab, core_fn_ty);
-                    self.callables.insert(effect.id, func);
+                    self.callables.insert(part.id, func);
 
                     // Component import
-                    let comp_params = effect
+                    let comp_params = part
+                        .ty
                         .params
                         .iter()
-                        .filter_map(|p| self.star_to_component_type(&p.ty).map(|t| ("x", t)))
+                        .filter_map(|p| self.star_to_component_type(p).map(|t| ("x", t)))
                         .collect::<Vec<_>>();
-                    let comp_result = self.star_to_component_type(&effect.return_type);
+                    let comp_result = self.star_to_component_type(&part.ty.result);
                     let iface = self.imported_interfaces.entry(interface).or_default();
                     let comp_fn_ty =
                         iface.encode_func(comp_params.into_iter(), comp_result.as_ref());
@@ -1458,9 +1460,10 @@ impl Compiler {
                         .inner
                         .export(&kebab, ComponentTypeRef::Func(comp_fn_ty));
                 }
-                TypedAbiPart::FnDecl(_) => {
+                FunctionKind::Normal => {
                     // ABI method codegen not yet implemented.
                 }
+                FunctionKind::Runtime => unreachable!(),
             }
         }
     }
@@ -1554,11 +1557,11 @@ impl Compiler {
     }
 
     fn visit_struct(&mut self, struct_: &TypedStructDef) {
-        self.export_component_ty(struct_.name.as_str(), &struct_.ty);
+        self.export_component_ty(struct_.ty.name.as_str(), &Type::Record(struct_.ty.clone()));
     }
 
     fn visit_enum(&mut self, enum_: &TypedEnumDef) {
-        self.export_component_ty(enum_.name.as_str(), &enum_.ty);
+        self.export_component_ty(enum_.ty.name.as_str(), &Type::Enum(enum_.ty.clone()));
     }
 
     fn pre_visit_utxo(&mut self, utxo: &TypedUtxoDef) {

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -3117,21 +3117,21 @@ impl Compiler {
                             } else if let Some(&core_fn_idx) = self.callables.get(name) {
                                 self.visit_call(func, bb, locals, span, core_fn_idx, args)
                             } else {
-                                return Err(self.push_error(
+                                Err(self.push_error(
                                     callee_span,
                                     format!(
                                         "no callable found for method {name} on type {}",
                                         target.node.ty
                                     ),
-                                ));
+                                ))
                             }
                         } else if let Some(&core_fn_idx) = self.callables.get(name) {
                             self.visit_call(func, bb, locals, span, core_fn_idx, args)
                         } else {
-                            return Err(self.push_error(
+                            Err(self.push_error(
                                 callee_span,
                                 format!("no callable found for function {name}"),
-                            ));
+                            ))
                         }
                     }
                     Some(StaticFunction::Constructor { variant }) => {

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -221,7 +221,7 @@ struct Compiler {
     builtin_starstream_i64_add_checked: Option<u32>,
     builtin_starstream_i64_sub_checked: Option<u32>,
     builtin_starstream_i64_mul_checked: Option<u32>,
-    /// Map from name to resource index.
+    /// Map from resource full name to resource index.
     resources: HashMap<String, u32>,
     /// Function bodies.
     code_bytes: Vec<Vec<u8>>,
@@ -952,9 +952,9 @@ impl Compiler {
                     ComponentAbiType::Borrow { resource: idx }
                 }
             }
-            Type::UtxoNamed(name) => {
-                if let Some(idx) = self.resources.get(name) {
-                    ComponentAbiType::Borrow { resource: *idx }
+            Type::Utxo(utxo) => {
+                if let Some(&idx) = self.resources.get(&utxo.name) {
+                    ComponentAbiType::Borrow { resource: idx }
                 } else {
                     return None;
                 }
@@ -972,9 +972,9 @@ impl Compiler {
                     ComponentAbiType::Borrow { resource: idx }
                 }
             }
-            Type::TokenNamed(name) => {
-                if let Some(idx) = self.resources.get(name) {
-                    ComponentAbiType::Borrow { resource: *idx }
+            Type::Token(token) => {
+                if let Some(&idx) = self.resources.get(&token.name) {
+                    ComponentAbiType::Borrow { resource: idx }
                 } else {
                     return None;
                 }
@@ -1142,7 +1142,7 @@ impl Compiler {
                     .and(ok);
                 dest.extend(flat);
             }
-            Type::UtxoAny | Type::UtxoNamed(_) | Type::TokenAny | Type::TokenNamed(_) => {
+            Type::UtxoAny | Type::Utxo(_) | Type::TokenAny | Type::Token(_) => {
                 dest.push(ValType::I32)
             }
             _ => ok = Err(self.push_error(span, format!("unknown core lowering for {ty:?}"))),
@@ -1227,7 +1227,7 @@ impl Compiler {
             Type::Unit => 0,
             Type::Bool => 1,
             Type::Int(_) => 1,
-            Type::UtxoAny | Type::UtxoNamed(_) | Type::TokenAny | Type::TokenNamed(_) => 1,
+            Type::UtxoAny | Type::Utxo(_) | Type::TokenAny | Type::Token(_) => 1,
             Type::Tuple(items) => items.iter().map(|t| self.star_count_core_types(t)).sum(),
             Type::Record(record) => record
                 .fields
@@ -2366,7 +2366,7 @@ impl Compiler {
                         func.instructions(bb).i64_const(value as i64);
                         Ok(())
                     }
-                    Type::Int(_) | Type::UtxoNamed(_) => {
+                    Type::Int(_) | Type::Utxo(_) => {
                         func.instructions(bb).i32_const(value as i32);
                         Ok(())
                     }

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -218,6 +218,8 @@ struct Compiler {
     core_func_type_cache: HashMap<FuncType, u32>,
     /// Map from name to function index.
     callables: HashMap<NameId, u32>,
+    /// Map from (this type, name) to function index, for calling ABI methods on concrete UTXOs.
+    method_callables: HashMap<(Type, NameId), u32>,
     builtin_starstream_i64_add_checked: Option<u32>,
     builtin_starstream_i64_sub_checked: Option<u32>,
     builtin_starstream_i64_mul_checked: Option<u32>,
@@ -1616,6 +1618,49 @@ impl Compiler {
                         self.callables.insert(function.id, idx);
                     }
                 }
+                TypedUtxoPart::AbiImpl {
+                    span: _,
+                    abi,
+                    parts,
+                } => {
+                    let always_on = utxo.ty.always_abis.iter().any(|a| a == abi);
+                    if always_on {
+                        let this = Type::Utxo(utxo.ty.clone());
+                        for function in parts {
+                            let mut params = Vec::with_capacity(16);
+                            _ = self.star_to_core_types(function.name.span, &mut params, &this);
+                            for p in &function.params {
+                                _ = self.star_to_core_types(
+                                    p.name.span_or(function.name.span()),
+                                    &mut params,
+                                    &p.ty,
+                                );
+                            }
+
+                            let mut results = Vec::with_capacity(1);
+                            _ = self.star_to_core_types(
+                                function.name.span(),
+                                &mut results,
+                                &function.return_type,
+                            );
+
+                            let wit_name = format!(
+                                "[method]{resource_name}.{}",
+                                to_kebab_case(function.name.as_str())
+                            );
+                            let ty = self.add_core_func_type(&FuncType::new(params, results));
+                            let idx = self.import_function(&interface_name, &wit_name, ty);
+                            let abi_function_id = abi
+                                .methods
+                                .iter()
+                                .find(|m| m.name == function.name)
+                                .unwrap()
+                                .id;
+                            self.method_callables
+                                .insert((this.clone(), abi_function_id), idx);
+                        }
+                    }
+                }
                 _ => {}
             }
         }
@@ -1698,10 +1743,10 @@ impl Compiler {
                 }
                 TypedUtxoPart::AbiImpl {
                     span: _,
-                    abi,
+                    abi: _,
                     parts,
                 } => {
-                    _ = abi; // TODO: generate cast functions
+                    // TODO: generate cast functions
                     let this = Type::Utxo(utxo.ty.clone());
                     for function in parts {
                         let core = self.visit_function(
@@ -3060,12 +3105,31 @@ impl Compiler {
                 };
                 match &func_ty.callee {
                     Some(StaticFunction::Named(name)) => {
-                        let Some(&target) = self.callables.get(name) else {
-                            return Err(
-                                self.push_error(callee_span, "no callable found for identifier")
-                            );
-                        };
-                        self.visit_call(func, bb, locals, span, target, args)
+                        if let TypedExprKind::FieldAccess { target, .. } = &callee.node.kind {
+                            if let Some(&core_fn_idx) =
+                                self.method_callables.get(&(target.node.ty.clone(), *name))
+                            {
+                                self.visit_expr_stack(func, bb, locals, target.span, &target.node)?;
+                                self.visit_call(func, bb, locals, span, core_fn_idx, args)
+                            } else if let Some(&core_fn_idx) = self.callables.get(name) {
+                                self.visit_call(func, bb, locals, span, core_fn_idx, args)
+                            } else {
+                                return Err(self.push_error(
+                                    callee_span,
+                                    format!(
+                                        "no callable found for method {name} on type {}",
+                                        target.node.ty
+                                    ),
+                                ));
+                            }
+                        } else if let Some(&core_fn_idx) = self.callables.get(name) {
+                            self.visit_call(func, bb, locals, span, core_fn_idx, args)
+                        } else {
+                            return Err(self.push_error(
+                                callee_span,
+                                format!("no callable found for function {name}"),
+                            ));
+                        }
                     }
                     Some(StaticFunction::Constructor { variant }) => {
                         // Enum tuple variant constructor.

--- a/starstream-to-wasm/tests/inputs/score.star
+++ b/starstream-to-wasm/tests/inputs/score.star
@@ -33,4 +33,5 @@ utxo ScoreProgress {
 
 script fn example() {
     let prog = ScoreProgress::new();
+    prog.plus_chips(10);
 }

--- a/starstream-to-wasm/tests/snapshots/inputs@blockheight.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@blockheight.star.snap
@@ -168,7 +168,6 @@ Program {
 }
 
 ==== Inference trace ====
-
 T-Fn: reexport => i64
   T-Expr: {reexport: fn() -> i64} ⊢ runtime blockHeight(); ⇒ ()
     T-Call: {reexport: fn() -> i64} ⊢ runtime blockHeight() ⇒ i64

--- a/starstream-to-wasm/tests/snapshots/inputs@effect_raise.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@effect_raise.star.snap
@@ -138,7 +138,6 @@ Program {
 }
 
 ==== Inference trace ====
-
 T-Fn: main => ()
   T-TryWith: {main: fn() -> ()} ⊢ try {
     raise Hello();
@@ -159,32 +158,52 @@ TypedProgram {
     definitions: [
         Abi(
             TypedAbiDef {
-                name: Identifier {
-                    name: "Foo",
-                    span: 4..7,
+                ty: AbiType {
+                    name: Identifier {
+                        name: "Foo",
+                        span: 4..7,
+                    },
+                    methods: [],
                 },
-                parts: [
-                    Effect(
-                        TypedEffectDef {
-                            name: Identifier {
-                                name: "Hello",
-                                span: 21..26,
-                            },
-                            id: NameId(2),
-                            params: [],
-                            return_type: Unit,
+                functions: [
+                    TypedAbiMethodDecl {
+                        name: Identifier {
+                            name: "Hello",
+                            span: 21..26,
                         },
-                    ),
-                    Event(
-                        TypedEventDef {
-                            name: Identifier {
-                                name: "Goodbye",
-                                span: 40..47,
-                            },
-                            id: NameId(3),
+                        id: NameId(2),
+                        ty: FunctionType {
+                            kind: Raise,
+                            name_span: 21..26,
                             params: [],
+                            param_spans: [],
+                            result: Unit,
+                            callee: Some(
+                                Named(
+                                    NameId(2),
+                                ),
+                            ),
                         },
-                    ),
+                    },
+                    TypedAbiMethodDecl {
+                        name: Identifier {
+                            name: "Goodbye",
+                            span: 40..47,
+                        },
+                        id: NameId(3),
+                        ty: FunctionType {
+                            kind: Emit,
+                            name_span: 40..47,
+                            params: [],
+                            param_spans: [],
+                            result: Unit,
+                            callee: Some(
+                                Named(
+                                    NameId(3),
+                                ),
+                            ),
+                        },
+                    },
                 ],
             },
         ),

--- a/starstream-to-wasm/tests/snapshots/inputs@enum.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@enum.star.snap
@@ -252,7 +252,6 @@ Program {
 }
 
 ==== Inference trace ====
-
 T-Fn: accepts_foo => ()
 
 T-Fn: get_bar => ()
@@ -284,62 +283,39 @@ TypedProgram {
     definitions: [
         Enum(
             TypedEnumDef {
-                name: Identifier {
-                    name: "Foo",
-                    span: 5..8,
-                },
-                variants: [
-                    TypedEnumVariant {
-                        name: Identifier {
-                            name: "Bar",
-                            span: 15..18,
-                        },
-                        payload: Tuple(
-                            [
-                                Bool,
-                            ],
-                        ),
-                    },
-                    TypedEnumVariant {
-                        name: Identifier {
-                            name: "Baz",
-                            span: 30..33,
-                        },
-                        payload: Tuple(
-                            [
-                                Int(
-                                    I64,
-                                ),
-                            ],
-                        ),
-                    },
-                ],
-                ty: Enum(
-                    EnumType {
+                ty: EnumType {
+                    name: Identifier {
                         name: "Foo",
-                        variants: [
-                            EnumVariantType {
-                                name: "Bar",
-                                kind: Tuple(
-                                    [
-                                        Bool,
-                                    ],
-                                ),
-                            },
-                            EnumVariantType {
-                                name: "Baz",
-                                kind: Tuple(
-                                    [
-                                        Int(
-                                            I64,
-                                        ),
-                                    ],
-                                ),
-                            },
-                        ],
-                        type_args: [],
+                        span: 5..8,
                     },
-                ),
+                    variants: [
+                        EnumVariantType {
+                            name: Identifier {
+                                name: "Bar",
+                                span: 15..18,
+                            },
+                            kind: Tuple(
+                                [
+                                    Bool,
+                                ],
+                            ),
+                        },
+                        EnumVariantType {
+                            name: Identifier {
+                                name: "Baz",
+                                span: 30..33,
+                            },
+                            kind: Tuple(
+                                [
+                                    Int(
+                                        I64,
+                                    ),
+                                ],
+                            ),
+                        },
+                    ],
+                    type_args: [],
+                },
             },
         ),
         Function(
@@ -359,10 +335,16 @@ TypedProgram {
                         },
                         ty: Enum(
                             EnumType {
-                                name: "Foo",
+                                name: Identifier {
+                                    name: "Foo",
+                                    span: 5..8,
+                                },
                                 variants: [
                                     EnumVariantType {
-                                        name: "Bar",
+                                        name: Identifier {
+                                            name: "Bar",
+                                            span: 15..18,
+                                        },
                                         kind: Tuple(
                                             [
                                                 Bool,
@@ -370,7 +352,10 @@ TypedProgram {
                                         ),
                                     },
                                     EnumVariantType {
-                                        name: "Baz",
+                                        name: Identifier {
+                                            name: "Baz",
+                                            span: 30..33,
+                                        },
                                         kind: Tuple(
                                             [
                                                 Int(
@@ -420,10 +405,16 @@ TypedProgram {
                                                         params: [
                                                             Enum(
                                                                 EnumType {
-                                                                    name: "Foo",
+                                                                    name: Identifier {
+                                                                        name: "Foo",
+                                                                        span: 5..8,
+                                                                    },
                                                                     variants: [
                                                                         EnumVariantType {
-                                                                            name: "Bar",
+                                                                            name: Identifier {
+                                                                                name: "Bar",
+                                                                                span: 15..18,
+                                                                            },
                                                                             kind: Tuple(
                                                                                 [
                                                                                     Bool,
@@ -431,7 +422,10 @@ TypedProgram {
                                                                             ),
                                                                         },
                                                                         EnumVariantType {
-                                                                            name: "Baz",
+                                                                            name: Identifier {
+                                                                                name: "Baz",
+                                                                                span: 30..33,
+                                                                            },
                                                                             kind: Tuple(
                                                                                 [
                                                                                     Int(
@@ -473,10 +467,16 @@ TypedProgram {
                                                 node: TypedExpr {
                                                     ty: Enum(
                                                         EnumType {
-                                                            name: "Foo",
+                                                            name: Identifier {
+                                                                name: "Foo",
+                                                                span: 5..8,
+                                                            },
                                                             variants: [
                                                                 EnumVariantType {
-                                                                    name: "Bar",
+                                                                    name: Identifier {
+                                                                        name: "Bar",
+                                                                        span: 15..18,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Bool,
@@ -484,7 +484,10 @@ TypedProgram {
                                                                     ),
                                                                 },
                                                                 EnumVariantType {
-                                                                    name: "Baz",
+                                                                    name: Identifier {
+                                                                        name: "Baz",
+                                                                        span: 30..33,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Int(
@@ -510,10 +513,16 @@ TypedProgram {
                                                                         param_spans: [],
                                                                         result: Enum(
                                                                             EnumType {
-                                                                                name: "Foo",
+                                                                                name: Identifier {
+                                                                                    name: "Foo",
+                                                                                    span: 5..8,
+                                                                                },
                                                                                 variants: [
                                                                                     EnumVariantType {
-                                                                                        name: "Bar",
+                                                                                        name: Identifier {
+                                                                                            name: "Bar",
+                                                                                            span: 15..18,
+                                                                                        },
                                                                                         kind: Tuple(
                                                                                             [
                                                                                                 Bool,
@@ -521,7 +530,10 @@ TypedProgram {
                                                                                         ),
                                                                                     },
                                                                                     EnumVariantType {
-                                                                                        name: "Baz",
+                                                                                        name: Identifier {
+                                                                                            name: "Baz",
+                                                                                            span: 30..33,
+                                                                                        },
                                                                                         kind: Tuple(
                                                                                             [
                                                                                                 Int(
@@ -615,10 +627,16 @@ TypedProgram {
                                                         params: [
                                                             Enum(
                                                                 EnumType {
-                                                                    name: "Foo",
+                                                                    name: Identifier {
+                                                                        name: "Foo",
+                                                                        span: 5..8,
+                                                                    },
                                                                     variants: [
                                                                         EnumVariantType {
-                                                                            name: "Bar",
+                                                                            name: Identifier {
+                                                                                name: "Bar",
+                                                                                span: 15..18,
+                                                                            },
                                                                             kind: Tuple(
                                                                                 [
                                                                                     Bool,
@@ -626,7 +644,10 @@ TypedProgram {
                                                                             ),
                                                                         },
                                                                         EnumVariantType {
-                                                                            name: "Baz",
+                                                                            name: Identifier {
+                                                                                name: "Baz",
+                                                                                span: 30..33,
+                                                                            },
                                                                             kind: Tuple(
                                                                                 [
                                                                                     Int(
@@ -668,10 +689,16 @@ TypedProgram {
                                                 node: TypedExpr {
                                                     ty: Enum(
                                                         EnumType {
-                                                            name: "Foo",
+                                                            name: Identifier {
+                                                                name: "Foo",
+                                                                span: 5..8,
+                                                            },
                                                             variants: [
                                                                 EnumVariantType {
-                                                                    name: "Bar",
+                                                                    name: Identifier {
+                                                                        name: "Bar",
+                                                                        span: 15..18,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Bool,
@@ -679,7 +706,10 @@ TypedProgram {
                                                                     ),
                                                                 },
                                                                 EnumVariantType {
-                                                                    name: "Baz",
+                                                                    name: Identifier {
+                                                                        name: "Baz",
+                                                                        span: 30..33,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Int(
@@ -707,10 +737,16 @@ TypedProgram {
                                                                         param_spans: [],
                                                                         result: Enum(
                                                                             EnumType {
-                                                                                name: "Foo",
+                                                                                name: Identifier {
+                                                                                    name: "Foo",
+                                                                                    span: 5..8,
+                                                                                },
                                                                                 variants: [
                                                                                     EnumVariantType {
-                                                                                        name: "Bar",
+                                                                                        name: Identifier {
+                                                                                            name: "Bar",
+                                                                                            span: 15..18,
+                                                                                        },
                                                                                         kind: Tuple(
                                                                                             [
                                                                                                 Bool,
@@ -718,7 +754,10 @@ TypedProgram {
                                                                                         ),
                                                                                     },
                                                                                     EnumVariantType {
-                                                                                        name: "Baz",
+                                                                                        name: Identifier {
+                                                                                            name: "Baz",
+                                                                                            span: 30..33,
+                                                                                        },
                                                                                         kind: Tuple(
                                                                                             [
                                                                                                 Int(

--- a/starstream-to-wasm/tests/snapshots/inputs@enum_simple.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@enum_simple.star.snap
@@ -57,54 +57,35 @@ TypedProgram {
     definitions: [
         Enum(
             TypedEnumDef {
-                name: Identifier {
-                    name: "Message",
-                    span: 5..12,
-                },
-                variants: [
-                    TypedEnumVariant {
-                        name: Identifier {
-                            name: "Ping",
-                            span: 19..23,
-                        },
-                        payload: Unit,
-                    },
-                    TypedEnumVariant {
-                        name: Identifier {
-                            name: "Pong",
-                            span: 29..33,
-                        },
-                        payload: Tuple(
-                            [
-                                Int(
-                                    I64,
-                                ),
-                            ],
-                        ),
-                    },
-                ],
-                ty: Enum(
-                    EnumType {
+                ty: EnumType {
+                    name: Identifier {
                         name: "Message",
-                        variants: [
-                            EnumVariantType {
-                                name: "Ping",
-                                kind: Unit,
-                            },
-                            EnumVariantType {
-                                name: "Pong",
-                                kind: Tuple(
-                                    [
-                                        Int(
-                                            I64,
-                                        ),
-                                    ],
-                                ),
-                            },
-                        ],
-                        type_args: [],
+                        span: 5..12,
                     },
-                ),
+                    variants: [
+                        EnumVariantType {
+                            name: Identifier {
+                                name: "Ping",
+                                span: 19..23,
+                            },
+                            kind: Unit,
+                        },
+                        EnumVariantType {
+                            name: Identifier {
+                                name: "Pong",
+                                span: 29..33,
+                            },
+                            kind: Tuple(
+                                [
+                                    Int(
+                                        I64,
+                                    ),
+                                ],
+                            ),
+                        },
+                    ],
+                    type_args: [],
+                },
             },
         ),
     ],

--- a/starstream-to-wasm/tests/snapshots/inputs@events.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@events.star.snap
@@ -77,7 +77,6 @@ Program {
 }
 
 ==== Inference trace ====
-
 T-Fn: main => ()
   T-Expr: {main: fn() -> ()} ⊢ emit Hello(); ⇒ ()
     T-Call: {main: fn() -> ()} ⊢ emit Hello() ⇒ ()
@@ -88,21 +87,33 @@ TypedProgram {
     definitions: [
         Abi(
             TypedAbiDef {
-                name: Identifier {
-                    name: "Foo",
-                    span: 4..7,
+                ty: AbiType {
+                    name: Identifier {
+                        name: "Foo",
+                        span: 4..7,
+                    },
+                    methods: [],
                 },
-                parts: [
-                    Event(
-                        TypedEventDef {
-                            name: Identifier {
-                                name: "Hello",
-                                span: 20..25,
-                            },
-                            id: NameId(2),
-                            params: [],
+                functions: [
+                    TypedAbiMethodDecl {
+                        name: Identifier {
+                            name: "Hello",
+                            span: 20..25,
                         },
-                    ),
+                        id: NameId(2),
+                        ty: FunctionType {
+                            kind: Emit,
+                            name_span: 20..25,
+                            params: [],
+                            param_spans: [],
+                            result: Unit,
+                            callee: Some(
+                                Named(
+                                    NameId(2),
+                                ),
+                            ),
+                        },
+                    },
                 ],
             },
         ),

--- a/starstream-to-wasm/tests/snapshots/inputs@match_expression.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@match_expression.star.snap
@@ -943,9 +943,6 @@ Program {
 }
 
 ==== Inference trace ====
-
-
-
 T-Fn: match_foo => i64
   T-ReturnTail: match foo {
     Foo::Thing(Thing::Wow(ctx)) => {
@@ -1068,7 +1065,6 @@ T-Fn: match_literal => i64
       Unify-Var: i64 ~ i64 => i64
     Unify-Var: i64 ~ i64 => {i64/t7}
 
-
 T-Fn: match_point => i64
   T-ReturnTail: match msg {
     Message::Point { x, y } => {
@@ -1120,262 +1116,166 @@ TypedProgram {
     definitions: [
         Struct(
             TypedStructDef {
-                name: Identifier {
-                    name: "Ctx",
-                    span: 7..10,
-                },
-                fields: [
-                    TypedStructField {
-                        name: Identifier {
-                            name: "x",
-                            span: 17..18,
-                        },
-                        ty: Int(
-                            I64,
-                        ),
-                    },
-                ],
-                ty: Record(
-                    RecordType {
+                ty: RecordType {
+                    name: Identifier {
                         name: "Ctx",
-                        fields: [
-                            RecordFieldType {
-                                name: Identifier {
-                                    name: "x",
-                                    span: 17..18,
-                                },
-                                ty: Int(
-                                    I64,
-                                ),
-                            },
-                        ],
+                        span: 7..10,
                     },
-                ),
+                    fields: [
+                        RecordFieldType {
+                            name: Identifier {
+                                name: "x",
+                                span: 17..18,
+                            },
+                            ty: Int(
+                                I64,
+                            ),
+                        },
+                    ],
+                },
             },
         ),
         Enum(
             TypedEnumDef {
-                name: Identifier {
-                    name: "Thing",
-                    span: 33..38,
-                },
-                variants: [
-                    TypedEnumVariant {
-                        name: Identifier {
-                            name: "Wow",
-                            span: 45..48,
-                        },
-                        payload: Tuple(
-                            [
-                                Record(
-                                    RecordType {
-                                        name: "Ctx",
-                                        fields: [
-                                            RecordFieldType {
-                                                name: Identifier {
-                                                    name: "x",
-                                                    span: 17..18,
-                                                },
-                                                ty: Int(
-                                                    I64,
-                                                ),
-                                            },
-                                        ],
-                                    },
-                                ),
-                            ],
-                        ),
-                    },
-                    TypedEnumVariant {
-                        name: Identifier {
-                            name: "Who",
-                            span: 59..62,
-                        },
-                        payload: Unit,
-                    },
-                ],
-                ty: Enum(
-                    EnumType {
+                ty: EnumType {
+                    name: Identifier {
                         name: "Thing",
-                        variants: [
-                            EnumVariantType {
-                                name: "Wow",
-                                kind: Tuple(
-                                    [
-                                        Record(
-                                            RecordType {
-                                                name: "Ctx",
-                                                fields: [
-                                                    RecordFieldType {
-                                                        name: Identifier {
-                                                            name: "x",
-                                                            span: 17..18,
-                                                        },
-                                                        ty: Int(
-                                                            I64,
-                                                        ),
-                                                    },
-                                                ],
-                                            },
-                                        ),
-                                    ],
-                                ),
-                            },
-                            EnumVariantType {
-                                name: "Who",
-                                kind: Unit,
-                            },
-                        ],
-                        type_args: [],
+                        span: 33..38,
                     },
-                ),
+                    variants: [
+                        EnumVariantType {
+                            name: Identifier {
+                                name: "Wow",
+                                span: 45..48,
+                            },
+                            kind: Tuple(
+                                [
+                                    Record(
+                                        RecordType {
+                                            name: Identifier {
+                                                name: "Ctx",
+                                                span: 7..10,
+                                            },
+                                            fields: [
+                                                RecordFieldType {
+                                                    name: Identifier {
+                                                        name: "x",
+                                                        span: 17..18,
+                                                    },
+                                                    ty: Int(
+                                                        I64,
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                ],
+                            ),
+                        },
+                        EnumVariantType {
+                            name: Identifier {
+                                name: "Who",
+                                span: 59..62,
+                            },
+                            kind: Unit,
+                        },
+                    ],
+                    type_args: [],
+                },
             },
         ),
         Enum(
             TypedEnumDef {
-                name: Identifier {
-                    name: "Foo",
-                    span: 72..75,
-                },
-                variants: [
-                    TypedEnumVariant {
-                        name: Identifier {
-                            name: "Bar",
-                            span: 82..85,
-                        },
-                        payload: Tuple(
-                            [
-                                Bool,
-                            ],
-                        ),
-                    },
-                    TypedEnumVariant {
-                        name: Identifier {
-                            name: "Baz",
-                            span: 97..100,
-                        },
-                        payload: Tuple(
-                            [
-                                Int(
-                                    I64,
-                                ),
-                            ],
-                        ),
-                    },
-                    TypedEnumVariant {
-                        name: Identifier {
-                            name: "Thing",
-                            span: 111..116,
-                        },
-                        payload: Tuple(
-                            [
-                                Enum(
-                                    EnumType {
-                                        name: "Thing",
-                                        variants: [
-                                            EnumVariantType {
-                                                name: "Wow",
-                                                kind: Tuple(
-                                                    [
-                                                        Record(
-                                                            RecordType {
-                                                                name: "Ctx",
-                                                                fields: [
-                                                                    RecordFieldType {
-                                                                        name: Identifier {
-                                                                            name: "x",
-                                                                            span: 17..18,
-                                                                        },
-                                                                        ty: Int(
-                                                                            I64,
-                                                                        ),
-                                                                    },
-                                                                ],
-                                                            },
-                                                        ),
-                                                    ],
-                                                ),
-                                            },
-                                            EnumVariantType {
-                                                name: "Who",
-                                                kind: Unit,
-                                            },
-                                        ],
-                                        type_args: [],
-                                    },
-                                ),
-                            ],
-                        ),
-                    },
-                ],
-                ty: Enum(
-                    EnumType {
+                ty: EnumType {
+                    name: Identifier {
                         name: "Foo",
-                        variants: [
-                            EnumVariantType {
-                                name: "Bar",
-                                kind: Tuple(
-                                    [
-                                        Bool,
-                                    ],
-                                ),
-                            },
-                            EnumVariantType {
-                                name: "Baz",
-                                kind: Tuple(
-                                    [
-                                        Int(
-                                            I64,
-                                        ),
-                                    ],
-                                ),
-                            },
-                            EnumVariantType {
-                                name: "Thing",
-                                kind: Tuple(
-                                    [
-                                        Enum(
-                                            EnumType {
-                                                name: "Thing",
-                                                variants: [
-                                                    EnumVariantType {
-                                                        name: "Wow",
-                                                        kind: Tuple(
-                                                            [
-                                                                Record(
-                                                                    RecordType {
-                                                                        name: "Ctx",
-                                                                        fields: [
-                                                                            RecordFieldType {
-                                                                                name: Identifier {
-                                                                                    name: "x",
-                                                                                    span: 17..18,
-                                                                                },
-                                                                                ty: Int(
-                                                                                    I64,
-                                                                                ),
-                                                                            },
-                                                                        ],
-                                                                    },
-                                                                ),
-                                                            ],
-                                                        ),
-                                                    },
-                                                    EnumVariantType {
-                                                        name: "Who",
-                                                        kind: Unit,
-                                                    },
-                                                ],
-                                                type_args: [],
-                                            },
-                                        ),
-                                    ],
-                                ),
-                            },
-                        ],
-                        type_args: [],
+                        span: 72..75,
                     },
-                ),
+                    variants: [
+                        EnumVariantType {
+                            name: Identifier {
+                                name: "Bar",
+                                span: 82..85,
+                            },
+                            kind: Tuple(
+                                [
+                                    Bool,
+                                ],
+                            ),
+                        },
+                        EnumVariantType {
+                            name: Identifier {
+                                name: "Baz",
+                                span: 97..100,
+                            },
+                            kind: Tuple(
+                                [
+                                    Int(
+                                        I64,
+                                    ),
+                                ],
+                            ),
+                        },
+                        EnumVariantType {
+                            name: Identifier {
+                                name: "Thing",
+                                span: 111..116,
+                            },
+                            kind: Tuple(
+                                [
+                                    Enum(
+                                        EnumType {
+                                            name: Identifier {
+                                                name: "Thing",
+                                                span: 33..38,
+                                            },
+                                            variants: [
+                                                EnumVariantType {
+                                                    name: Identifier {
+                                                        name: "Wow",
+                                                        span: 45..48,
+                                                    },
+                                                    kind: Tuple(
+                                                        [
+                                                            Record(
+                                                                RecordType {
+                                                                    name: Identifier {
+                                                                        name: "Ctx",
+                                                                        span: 7..10,
+                                                                    },
+                                                                    fields: [
+                                                                        RecordFieldType {
+                                                                            name: Identifier {
+                                                                                name: "x",
+                                                                                span: 17..18,
+                                                                            },
+                                                                            ty: Int(
+                                                                                I64,
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                },
+                                                            ),
+                                                        ],
+                                                    ),
+                                                },
+                                                EnumVariantType {
+                                                    name: Identifier {
+                                                        name: "Who",
+                                                        span: 59..62,
+                                                    },
+                                                    kind: Unit,
+                                                },
+                                            ],
+                                            type_args: [],
+                                        },
+                                    ),
+                                ],
+                            ),
+                        },
+                    ],
+                    type_args: [],
+                },
             },
         ),
         Function(
@@ -1395,10 +1295,16 @@ TypedProgram {
                         },
                         ty: Enum(
                             EnumType {
-                                name: "Foo",
+                                name: Identifier {
+                                    name: "Foo",
+                                    span: 72..75,
+                                },
                                 variants: [
                                     EnumVariantType {
-                                        name: "Bar",
+                                        name: Identifier {
+                                            name: "Bar",
+                                            span: 82..85,
+                                        },
                                         kind: Tuple(
                                             [
                                                 Bool,
@@ -1406,7 +1312,10 @@ TypedProgram {
                                         ),
                                     },
                                     EnumVariantType {
-                                        name: "Baz",
+                                        name: Identifier {
+                                            name: "Baz",
+                                            span: 97..100,
+                                        },
                                         kind: Tuple(
                                             [
                                                 Int(
@@ -1416,20 +1325,32 @@ TypedProgram {
                                         ),
                                     },
                                     EnumVariantType {
-                                        name: "Thing",
+                                        name: Identifier {
+                                            name: "Thing",
+                                            span: 111..116,
+                                        },
                                         kind: Tuple(
                                             [
                                                 Enum(
                                                     EnumType {
-                                                        name: "Thing",
+                                                        name: Identifier {
+                                                            name: "Thing",
+                                                            span: 33..38,
+                                                        },
                                                         variants: [
                                                             EnumVariantType {
-                                                                name: "Wow",
+                                                                name: Identifier {
+                                                                    name: "Wow",
+                                                                    span: 45..48,
+                                                                },
                                                                 kind: Tuple(
                                                                     [
                                                                         Record(
                                                                             RecordType {
-                                                                                name: "Ctx",
+                                                                                name: Identifier {
+                                                                                    name: "Ctx",
+                                                                                    span: 7..10,
+                                                                                },
                                                                                 fields: [
                                                                                     RecordFieldType {
                                                                                         name: Identifier {
@@ -1447,7 +1368,10 @@ TypedProgram {
                                                                 ),
                                                             },
                                                             EnumVariantType {
-                                                                name: "Who",
+                                                                name: Identifier {
+                                                                    name: "Who",
+                                                                    span: 59..62,
+                                                                },
                                                                 kind: Unit,
                                                             },
                                                         ],
@@ -1479,10 +1403,16 @@ TypedProgram {
                                         node: TypedExpr {
                                             ty: Enum(
                                                 EnumType {
-                                                    name: "Foo",
+                                                    name: Identifier {
+                                                        name: "Foo",
+                                                        span: 72..75,
+                                                    },
                                                     variants: [
                                                         EnumVariantType {
-                                                            name: "Bar",
+                                                            name: Identifier {
+                                                                name: "Bar",
+                                                                span: 82..85,
+                                                            },
                                                             kind: Tuple(
                                                                 [
                                                                     Bool,
@@ -1490,7 +1420,10 @@ TypedProgram {
                                                             ),
                                                         },
                                                         EnumVariantType {
-                                                            name: "Baz",
+                                                            name: Identifier {
+                                                                name: "Baz",
+                                                                span: 97..100,
+                                                            },
                                                             kind: Tuple(
                                                                 [
                                                                     Int(
@@ -1500,20 +1433,32 @@ TypedProgram {
                                                             ),
                                                         },
                                                         EnumVariantType {
-                                                            name: "Thing",
+                                                            name: Identifier {
+                                                                name: "Thing",
+                                                                span: 111..116,
+                                                            },
                                                             kind: Tuple(
                                                                 [
                                                                     Enum(
                                                                         EnumType {
-                                                                            name: "Thing",
+                                                                            name: Identifier {
+                                                                                name: "Thing",
+                                                                                span: 33..38,
+                                                                            },
                                                                             variants: [
                                                                                 EnumVariantType {
-                                                                                    name: "Wow",
+                                                                                    name: Identifier {
+                                                                                        name: "Wow",
+                                                                                        span: 45..48,
+                                                                                    },
                                                                                     kind: Tuple(
                                                                                         [
                                                                                             Record(
                                                                                                 RecordType {
-                                                                                                    name: "Ctx",
+                                                                                                    name: Identifier {
+                                                                                                        name: "Ctx",
+                                                                                                        span: 7..10,
+                                                                                                    },
                                                                                                     fields: [
                                                                                                         RecordFieldType {
                                                                                                             name: Identifier {
@@ -1531,7 +1476,10 @@ TypedProgram {
                                                                                     ),
                                                                                 },
                                                                                 EnumVariantType {
-                                                                                    name: "Who",
+                                                                                    name: Identifier {
+                                                                                        name: "Who",
+                                                                                        span: 59..62,
+                                                                                    },
                                                                                     kind: Unit,
                                                                                 },
                                                                             ],
@@ -1606,7 +1554,10 @@ TypedProgram {
                                                                     node: TypedExpr {
                                                                         ty: Record(
                                                                             RecordType {
-                                                                                name: "Ctx",
+                                                                                name: Identifier {
+                                                                                    name: "Ctx",
+                                                                                    span: 7..10,
+                                                                                },
                                                                                 fields: [
                                                                                     RecordFieldType {
                                                                                         name: Identifier {
@@ -1780,10 +1731,16 @@ TypedProgram {
                         },
                         ty: Enum(
                             EnumType {
-                                name: "Foo",
+                                name: Identifier {
+                                    name: "Foo",
+                                    span: 72..75,
+                                },
                                 variants: [
                                     EnumVariantType {
-                                        name: "Bar",
+                                        name: Identifier {
+                                            name: "Bar",
+                                            span: 82..85,
+                                        },
                                         kind: Tuple(
                                             [
                                                 Bool,
@@ -1791,7 +1748,10 @@ TypedProgram {
                                         ),
                                     },
                                     EnumVariantType {
-                                        name: "Baz",
+                                        name: Identifier {
+                                            name: "Baz",
+                                            span: 97..100,
+                                        },
                                         kind: Tuple(
                                             [
                                                 Int(
@@ -1801,20 +1761,32 @@ TypedProgram {
                                         ),
                                     },
                                     EnumVariantType {
-                                        name: "Thing",
+                                        name: Identifier {
+                                            name: "Thing",
+                                            span: 111..116,
+                                        },
                                         kind: Tuple(
                                             [
                                                 Enum(
                                                     EnumType {
-                                                        name: "Thing",
+                                                        name: Identifier {
+                                                            name: "Thing",
+                                                            span: 33..38,
+                                                        },
                                                         variants: [
                                                             EnumVariantType {
-                                                                name: "Wow",
+                                                                name: Identifier {
+                                                                    name: "Wow",
+                                                                    span: 45..48,
+                                                                },
                                                                 kind: Tuple(
                                                                     [
                                                                         Record(
                                                                             RecordType {
-                                                                                name: "Ctx",
+                                                                                name: Identifier {
+                                                                                    name: "Ctx",
+                                                                                    span: 7..10,
+                                                                                },
                                                                                 fields: [
                                                                                     RecordFieldType {
                                                                                         name: Identifier {
@@ -1832,7 +1804,10 @@ TypedProgram {
                                                                 ),
                                                             },
                                                             EnumVariantType {
-                                                                name: "Who",
+                                                                name: Identifier {
+                                                                    name: "Who",
+                                                                    span: 59..62,
+                                                                },
                                                                 kind: Unit,
                                                             },
                                                         ],
@@ -1864,10 +1839,16 @@ TypedProgram {
                                         node: TypedExpr {
                                             ty: Enum(
                                                 EnumType {
-                                                    name: "Foo",
+                                                    name: Identifier {
+                                                        name: "Foo",
+                                                        span: 72..75,
+                                                    },
                                                     variants: [
                                                         EnumVariantType {
-                                                            name: "Bar",
+                                                            name: Identifier {
+                                                                name: "Bar",
+                                                                span: 82..85,
+                                                            },
                                                             kind: Tuple(
                                                                 [
                                                                     Bool,
@@ -1875,7 +1856,10 @@ TypedProgram {
                                                             ),
                                                         },
                                                         EnumVariantType {
-                                                            name: "Baz",
+                                                            name: Identifier {
+                                                                name: "Baz",
+                                                                span: 97..100,
+                                                            },
                                                             kind: Tuple(
                                                                 [
                                                                     Int(
@@ -1885,20 +1869,32 @@ TypedProgram {
                                                             ),
                                                         },
                                                         EnumVariantType {
-                                                            name: "Thing",
+                                                            name: Identifier {
+                                                                name: "Thing",
+                                                                span: 111..116,
+                                                            },
                                                             kind: Tuple(
                                                                 [
                                                                     Enum(
                                                                         EnumType {
-                                                                            name: "Thing",
+                                                                            name: Identifier {
+                                                                                name: "Thing",
+                                                                                span: 33..38,
+                                                                            },
                                                                             variants: [
                                                                                 EnumVariantType {
-                                                                                    name: "Wow",
+                                                                                    name: Identifier {
+                                                                                        name: "Wow",
+                                                                                        span: 45..48,
+                                                                                    },
                                                                                     kind: Tuple(
                                                                                         [
                                                                                             Record(
                                                                                                 RecordType {
-                                                                                                    name: "Ctx",
+                                                                                                    name: Identifier {
+                                                                                                        name: "Ctx",
+                                                                                                        span: 7..10,
+                                                                                                    },
                                                                                                     fields: [
                                                                                                         RecordFieldType {
                                                                                                             name: Identifier {
@@ -1916,7 +1912,10 @@ TypedProgram {
                                                                                     ),
                                                                                 },
                                                                                 EnumVariantType {
-                                                                                    name: "Who",
+                                                                                    name: Identifier {
+                                                                                        name: "Who",
+                                                                                        span: 59..62,
+                                                                                    },
                                                                                     kind: Unit,
                                                                                 },
                                                                             ],
@@ -2135,84 +2134,50 @@ TypedProgram {
         ),
         Enum(
             TypedEnumDef {
-                name: Identifier {
-                    name: "Message",
-                    span: 695..702,
-                },
-                variants: [
-                    TypedEnumVariant {
-                        name: Identifier {
-                            name: "Ping",
-                            span: 709..713,
-                        },
-                        payload: Unit,
-                    },
-                    TypedEnumVariant {
-                        name: Identifier {
-                            name: "Point",
-                            span: 719..724,
-                        },
-                        payload: Struct(
-                            [
-                                TypedStructField {
-                                    name: Identifier {
-                                        name: "x",
-                                        span: 727..728,
-                                    },
-                                    ty: Int(
-                                        I64,
-                                    ),
-                                },
-                                TypedStructField {
-                                    name: Identifier {
-                                        name: "y",
-                                        span: 735..736,
-                                    },
-                                    ty: Int(
-                                        I64,
-                                    ),
-                                },
-                            ],
-                        ),
-                    },
-                ],
-                ty: Enum(
-                    EnumType {
+                ty: EnumType {
+                    name: Identifier {
                         name: "Message",
-                        variants: [
-                            EnumVariantType {
-                                name: "Ping",
-                                kind: Unit,
-                            },
-                            EnumVariantType {
-                                name: "Point",
-                                kind: Struct(
-                                    [
-                                        RecordFieldType {
-                                            name: Identifier {
-                                                name: "x",
-                                                span: 727..728,
-                                            },
-                                            ty: Int(
-                                                I64,
-                                            ),
-                                        },
-                                        RecordFieldType {
-                                            name: Identifier {
-                                                name: "y",
-                                                span: 735..736,
-                                            },
-                                            ty: Int(
-                                                I64,
-                                            ),
-                                        },
-                                    ],
-                                ),
-                            },
-                        ],
-                        type_args: [],
+                        span: 695..702,
                     },
-                ),
+                    variants: [
+                        EnumVariantType {
+                            name: Identifier {
+                                name: "Ping",
+                                span: 709..713,
+                            },
+                            kind: Unit,
+                        },
+                        EnumVariantType {
+                            name: Identifier {
+                                name: "Point",
+                                span: 719..724,
+                            },
+                            kind: Struct(
+                                [
+                                    RecordFieldType {
+                                        name: Identifier {
+                                            name: "x",
+                                            span: 727..728,
+                                        },
+                                        ty: Int(
+                                            I64,
+                                        ),
+                                    },
+                                    RecordFieldType {
+                                        name: Identifier {
+                                            name: "y",
+                                            span: 735..736,
+                                        },
+                                        ty: Int(
+                                            I64,
+                                        ),
+                                    },
+                                ],
+                            ),
+                        },
+                    ],
+                    type_args: [],
+                },
             },
         ),
         Function(
@@ -2232,14 +2197,23 @@ TypedProgram {
                         },
                         ty: Enum(
                             EnumType {
-                                name: "Message",
+                                name: Identifier {
+                                    name: "Message",
+                                    span: 695..702,
+                                },
                                 variants: [
                                     EnumVariantType {
-                                        name: "Ping",
+                                        name: Identifier {
+                                            name: "Ping",
+                                            span: 709..713,
+                                        },
                                         kind: Unit,
                                     },
                                     EnumVariantType {
-                                        name: "Point",
+                                        name: Identifier {
+                                            name: "Point",
+                                            span: 719..724,
+                                        },
                                         kind: Struct(
                                             [
                                                 RecordFieldType {
@@ -2285,14 +2259,23 @@ TypedProgram {
                                         node: TypedExpr {
                                             ty: Enum(
                                                 EnumType {
-                                                    name: "Message",
+                                                    name: Identifier {
+                                                        name: "Message",
+                                                        span: 695..702,
+                                                    },
                                                     variants: [
                                                         EnumVariantType {
-                                                            name: "Ping",
+                                                            name: Identifier {
+                                                                name: "Ping",
+                                                                span: 709..713,
+                                                            },
                                                             kind: Unit,
                                                         },
                                                         EnumVariantType {
-                                                            name: "Point",
+                                                            name: Identifier {
+                                                                name: "Point",
+                                                                span: 719..724,
+                                                            },
                                                             kind: Struct(
                                                                 [
                                                                     RecordFieldType {
@@ -2486,10 +2469,16 @@ TypedProgram {
                                                         params: [
                                                             Enum(
                                                                 EnumType {
-                                                                    name: "Foo",
+                                                                    name: Identifier {
+                                                                        name: "Foo",
+                                                                        span: 72..75,
+                                                                    },
                                                                     variants: [
                                                                         EnumVariantType {
-                                                                            name: "Bar",
+                                                                            name: Identifier {
+                                                                                name: "Bar",
+                                                                                span: 82..85,
+                                                                            },
                                                                             kind: Tuple(
                                                                                 [
                                                                                     Bool,
@@ -2497,7 +2486,10 @@ TypedProgram {
                                                                             ),
                                                                         },
                                                                         EnumVariantType {
-                                                                            name: "Baz",
+                                                                            name: Identifier {
+                                                                                name: "Baz",
+                                                                                span: 97..100,
+                                                                            },
                                                                             kind: Tuple(
                                                                                 [
                                                                                     Int(
@@ -2507,20 +2499,32 @@ TypedProgram {
                                                                             ),
                                                                         },
                                                                         EnumVariantType {
-                                                                            name: "Thing",
+                                                                            name: Identifier {
+                                                                                name: "Thing",
+                                                                                span: 111..116,
+                                                                            },
                                                                             kind: Tuple(
                                                                                 [
                                                                                     Enum(
                                                                                         EnumType {
-                                                                                            name: "Thing",
+                                                                                            name: Identifier {
+                                                                                                name: "Thing",
+                                                                                                span: 33..38,
+                                                                                            },
                                                                                             variants: [
                                                                                                 EnumVariantType {
-                                                                                                    name: "Wow",
+                                                                                                    name: Identifier {
+                                                                                                        name: "Wow",
+                                                                                                        span: 45..48,
+                                                                                                    },
                                                                                                     kind: Tuple(
                                                                                                         [
                                                                                                             Record(
                                                                                                                 RecordType {
-                                                                                                                    name: "Ctx",
+                                                                                                                    name: Identifier {
+                                                                                                                        name: "Ctx",
+                                                                                                                        span: 7..10,
+                                                                                                                    },
                                                                                                                     fields: [
                                                                                                                         RecordFieldType {
                                                                                                                             name: Identifier {
@@ -2538,7 +2542,10 @@ TypedProgram {
                                                                                                     ),
                                                                                                 },
                                                                                                 EnumVariantType {
-                                                                                                    name: "Who",
+                                                                                                    name: Identifier {
+                                                                                                        name: "Who",
+                                                                                                        span: 59..62,
+                                                                                                    },
                                                                                                     kind: Unit,
                                                                                                 },
                                                                                             ],
@@ -2583,10 +2590,16 @@ TypedProgram {
                                                 node: TypedExpr {
                                                     ty: Enum(
                                                         EnumType {
-                                                            name: "Foo",
+                                                            name: Identifier {
+                                                                name: "Foo",
+                                                                span: 72..75,
+                                                            },
                                                             variants: [
                                                                 EnumVariantType {
-                                                                    name: "Bar",
+                                                                    name: Identifier {
+                                                                        name: "Bar",
+                                                                        span: 82..85,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Bool,
@@ -2594,7 +2607,10 @@ TypedProgram {
                                                                     ),
                                                                 },
                                                                 EnumVariantType {
-                                                                    name: "Baz",
+                                                                    name: Identifier {
+                                                                        name: "Baz",
+                                                                        span: 97..100,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Int(
@@ -2604,20 +2620,32 @@ TypedProgram {
                                                                     ),
                                                                 },
                                                                 EnumVariantType {
-                                                                    name: "Thing",
+                                                                    name: Identifier {
+                                                                        name: "Thing",
+                                                                        span: 111..116,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Enum(
                                                                                 EnumType {
-                                                                                    name: "Thing",
+                                                                                    name: Identifier {
+                                                                                        name: "Thing",
+                                                                                        span: 33..38,
+                                                                                    },
                                                                                     variants: [
                                                                                         EnumVariantType {
-                                                                                            name: "Wow",
+                                                                                            name: Identifier {
+                                                                                                name: "Wow",
+                                                                                                span: 45..48,
+                                                                                            },
                                                                                             kind: Tuple(
                                                                                                 [
                                                                                                     Record(
                                                                                                         RecordType {
-                                                                                                            name: "Ctx",
+                                                                                                            name: Identifier {
+                                                                                                                name: "Ctx",
+                                                                                                                span: 7..10,
+                                                                                                            },
                                                                                                             fields: [
                                                                                                                 RecordFieldType {
                                                                                                                     name: Identifier {
@@ -2635,7 +2663,10 @@ TypedProgram {
                                                                                             ),
                                                                                         },
                                                                                         EnumVariantType {
-                                                                                            name: "Who",
+                                                                                            name: Identifier {
+                                                                                                name: "Who",
+                                                                                                span: 59..62,
+                                                                                            },
                                                                                             kind: Unit,
                                                                                         },
                                                                                     ],
@@ -2662,10 +2693,16 @@ TypedProgram {
                                                                         param_spans: [],
                                                                         result: Enum(
                                                                             EnumType {
-                                                                                name: "Foo",
+                                                                                name: Identifier {
+                                                                                    name: "Foo",
+                                                                                    span: 72..75,
+                                                                                },
                                                                                 variants: [
                                                                                     EnumVariantType {
-                                                                                        name: "Bar",
+                                                                                        name: Identifier {
+                                                                                            name: "Bar",
+                                                                                            span: 82..85,
+                                                                                        },
                                                                                         kind: Tuple(
                                                                                             [
                                                                                                 Bool,
@@ -2673,7 +2710,10 @@ TypedProgram {
                                                                                         ),
                                                                                     },
                                                                                     EnumVariantType {
-                                                                                        name: "Baz",
+                                                                                        name: Identifier {
+                                                                                            name: "Baz",
+                                                                                            span: 97..100,
+                                                                                        },
                                                                                         kind: Tuple(
                                                                                             [
                                                                                                 Int(
@@ -2683,20 +2723,32 @@ TypedProgram {
                                                                                         ),
                                                                                     },
                                                                                     EnumVariantType {
-                                                                                        name: "Thing",
+                                                                                        name: Identifier {
+                                                                                            name: "Thing",
+                                                                                            span: 111..116,
+                                                                                        },
                                                                                         kind: Tuple(
                                                                                             [
                                                                                                 Enum(
                                                                                                     EnumType {
-                                                                                                        name: "Thing",
+                                                                                                        name: Identifier {
+                                                                                                            name: "Thing",
+                                                                                                            span: 33..38,
+                                                                                                        },
                                                                                                         variants: [
                                                                                                             EnumVariantType {
-                                                                                                                name: "Wow",
+                                                                                                                name: Identifier {
+                                                                                                                    name: "Wow",
+                                                                                                                    span: 45..48,
+                                                                                                                },
                                                                                                                 kind: Tuple(
                                                                                                                     [
                                                                                                                         Record(
                                                                                                                             RecordType {
-                                                                                                                                name: "Ctx",
+                                                                                                                                name: Identifier {
+                                                                                                                                    name: "Ctx",
+                                                                                                                                    span: 7..10,
+                                                                                                                                },
                                                                                                                                 fields: [
                                                                                                                                     RecordFieldType {
                                                                                                                                         name: Identifier {
@@ -2714,7 +2766,10 @@ TypedProgram {
                                                                                                                 ),
                                                                                                             },
                                                                                                             EnumVariantType {
-                                                                                                                name: "Who",
+                                                                                                                name: Identifier {
+                                                                                                                    name: "Who",
+                                                                                                                    span: 59..62,
+                                                                                                                },
                                                                                                                 kind: Unit,
                                                                                                             },
                                                                                                         ],

--- a/starstream-to-wasm/tests/snapshots/inputs@option_result.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@option_result.star.snap
@@ -904,7 +904,6 @@ T-Fn: unwrap_result => i64
       Unify-Var: i64 ~ i64 => i64
     Unify-Const: i64 ~ i64 => {}
 
-
 T-Fn: run => ()
   T-Expr: {make_err: fn() -> Result<i64, bool>, make_none: fn() -> Option<i64>, make_ok: fn() -> Result<i64, bool>, make_some: fn() -> Option<i64>, run: fn(Thing, Result<i64, bool>) -> (), unwrap_option: fn(Option<i64>) -> i64, unwrap_result: fn(Result<i64, bool>) -> i64, x: Thing, y: Result<i64, bool>} ⊢ unwrap_option(make_some()); ⇒ ()
     T-Call: {make_err: fn() -> Result<i64, bool>, make_none: fn() -> Option<i64>, make_ok: fn() -> Result<i64, bool>, make_some: fn() -> Option<i64>, run: fn(Thing, Result<i64, bool>) -> (), unwrap_option: fn(Option<i64>) -> i64, unwrap_result: fn(Result<i64, bool>) -> i64, x: Thing, y: Result<i64, bool>} ⊢ unwrap_option(make_some()) ⇒ i64
@@ -936,14 +935,23 @@ TypedProgram {
                 params: [],
                 return_type: Enum(
                     EnumType {
-                        name: "Option",
+                        name: Identifier {
+                            name: "Option",
+                            span: 0..0,
+                        },
                         variants: [
                             EnumVariantType {
-                                name: "None",
+                                name: Identifier {
+                                    name: "None",
+                                    span: 0..0,
+                                },
                                 kind: Unit,
                             },
                             EnumVariantType {
-                                name: "Some",
+                                name: Identifier {
+                                    name: "Some",
+                                    span: 0..0,
+                                },
                                 kind: Tuple(
                                     [
                                         Int(
@@ -967,14 +975,23 @@ TypedProgram {
                             node: TypedExpr {
                                 ty: Enum(
                                     EnumType {
-                                        name: "Option",
+                                        name: Identifier {
+                                            name: "Option",
+                                            span: 0..0,
+                                        },
                                         variants: [
                                             EnumVariantType {
-                                                name: "None",
+                                                name: Identifier {
+                                                    name: "None",
+                                                    span: 0..0,
+                                                },
                                                 kind: Unit,
                                             },
                                             EnumVariantType {
-                                                name: "Some",
+                                                name: Identifier {
+                                                    name: "Some",
+                                                    span: 0..0,
+                                                },
                                                 kind: Tuple(
                                                     [
                                                         Int(
@@ -1002,14 +1019,23 @@ TypedProgram {
                                                     param_spans: [],
                                                     result: Enum(
                                                         EnumType {
-                                                            name: "Option",
+                                                            name: Identifier {
+                                                                name: "Option",
+                                                                span: 0..0,
+                                                            },
                                                             variants: [
                                                                 EnumVariantType {
-                                                                    name: "None",
+                                                                    name: Identifier {
+                                                                        name: "None",
+                                                                        span: 0..0,
+                                                                    },
                                                                     kind: Unit,
                                                                 },
                                                                 EnumVariantType {
-                                                                    name: "Some",
+                                                                    name: Identifier {
+                                                                        name: "Some",
+                                                                        span: 0..0,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Int(
@@ -1084,14 +1110,23 @@ TypedProgram {
                 params: [],
                 return_type: Enum(
                     EnumType {
-                        name: "Option",
+                        name: Identifier {
+                            name: "Option",
+                            span: 0..0,
+                        },
                         variants: [
                             EnumVariantType {
-                                name: "None",
+                                name: Identifier {
+                                    name: "None",
+                                    span: 0..0,
+                                },
                                 kind: Unit,
                             },
                             EnumVariantType {
-                                name: "Some",
+                                name: Identifier {
+                                    name: "Some",
+                                    span: 0..0,
+                                },
                                 kind: Tuple(
                                     [
                                         Int(
@@ -1115,14 +1150,23 @@ TypedProgram {
                             node: TypedExpr {
                                 ty: Enum(
                                     EnumType {
-                                        name: "Option",
+                                        name: Identifier {
+                                            name: "Option",
+                                            span: 0..0,
+                                        },
                                         variants: [
                                             EnumVariantType {
-                                                name: "None",
+                                                name: Identifier {
+                                                    name: "None",
+                                                    span: 0..0,
+                                                },
                                                 kind: Unit,
                                             },
                                             EnumVariantType {
-                                                name: "Some",
+                                                name: Identifier {
+                                                    name: "Some",
+                                                    span: 0..0,
+                                                },
                                                 kind: Tuple(
                                                     [
                                                         Int(
@@ -1178,14 +1222,23 @@ TypedProgram {
                         },
                         ty: Enum(
                             EnumType {
-                                name: "Option",
+                                name: Identifier {
+                                    name: "Option",
+                                    span: 0..0,
+                                },
                                 variants: [
                                     EnumVariantType {
-                                        name: "None",
+                                        name: Identifier {
+                                            name: "None",
+                                            span: 0..0,
+                                        },
                                         kind: Unit,
                                     },
                                     EnumVariantType {
-                                        name: "Some",
+                                        name: Identifier {
+                                            name: "Some",
+                                            span: 0..0,
+                                        },
                                         kind: Tuple(
                                             [
                                                 Int(
@@ -1220,14 +1273,23 @@ TypedProgram {
                                         node: TypedExpr {
                                             ty: Enum(
                                                 EnumType {
-                                                    name: "Option",
+                                                    name: Identifier {
+                                                        name: "Option",
+                                                        span: 0..0,
+                                                    },
                                                     variants: [
                                                         EnumVariantType {
-                                                            name: "None",
+                                                            name: Identifier {
+                                                                name: "None",
+                                                                span: 0..0,
+                                                            },
                                                             kind: Unit,
                                                         },
                                                         EnumVariantType {
-                                                            name: "Some",
+                                                            name: Identifier {
+                                                                name: "Some",
+                                                                span: 0..0,
+                                                            },
                                                             kind: Tuple(
                                                                 [
                                                                     Int(
@@ -1357,10 +1419,16 @@ TypedProgram {
                 params: [],
                 return_type: Enum(
                     EnumType {
-                        name: "Result",
+                        name: Identifier {
+                            name: "Result",
+                            span: 0..0,
+                        },
                         variants: [
                             EnumVariantType {
-                                name: "Ok",
+                                name: Identifier {
+                                    name: "Ok",
+                                    span: 0..0,
+                                },
                                 kind: Tuple(
                                     [
                                         Int(
@@ -1370,7 +1438,10 @@ TypedProgram {
                                 ),
                             },
                             EnumVariantType {
-                                name: "Err",
+                                name: Identifier {
+                                    name: "Err",
+                                    span: 0..0,
+                                },
                                 kind: Tuple(
                                     [
                                         Bool,
@@ -1393,10 +1464,16 @@ TypedProgram {
                             node: TypedExpr {
                                 ty: Enum(
                                     EnumType {
-                                        name: "Result",
+                                        name: Identifier {
+                                            name: "Result",
+                                            span: 0..0,
+                                        },
                                         variants: [
                                             EnumVariantType {
-                                                name: "Ok",
+                                                name: Identifier {
+                                                    name: "Ok",
+                                                    span: 0..0,
+                                                },
                                                 kind: Tuple(
                                                     [
                                                         Int(
@@ -1406,7 +1483,10 @@ TypedProgram {
                                                 ),
                                             },
                                             EnumVariantType {
-                                                name: "Err",
+                                                name: Identifier {
+                                                    name: "Err",
+                                                    span: 0..0,
+                                                },
                                                 kind: Tuple(
                                                     [
                                                         Bool,
@@ -1432,10 +1512,16 @@ TypedProgram {
                                                     param_spans: [],
                                                     result: Enum(
                                                         EnumType {
-                                                            name: "Result",
+                                                            name: Identifier {
+                                                                name: "Result",
+                                                                span: 0..0,
+                                                            },
                                                             variants: [
                                                                 EnumVariantType {
-                                                                    name: "Ok",
+                                                                    name: Identifier {
+                                                                        name: "Ok",
+                                                                        span: 0..0,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Int(
@@ -1445,7 +1531,10 @@ TypedProgram {
                                                                     ),
                                                                 },
                                                                 EnumVariantType {
-                                                                    name: "Err",
+                                                                    name: Identifier {
+                                                                        name: "Err",
+                                                                        span: 0..0,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Bool,
@@ -1518,10 +1607,16 @@ TypedProgram {
                 params: [],
                 return_type: Enum(
                     EnumType {
-                        name: "Result",
+                        name: Identifier {
+                            name: "Result",
+                            span: 0..0,
+                        },
                         variants: [
                             EnumVariantType {
-                                name: "Ok",
+                                name: Identifier {
+                                    name: "Ok",
+                                    span: 0..0,
+                                },
                                 kind: Tuple(
                                     [
                                         Int(
@@ -1531,7 +1626,10 @@ TypedProgram {
                                 ),
                             },
                             EnumVariantType {
-                                name: "Err",
+                                name: Identifier {
+                                    name: "Err",
+                                    span: 0..0,
+                                },
                                 kind: Tuple(
                                     [
                                         Bool,
@@ -1554,10 +1652,16 @@ TypedProgram {
                             node: TypedExpr {
                                 ty: Enum(
                                     EnumType {
-                                        name: "Result",
+                                        name: Identifier {
+                                            name: "Result",
+                                            span: 0..0,
+                                        },
                                         variants: [
                                             EnumVariantType {
-                                                name: "Ok",
+                                                name: Identifier {
+                                                    name: "Ok",
+                                                    span: 0..0,
+                                                },
                                                 kind: Tuple(
                                                     [
                                                         Int(
@@ -1567,7 +1671,10 @@ TypedProgram {
                                                 ),
                                             },
                                             EnumVariantType {
-                                                name: "Err",
+                                                name: Identifier {
+                                                    name: "Err",
+                                                    span: 0..0,
+                                                },
                                                 kind: Tuple(
                                                     [
                                                         Bool,
@@ -1591,10 +1698,16 @@ TypedProgram {
                                                     param_spans: [],
                                                     result: Enum(
                                                         EnumType {
-                                                            name: "Result",
+                                                            name: Identifier {
+                                                                name: "Result",
+                                                                span: 0..0,
+                                                            },
                                                             variants: [
                                                                 EnumVariantType {
-                                                                    name: "Ok",
+                                                                    name: Identifier {
+                                                                        name: "Ok",
+                                                                        span: 0..0,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Int(
@@ -1604,7 +1717,10 @@ TypedProgram {
                                                                     ),
                                                                 },
                                                                 EnumVariantType {
-                                                                    name: "Err",
+                                                                    name: Identifier {
+                                                                        name: "Err",
+                                                                        span: 0..0,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Bool,
@@ -1678,10 +1794,16 @@ TypedProgram {
                         },
                         ty: Enum(
                             EnumType {
-                                name: "Result",
+                                name: Identifier {
+                                    name: "Result",
+                                    span: 0..0,
+                                },
                                 variants: [
                                     EnumVariantType {
-                                        name: "Ok",
+                                        name: Identifier {
+                                            name: "Ok",
+                                            span: 0..0,
+                                        },
                                         kind: Tuple(
                                             [
                                                 Int(
@@ -1691,7 +1813,10 @@ TypedProgram {
                                         ),
                                     },
                                     EnumVariantType {
-                                        name: "Err",
+                                        name: Identifier {
+                                            name: "Err",
+                                            span: 0..0,
+                                        },
                                         kind: Tuple(
                                             [
                                                 Bool,
@@ -1725,10 +1850,16 @@ TypedProgram {
                                         node: TypedExpr {
                                             ty: Enum(
                                                 EnumType {
-                                                    name: "Result",
+                                                    name: Identifier {
+                                                        name: "Result",
+                                                        span: 0..0,
+                                                    },
                                                     variants: [
                                                         EnumVariantType {
-                                                            name: "Ok",
+                                                            name: Identifier {
+                                                                name: "Ok",
+                                                                span: 0..0,
+                                                            },
                                                             kind: Tuple(
                                                                 [
                                                                     Int(
@@ -1738,7 +1869,10 @@ TypedProgram {
                                                             ),
                                                         },
                                                         EnumVariantType {
-                                                            name: "Err",
+                                                            name: Identifier {
+                                                                name: "Err",
+                                                                span: 0..0,
+                                                            },
                                                             kind: Tuple(
                                                                 [
                                                                     Bool,
@@ -1865,83 +1999,55 @@ TypedProgram {
         ),
         Struct(
             TypedStructDef {
-                name: Identifier {
-                    name: "Thing",
-                    span: 590..595,
-                },
-                fields: [
-                    TypedStructField {
-                        name: Identifier {
-                            name: "x",
-                            span: 602..603,
-                        },
-                        ty: Enum(
-                            EnumType {
-                                name: "Option",
-                                variants: [
-                                    EnumVariantType {
-                                        name: "None",
-                                        kind: Unit,
-                                    },
-                                    EnumVariantType {
-                                        name: "Some",
-                                        kind: Tuple(
-                                            [
-                                                Int(
-                                                    I64,
-                                                ),
-                                            ],
-                                        ),
-                                    },
-                                ],
-                                type_args: [
-                                    Int(
-                                        I64,
-                                    ),
-                                ],
-                            },
-                        ),
-                    },
-                ],
-                ty: Record(
-                    RecordType {
+                ty: RecordType {
+                    name: Identifier {
                         name: "Thing",
-                        fields: [
-                            RecordFieldType {
-                                name: Identifier {
-                                    name: "x",
-                                    span: 602..603,
-                                },
-                                ty: Enum(
-                                    EnumType {
-                                        name: "Option",
-                                        variants: [
-                                            EnumVariantType {
-                                                name: "None",
-                                                kind: Unit,
-                                            },
-                                            EnumVariantType {
-                                                name: "Some",
-                                                kind: Tuple(
-                                                    [
-                                                        Int(
-                                                            I64,
-                                                        ),
-                                                    ],
-                                                ),
-                                            },
-                                        ],
-                                        type_args: [
-                                            Int(
-                                                I64,
-                                            ),
-                                        ],
-                                    },
-                                ),
-                            },
-                        ],
+                        span: 590..595,
                     },
-                ),
+                    fields: [
+                        RecordFieldType {
+                            name: Identifier {
+                                name: "x",
+                                span: 602..603,
+                            },
+                            ty: Enum(
+                                EnumType {
+                                    name: Identifier {
+                                        name: "Option",
+                                        span: 0..0,
+                                    },
+                                    variants: [
+                                        EnumVariantType {
+                                            name: Identifier {
+                                                name: "None",
+                                                span: 0..0,
+                                            },
+                                            kind: Unit,
+                                        },
+                                        EnumVariantType {
+                                            name: Identifier {
+                                                name: "Some",
+                                                span: 0..0,
+                                            },
+                                            kind: Tuple(
+                                                [
+                                                    Int(
+                                                        I64,
+                                                    ),
+                                                ],
+                                            ),
+                                        },
+                                    ],
+                                    type_args: [
+                                        Int(
+                                            I64,
+                                        ),
+                                    ],
+                                },
+                            ),
+                        },
+                    ],
+                },
             },
         ),
         Function(
@@ -1963,7 +2069,10 @@ TypedProgram {
                         },
                         ty: Record(
                             RecordType {
-                                name: "Thing",
+                                name: Identifier {
+                                    name: "Thing",
+                                    span: 590..595,
+                                },
                                 fields: [
                                     RecordFieldType {
                                         name: Identifier {
@@ -1972,14 +2081,23 @@ TypedProgram {
                                         },
                                         ty: Enum(
                                             EnumType {
-                                                name: "Option",
+                                                name: Identifier {
+                                                    name: "Option",
+                                                    span: 0..0,
+                                                },
                                                 variants: [
                                                     EnumVariantType {
-                                                        name: "None",
+                                                        name: Identifier {
+                                                            name: "None",
+                                                            span: 0..0,
+                                                        },
                                                         kind: Unit,
                                                     },
                                                     EnumVariantType {
-                                                        name: "Some",
+                                                        name: Identifier {
+                                                            name: "Some",
+                                                            span: 0..0,
+                                                        },
                                                         kind: Tuple(
                                                             [
                                                                 Int(
@@ -2009,10 +2127,16 @@ TypedProgram {
                         },
                         ty: Enum(
                             EnumType {
-                                name: "Result",
+                                name: Identifier {
+                                    name: "Result",
+                                    span: 0..0,
+                                },
                                 variants: [
                                     EnumVariantType {
-                                        name: "Ok",
+                                        name: Identifier {
+                                            name: "Ok",
+                                            span: 0..0,
+                                        },
                                         kind: Tuple(
                                             [
                                                 Int(
@@ -2022,7 +2146,10 @@ TypedProgram {
                                         ),
                                     },
                                     EnumVariantType {
-                                        name: "Err",
+                                        name: Identifier {
+                                            name: "Err",
+                                            span: 0..0,
+                                        },
                                         kind: Tuple(
                                             [
                                                 Bool,
@@ -2059,14 +2186,23 @@ TypedProgram {
                                                         params: [
                                                             Enum(
                                                                 EnumType {
-                                                                    name: "Option",
+                                                                    name: Identifier {
+                                                                        name: "Option",
+                                                                        span: 0..0,
+                                                                    },
                                                                     variants: [
                                                                         EnumVariantType {
-                                                                            name: "None",
+                                                                            name: Identifier {
+                                                                                name: "None",
+                                                                                span: 0..0,
+                                                                            },
                                                                             kind: Unit,
                                                                         },
                                                                         EnumVariantType {
-                                                                            name: "Some",
+                                                                            name: Identifier {
+                                                                                name: "Some",
+                                                                                span: 0..0,
+                                                                            },
                                                                             kind: Tuple(
                                                                                 [
                                                                                     Int(
@@ -2114,14 +2250,23 @@ TypedProgram {
                                                 node: TypedExpr {
                                                     ty: Enum(
                                                         EnumType {
-                                                            name: "Option",
+                                                            name: Identifier {
+                                                                name: "Option",
+                                                                span: 0..0,
+                                                            },
                                                             variants: [
                                                                 EnumVariantType {
-                                                                    name: "None",
+                                                                    name: Identifier {
+                                                                        name: "None",
+                                                                        span: 0..0,
+                                                                    },
                                                                     kind: Unit,
                                                                 },
                                                                 EnumVariantType {
-                                                                    name: "Some",
+                                                                    name: Identifier {
+                                                                        name: "Some",
+                                                                        span: 0..0,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Int(
@@ -2149,14 +2294,23 @@ TypedProgram {
                                                                         param_spans: [],
                                                                         result: Enum(
                                                                             EnumType {
-                                                                                name: "Option",
+                                                                                name: Identifier {
+                                                                                    name: "Option",
+                                                                                    span: 0..0,
+                                                                                },
                                                                                 variants: [
                                                                                     EnumVariantType {
-                                                                                        name: "None",
+                                                                                        name: Identifier {
+                                                                                            name: "None",
+                                                                                            span: 0..0,
+                                                                                        },
                                                                                         kind: Unit,
                                                                                     },
                                                                                     EnumVariantType {
-                                                                                        name: "Some",
+                                                                                        name: Identifier {
+                                                                                            name: "Some",
+                                                                                            span: 0..0,
+                                                                                        },
                                                                                         kind: Tuple(
                                                                                             [
                                                                                                 Int(
@@ -2219,10 +2373,16 @@ TypedProgram {
                                                         params: [
                                                             Enum(
                                                                 EnumType {
-                                                                    name: "Result",
+                                                                    name: Identifier {
+                                                                        name: "Result",
+                                                                        span: 0..0,
+                                                                    },
                                                                     variants: [
                                                                         EnumVariantType {
-                                                                            name: "Ok",
+                                                                            name: Identifier {
+                                                                                name: "Ok",
+                                                                                span: 0..0,
+                                                                            },
                                                                             kind: Tuple(
                                                                                 [
                                                                                     Int(
@@ -2232,7 +2392,10 @@ TypedProgram {
                                                                             ),
                                                                         },
                                                                         EnumVariantType {
-                                                                            name: "Err",
+                                                                            name: Identifier {
+                                                                                name: "Err",
+                                                                                span: 0..0,
+                                                                            },
                                                                             kind: Tuple(
                                                                                 [
                                                                                     Bool,
@@ -2279,10 +2442,16 @@ TypedProgram {
                                                 node: TypedExpr {
                                                     ty: Enum(
                                                         EnumType {
-                                                            name: "Result",
+                                                            name: Identifier {
+                                                                name: "Result",
+                                                                span: 0..0,
+                                                            },
                                                             variants: [
                                                                 EnumVariantType {
-                                                                    name: "Ok",
+                                                                    name: Identifier {
+                                                                        name: "Ok",
+                                                                        span: 0..0,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Int(
@@ -2292,7 +2461,10 @@ TypedProgram {
                                                                     ),
                                                                 },
                                                                 EnumVariantType {
-                                                                    name: "Err",
+                                                                    name: Identifier {
+                                                                        name: "Err",
+                                                                        span: 0..0,
+                                                                    },
                                                                     kind: Tuple(
                                                                         [
                                                                             Bool,
@@ -2319,10 +2491,16 @@ TypedProgram {
                                                                         param_spans: [],
                                                                         result: Enum(
                                                                             EnumType {
-                                                                                name: "Result",
+                                                                                name: Identifier {
+                                                                                    name: "Result",
+                                                                                    span: 0..0,
+                                                                                },
                                                                                 variants: [
                                                                                     EnumVariantType {
-                                                                                        name: "Ok",
+                                                                                        name: Identifier {
+                                                                                            name: "Ok",
+                                                                                            span: 0..0,
+                                                                                        },
                                                                                         kind: Tuple(
                                                                                             [
                                                                                                 Int(
@@ -2332,7 +2510,10 @@ TypedProgram {
                                                                                         ),
                                                                                     },
                                                                                     EnumVariantType {
-                                                                                        name: "Err",
+                                                                                        name: Identifier {
+                                                                                            name: "Err",
+                                                                                            span: 0..0,
+                                                                                        },
                                                                                         kind: Tuple(
                                                                                             [
                                                                                                 Bool,

--- a/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
@@ -1495,220 +1495,218 @@ TypedProgram {
                         ],
                     },
                 ],
-                ty: Utxo(
-                    UtxoType {
-                        name: "ScoreProgress",
-                        id: NameId(7),
-                        possible_abis: [
-                            AbiType {
-                                name: Identifier {
-                                    name: "Score",
-                                    span: 4..9,
-                                },
-                                methods: [
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "plus_chips",
-                                            span: 19..29,
-                                        },
-                                        id: NameId(2),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 19..29,
-                                            params: [
-                                                Int(
-                                                    U64,
-                                                ),
-                                            ],
-                                            param_spans: [
-                                                30..35,
-                                            ],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(2),
-                                                ),
-                                            ),
-                                        },
-                                    },
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "plus_mult",
-                                            span: 50..59,
-                                        },
-                                        id: NameId(3),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 50..59,
-                                            params: [
-                                                Int(
-                                                    U64,
-                                                ),
-                                            ],
-                                            param_spans: [
-                                                60..64,
-                                            ],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(3),
-                                                ),
-                                            ),
-                                        },
-                                    },
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "mult_mult",
-                                            span: 79..88,
-                                        },
-                                        id: NameId(4),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 79..88,
-                                            params: [
-                                                Int(
-                                                    U64,
-                                                ),
-                                            ],
-                                            param_spans: [
-                                                89..97,
-                                            ],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(4),
-                                                ),
-                                            ),
-                                        },
-                                    },
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "finish",
-                                            span: 112..118,
-                                        },
-                                        id: NameId(5),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 112..118,
-                                            params: [],
-                                            param_spans: [],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(5),
-                                                ),
-                                            ),
-                                        },
-                                    },
-                                ],
+                ty: UtxoType {
+                    name: "ScoreProgress",
+                    id: NameId(7),
+                    possible_abis: [
+                        AbiType {
+                            name: Identifier {
+                                name: "Score",
+                                span: 4..9,
                             },
-                        ],
-                        always_abis: [
-                            AbiType {
-                                name: Identifier {
-                                    name: "Score",
-                                    span: 4..9,
+                            methods: [
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "plus_chips",
+                                        span: 19..29,
+                                    },
+                                    id: NameId(2),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 19..29,
+                                        params: [
+                                            Int(
+                                                U64,
+                                            ),
+                                        ],
+                                        param_spans: [
+                                            30..35,
+                                        ],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(2),
+                                            ),
+                                        ),
+                                    },
                                 },
-                                methods: [
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "plus_chips",
-                                            span: 19..29,
-                                        },
-                                        id: NameId(2),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 19..29,
-                                            params: [
-                                                Int(
-                                                    U64,
-                                                ),
-                                            ],
-                                            param_spans: [
-                                                30..35,
-                                            ],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(2),
-                                                ),
-                                            ),
-                                        },
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "plus_mult",
+                                        span: 50..59,
                                     },
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "plus_mult",
-                                            span: 50..59,
-                                        },
-                                        id: NameId(3),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 50..59,
-                                            params: [
-                                                Int(
-                                                    U64,
-                                                ),
-                                            ],
-                                            param_spans: [
-                                                60..64,
-                                            ],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(3),
-                                                ),
+                                    id: NameId(3),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 50..59,
+                                        params: [
+                                            Int(
+                                                U64,
                                             ),
-                                        },
-                                    },
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "mult_mult",
-                                            span: 79..88,
-                                        },
-                                        id: NameId(4),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 79..88,
-                                            params: [
-                                                Int(
-                                                    U64,
-                                                ),
-                                            ],
-                                            param_spans: [
-                                                89..97,
-                                            ],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(4),
-                                                ),
+                                        ],
+                                        param_spans: [
+                                            60..64,
+                                        ],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(3),
                                             ),
-                                        },
+                                        ),
                                     },
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "finish",
-                                            span: 112..118,
-                                        },
-                                        id: NameId(5),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 112..118,
-                                            params: [],
-                                            param_spans: [],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(5),
-                                                ),
+                                },
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "mult_mult",
+                                        span: 79..88,
+                                    },
+                                    id: NameId(4),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 79..88,
+                                        params: [
+                                            Int(
+                                                U64,
                                             ),
-                                        },
+                                        ],
+                                        param_spans: [
+                                            89..97,
+                                        ],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(4),
+                                            ),
+                                        ),
                                     },
-                                ],
+                                },
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "finish",
+                                        span: 112..118,
+                                    },
+                                    id: NameId(5),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 112..118,
+                                        params: [],
+                                        param_spans: [],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(5),
+                                            ),
+                                        ),
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                    always_abis: [
+                        AbiType {
+                            name: Identifier {
+                                name: "Score",
+                                span: 4..9,
                             },
-                        ],
-                    },
-                ),
+                            methods: [
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "plus_chips",
+                                        span: 19..29,
+                                    },
+                                    id: NameId(2),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 19..29,
+                                        params: [
+                                            Int(
+                                                U64,
+                                            ),
+                                        ],
+                                        param_spans: [
+                                            30..35,
+                                        ],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(2),
+                                            ),
+                                        ),
+                                    },
+                                },
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "plus_mult",
+                                        span: 50..59,
+                                    },
+                                    id: NameId(3),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 50..59,
+                                        params: [
+                                            Int(
+                                                U64,
+                                            ),
+                                        ],
+                                        param_spans: [
+                                            60..64,
+                                        ],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(3),
+                                            ),
+                                        ),
+                                    },
+                                },
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "mult_mult",
+                                        span: 79..88,
+                                    },
+                                    id: NameId(4),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 79..88,
+                                        params: [
+                                            Int(
+                                                U64,
+                                            ),
+                                        ],
+                                        param_spans: [
+                                            89..97,
+                                        ],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(4),
+                                            ),
+                                        ),
+                                    },
+                                },
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "finish",
+                                        span: 112..118,
+                                    },
+                                    id: NameId(5),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 112..118,
+                                        params: [],
+                                        param_spans: [],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(5),
+                                            ),
+                                        ),
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
             },
         ),
         Function(

--- a/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
@@ -1404,8 +1404,10 @@ TypedProgram {
                         ],
                     },
                 ],
-                ty: UtxoNamed(
-                    "ScoreProgress",
+                ty: Utxo(
+                    UtxoType {
+                        name: "ScoreProgress",
+                    },
                 ),
             },
         ),
@@ -1432,8 +1434,10 @@ TypedProgram {
                             },
                             value: Spanned {
                                 node: TypedExpr {
-                                    ty: UtxoNamed(
-                                        "ScoreProgress",
+                                    ty: Utxo(
+                                        UtxoType {
+                                            name: "ScoreProgress",
+                                        },
                                     ),
                                     kind: Call {
                                         callee: Spanned {
@@ -1444,8 +1448,10 @@ TypedProgram {
                                                         name_span: 263..266,
                                                         params: [],
                                                         param_spans: [],
-                                                        result: UtxoNamed(
-                                                            "ScoreProgress",
+                                                        result: Utxo(
+                                                            UtxoType {
+                                                                name: "ScoreProgress",
+                                                            },
                                                         ),
                                                         callee: Some(
                                                             Named(

--- a/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
@@ -1115,110 +1115,108 @@ TypedProgram {
                     ),
                     AbiImpl {
                         span: 343..348,
-                        abi: Abi(
-                            AbiType {
-                                name: Identifier {
-                                    name: "Score",
-                                    span: 4..9,
-                                },
-                                methods: [
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "plus_chips",
-                                            span: 19..29,
-                                        },
-                                        id: NameId(2),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 19..29,
-                                            params: [
-                                                Int(
-                                                    U64,
-                                                ),
-                                            ],
-                                            param_spans: [
-                                                30..35,
-                                            ],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(2),
-                                                ),
-                                            ),
-                                        },
-                                    },
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "plus_mult",
-                                            span: 50..59,
-                                        },
-                                        id: NameId(3),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 50..59,
-                                            params: [
-                                                Int(
-                                                    U64,
-                                                ),
-                                            ],
-                                            param_spans: [
-                                                60..64,
-                                            ],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(3),
-                                                ),
-                                            ),
-                                        },
-                                    },
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "mult_mult",
-                                            span: 79..88,
-                                        },
-                                        id: NameId(4),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 79..88,
-                                            params: [
-                                                Int(
-                                                    U64,
-                                                ),
-                                            ],
-                                            param_spans: [
-                                                89..97,
-                                            ],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(4),
-                                                ),
-                                            ),
-                                        },
-                                    },
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "finish",
-                                            span: 112..118,
-                                        },
-                                        id: NameId(5),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 112..118,
-                                            params: [],
-                                            param_spans: [],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(5),
-                                                ),
-                                            ),
-                                        },
-                                    },
-                                ],
+                        abi: AbiType {
+                            name: Identifier {
+                                name: "Score",
+                                span: 4..9,
                             },
-                        ),
+                            methods: [
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "plus_chips",
+                                        span: 19..29,
+                                    },
+                                    id: NameId(2),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 19..29,
+                                        params: [
+                                            Int(
+                                                U64,
+                                            ),
+                                        ],
+                                        param_spans: [
+                                            30..35,
+                                        ],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(2),
+                                            ),
+                                        ),
+                                    },
+                                },
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "plus_mult",
+                                        span: 50..59,
+                                    },
+                                    id: NameId(3),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 50..59,
+                                        params: [
+                                            Int(
+                                                U64,
+                                            ),
+                                        ],
+                                        param_spans: [
+                                            60..64,
+                                        ],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(3),
+                                            ),
+                                        ),
+                                    },
+                                },
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "mult_mult",
+                                        span: 79..88,
+                                    },
+                                    id: NameId(4),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 79..88,
+                                        params: [
+                                            Int(
+                                                U64,
+                                            ),
+                                        ],
+                                        param_spans: [
+                                            89..97,
+                                        ],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(4),
+                                            ),
+                                        ),
+                                    },
+                                },
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "finish",
+                                        span: 112..118,
+                                    },
+                                    id: NameId(5),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 112..118,
+                                        params: [],
+                                        param_spans: [],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(5),
+                                            ),
+                                        ),
+                                    },
+                                },
+                            ],
+                        },
                         parts: [
                             TypedFunctionDef {
                                 export: None,

--- a/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
@@ -584,7 +584,6 @@ Program {
 }
 
 ==== Inference trace ====
-
 T-Utxo: ScoreProgress => 
   T-Fn: new => ()
     T-Expr: {chips: u64, mult: u64, new: fn() -> ()} ⊢ yield(Score); ⇒ ()
@@ -634,18 +633,18 @@ TypedProgram {
     definitions: [
         Abi(
             TypedAbiDef {
-                name: Identifier {
-                    name: "Score",
-                    span: 4..9,
-                },
-                parts: [
-                    FnDecl(
+                ty: AbiType {
+                    name: Identifier {
+                        name: "Score",
+                        span: 4..9,
+                    },
+                    methods: [
                         TypedAbiMethodDecl {
                             name: Identifier {
                                 name: "plus_chips",
                                 span: 19..29,
                             },
-                            span: 19..29,
+                            id: NameId(2),
                             ty: FunctionType {
                                 kind: Normal,
                                 name_span: 19..29,
@@ -665,14 +664,12 @@ TypedProgram {
                                 ),
                             },
                         },
-                    ),
-                    FnDecl(
                         TypedAbiMethodDecl {
                             name: Identifier {
                                 name: "plus_mult",
                                 span: 50..59,
                             },
-                            span: 50..59,
+                            id: NameId(3),
                             ty: FunctionType {
                                 kind: Normal,
                                 name_span: 50..59,
@@ -692,14 +689,12 @@ TypedProgram {
                                 ),
                             },
                         },
-                    ),
-                    FnDecl(
                         TypedAbiMethodDecl {
                             name: Identifier {
                                 name: "mult_mult",
                                 span: 79..88,
                             },
-                            span: 79..88,
+                            id: NameId(4),
                             ty: FunctionType {
                                 kind: Normal,
                                 name_span: 79..88,
@@ -719,14 +714,12 @@ TypedProgram {
                                 ),
                             },
                         },
-                    ),
-                    FnDecl(
                         TypedAbiMethodDecl {
                             name: Identifier {
                                 name: "finish",
                                 span: 112..118,
                             },
-                            span: 112..118,
+                            id: NameId(5),
                             ty: FunctionType {
                                 kind: Normal,
                                 name_span: 112..118,
@@ -740,28 +733,128 @@ TypedProgram {
                                 ),
                             },
                         },
-                    ),
-                    Event(
-                        TypedEventDef {
-                            name: Identifier {
-                                name: "Finish",
-                                span: 132..138,
-                            },
-                            id: NameId(6),
-                            params: [
-                                TypedFunctionParam {
-                                    public: false,
-                                    name: Identifier {
-                                        name: "total",
-                                        span: 139..144,
-                                    },
-                                    ty: Int(
-                                        U64,
-                                    ),
-                                },
-                            ],
+                    ],
+                },
+                functions: [
+                    TypedAbiMethodDecl {
+                        name: Identifier {
+                            name: "plus_chips",
+                            span: 19..29,
                         },
-                    ),
+                        id: NameId(2),
+                        ty: FunctionType {
+                            kind: Normal,
+                            name_span: 19..29,
+                            params: [
+                                Int(
+                                    U64,
+                                ),
+                            ],
+                            param_spans: [
+                                30..35,
+                            ],
+                            result: Unit,
+                            callee: Some(
+                                Named(
+                                    NameId(2),
+                                ),
+                            ),
+                        },
+                    },
+                    TypedAbiMethodDecl {
+                        name: Identifier {
+                            name: "plus_mult",
+                            span: 50..59,
+                        },
+                        id: NameId(3),
+                        ty: FunctionType {
+                            kind: Normal,
+                            name_span: 50..59,
+                            params: [
+                                Int(
+                                    U64,
+                                ),
+                            ],
+                            param_spans: [
+                                60..64,
+                            ],
+                            result: Unit,
+                            callee: Some(
+                                Named(
+                                    NameId(3),
+                                ),
+                            ),
+                        },
+                    },
+                    TypedAbiMethodDecl {
+                        name: Identifier {
+                            name: "mult_mult",
+                            span: 79..88,
+                        },
+                        id: NameId(4),
+                        ty: FunctionType {
+                            kind: Normal,
+                            name_span: 79..88,
+                            params: [
+                                Int(
+                                    U64,
+                                ),
+                            ],
+                            param_spans: [
+                                89..97,
+                            ],
+                            result: Unit,
+                            callee: Some(
+                                Named(
+                                    NameId(4),
+                                ),
+                            ),
+                        },
+                    },
+                    TypedAbiMethodDecl {
+                        name: Identifier {
+                            name: "finish",
+                            span: 112..118,
+                        },
+                        id: NameId(5),
+                        ty: FunctionType {
+                            kind: Normal,
+                            name_span: 112..118,
+                            params: [],
+                            param_spans: [],
+                            result: Unit,
+                            callee: Some(
+                                Named(
+                                    NameId(5),
+                                ),
+                            ),
+                        },
+                    },
+                    TypedAbiMethodDecl {
+                        name: Identifier {
+                            name: "Finish",
+                            span: 132..138,
+                        },
+                        id: NameId(6),
+                        ty: FunctionType {
+                            kind: Emit,
+                            name_span: 132..138,
+                            params: [
+                                Int(
+                                    U64,
+                                ),
+                            ],
+                            param_spans: [
+                                146..149,
+                            ],
+                            result: Unit,
+                            callee: Some(
+                                Named(
+                                    NameId(6),
+                                ),
+                            ),
+                        },
+                    },
                 ],
             },
         ),
@@ -825,7 +918,7 @@ TypedProgram {
                                                                         name: "plus_chips",
                                                                         span: 19..29,
                                                                     },
-                                                                    span: 19..29,
+                                                                    id: NameId(2),
                                                                     ty: FunctionType {
                                                                         kind: Normal,
                                                                         name_span: 19..29,
@@ -850,7 +943,7 @@ TypedProgram {
                                                                         name: "plus_mult",
                                                                         span: 50..59,
                                                                     },
-                                                                    span: 50..59,
+                                                                    id: NameId(3),
                                                                     ty: FunctionType {
                                                                         kind: Normal,
                                                                         name_span: 50..59,
@@ -875,7 +968,7 @@ TypedProgram {
                                                                         name: "mult_mult",
                                                                         span: 79..88,
                                                                     },
-                                                                    span: 79..88,
+                                                                    id: NameId(4),
                                                                     ty: FunctionType {
                                                                         kind: Normal,
                                                                         name_span: 79..88,
@@ -900,7 +993,7 @@ TypedProgram {
                                                                         name: "finish",
                                                                         span: 112..118,
                                                                     },
-                                                                    span: 112..118,
+                                                                    id: NameId(5),
                                                                     ty: FunctionType {
                                                                         kind: Normal,
                                                                         name_span: 112..118,
@@ -1034,7 +1127,7 @@ TypedProgram {
                                             name: "plus_chips",
                                             span: 19..29,
                                         },
-                                        span: 19..29,
+                                        id: NameId(2),
                                         ty: FunctionType {
                                             kind: Normal,
                                             name_span: 19..29,
@@ -1059,7 +1152,7 @@ TypedProgram {
                                             name: "plus_mult",
                                             span: 50..59,
                                         },
-                                        span: 50..59,
+                                        id: NameId(3),
                                         ty: FunctionType {
                                             kind: Normal,
                                             name_span: 50..59,
@@ -1084,7 +1177,7 @@ TypedProgram {
                                             name: "mult_mult",
                                             span: 79..88,
                                         },
-                                        span: 79..88,
+                                        id: NameId(4),
                                         ty: FunctionType {
                                             kind: Normal,
                                             name_span: 79..88,
@@ -1109,7 +1202,7 @@ TypedProgram {
                                             name: "finish",
                                             span: 112..118,
                                         },
-                                        span: 112..118,
+                                        id: NameId(5),
                                         ty: FunctionType {
                                             kind: Normal,
                                             name_span: 112..118,
@@ -1133,7 +1226,7 @@ TypedProgram {
                                     name: "plus_chips",
                                     span: 362..372,
                                 },
-                                id: NameId(9),
+                                id: NameId(10),
                                 params: [
                                     TypedFunctionParam {
                                         public: true,
@@ -1210,7 +1303,7 @@ TypedProgram {
                                     name: "plus_mult",
                                     span: 449..458,
                                 },
-                                id: NameId(10),
+                                id: NameId(11),
                                 params: [
                                     TypedFunctionParam {
                                         public: true,
@@ -1287,7 +1380,7 @@ TypedProgram {
                                     name: "mult_mult",
                                     span: 531..540,
                                 },
-                                id: NameId(11),
+                                id: NameId(12),
                                 params: [
                                     TypedFunctionParam {
                                         public: true,
@@ -1391,7 +1484,7 @@ TypedProgram {
                                     name: "finish",
                                     span: 625..631,
                                 },
-                                id: NameId(12),
+                                id: NameId(13),
                                 params: [],
                                 return_type: Unit,
                                 body: TypedBlock {
@@ -1421,7 +1514,7 @@ TypedProgram {
                     name: "example",
                     span: 685..692,
                 },
-                id: NameId(13),
+                id: NameId(9),
                 params: [],
                 return_type: Unit,
                 body: TypedBlock {

--- a/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
@@ -1501,6 +1501,214 @@ TypedProgram {
                     UtxoType {
                         name: "ScoreProgress",
                         id: NameId(7),
+                        possible_abis: [
+                            AbiType {
+                                name: Identifier {
+                                    name: "Score",
+                                    span: 4..9,
+                                },
+                                methods: [
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "plus_chips",
+                                            span: 19..29,
+                                        },
+                                        id: NameId(2),
+                                        ty: FunctionType {
+                                            kind: Normal,
+                                            name_span: 19..29,
+                                            params: [
+                                                Int(
+                                                    U64,
+                                                ),
+                                            ],
+                                            param_spans: [
+                                                30..35,
+                                            ],
+                                            result: Unit,
+                                            callee: Some(
+                                                Named(
+                                                    NameId(2),
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "plus_mult",
+                                            span: 50..59,
+                                        },
+                                        id: NameId(3),
+                                        ty: FunctionType {
+                                            kind: Normal,
+                                            name_span: 50..59,
+                                            params: [
+                                                Int(
+                                                    U64,
+                                                ),
+                                            ],
+                                            param_spans: [
+                                                60..64,
+                                            ],
+                                            result: Unit,
+                                            callee: Some(
+                                                Named(
+                                                    NameId(3),
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "mult_mult",
+                                            span: 79..88,
+                                        },
+                                        id: NameId(4),
+                                        ty: FunctionType {
+                                            kind: Normal,
+                                            name_span: 79..88,
+                                            params: [
+                                                Int(
+                                                    U64,
+                                                ),
+                                            ],
+                                            param_spans: [
+                                                89..97,
+                                            ],
+                                            result: Unit,
+                                            callee: Some(
+                                                Named(
+                                                    NameId(4),
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "finish",
+                                            span: 112..118,
+                                        },
+                                        id: NameId(5),
+                                        ty: FunctionType {
+                                            kind: Normal,
+                                            name_span: 112..118,
+                                            params: [],
+                                            param_spans: [],
+                                            result: Unit,
+                                            callee: Some(
+                                                Named(
+                                                    NameId(5),
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
+                        always_abis: [
+                            AbiType {
+                                name: Identifier {
+                                    name: "Score",
+                                    span: 4..9,
+                                },
+                                methods: [
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "plus_chips",
+                                            span: 19..29,
+                                        },
+                                        id: NameId(2),
+                                        ty: FunctionType {
+                                            kind: Normal,
+                                            name_span: 19..29,
+                                            params: [
+                                                Int(
+                                                    U64,
+                                                ),
+                                            ],
+                                            param_spans: [
+                                                30..35,
+                                            ],
+                                            result: Unit,
+                                            callee: Some(
+                                                Named(
+                                                    NameId(2),
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "plus_mult",
+                                            span: 50..59,
+                                        },
+                                        id: NameId(3),
+                                        ty: FunctionType {
+                                            kind: Normal,
+                                            name_span: 50..59,
+                                            params: [
+                                                Int(
+                                                    U64,
+                                                ),
+                                            ],
+                                            param_spans: [
+                                                60..64,
+                                            ],
+                                            result: Unit,
+                                            callee: Some(
+                                                Named(
+                                                    NameId(3),
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "mult_mult",
+                                            span: 79..88,
+                                        },
+                                        id: NameId(4),
+                                        ty: FunctionType {
+                                            kind: Normal,
+                                            name_span: 79..88,
+                                            params: [
+                                                Int(
+                                                    U64,
+                                                ),
+                                            ],
+                                            param_spans: [
+                                                89..97,
+                                            ],
+                                            result: Unit,
+                                            callee: Some(
+                                                Named(
+                                                    NameId(4),
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "finish",
+                                            span: 112..118,
+                                        },
+                                        id: NameId(5),
+                                        ty: FunctionType {
+                                            kind: Normal,
+                                            name_span: 112..118,
+                                            params: [],
+                                            param_spans: [],
+                                            result: Unit,
+                                            callee: Some(
+                                                Named(
+                                                    NameId(5),
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
                     },
                 ),
             },
@@ -1532,6 +1740,214 @@ TypedProgram {
                                         UtxoType {
                                             name: "ScoreProgress",
                                             id: NameId(7),
+                                            possible_abis: [
+                                                AbiType {
+                                                    name: Identifier {
+                                                        name: "Score",
+                                                        span: 4..9,
+                                                    },
+                                                    methods: [
+                                                        TypedAbiMethodDecl {
+                                                            name: Identifier {
+                                                                name: "plus_chips",
+                                                                span: 19..29,
+                                                            },
+                                                            id: NameId(2),
+                                                            ty: FunctionType {
+                                                                kind: Normal,
+                                                                name_span: 19..29,
+                                                                params: [
+                                                                    Int(
+                                                                        U64,
+                                                                    ),
+                                                                ],
+                                                                param_spans: [
+                                                                    30..35,
+                                                                ],
+                                                                result: Unit,
+                                                                callee: Some(
+                                                                    Named(
+                                                                        NameId(2),
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        },
+                                                        TypedAbiMethodDecl {
+                                                            name: Identifier {
+                                                                name: "plus_mult",
+                                                                span: 50..59,
+                                                            },
+                                                            id: NameId(3),
+                                                            ty: FunctionType {
+                                                                kind: Normal,
+                                                                name_span: 50..59,
+                                                                params: [
+                                                                    Int(
+                                                                        U64,
+                                                                    ),
+                                                                ],
+                                                                param_spans: [
+                                                                    60..64,
+                                                                ],
+                                                                result: Unit,
+                                                                callee: Some(
+                                                                    Named(
+                                                                        NameId(3),
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        },
+                                                        TypedAbiMethodDecl {
+                                                            name: Identifier {
+                                                                name: "mult_mult",
+                                                                span: 79..88,
+                                                            },
+                                                            id: NameId(4),
+                                                            ty: FunctionType {
+                                                                kind: Normal,
+                                                                name_span: 79..88,
+                                                                params: [
+                                                                    Int(
+                                                                        U64,
+                                                                    ),
+                                                                ],
+                                                                param_spans: [
+                                                                    89..97,
+                                                                ],
+                                                                result: Unit,
+                                                                callee: Some(
+                                                                    Named(
+                                                                        NameId(4),
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        },
+                                                        TypedAbiMethodDecl {
+                                                            name: Identifier {
+                                                                name: "finish",
+                                                                span: 112..118,
+                                                            },
+                                                            id: NameId(5),
+                                                            ty: FunctionType {
+                                                                kind: Normal,
+                                                                name_span: 112..118,
+                                                                params: [],
+                                                                param_spans: [],
+                                                                result: Unit,
+                                                                callee: Some(
+                                                                    Named(
+                                                                        NameId(5),
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            always_abis: [
+                                                AbiType {
+                                                    name: Identifier {
+                                                        name: "Score",
+                                                        span: 4..9,
+                                                    },
+                                                    methods: [
+                                                        TypedAbiMethodDecl {
+                                                            name: Identifier {
+                                                                name: "plus_chips",
+                                                                span: 19..29,
+                                                            },
+                                                            id: NameId(2),
+                                                            ty: FunctionType {
+                                                                kind: Normal,
+                                                                name_span: 19..29,
+                                                                params: [
+                                                                    Int(
+                                                                        U64,
+                                                                    ),
+                                                                ],
+                                                                param_spans: [
+                                                                    30..35,
+                                                                ],
+                                                                result: Unit,
+                                                                callee: Some(
+                                                                    Named(
+                                                                        NameId(2),
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        },
+                                                        TypedAbiMethodDecl {
+                                                            name: Identifier {
+                                                                name: "plus_mult",
+                                                                span: 50..59,
+                                                            },
+                                                            id: NameId(3),
+                                                            ty: FunctionType {
+                                                                kind: Normal,
+                                                                name_span: 50..59,
+                                                                params: [
+                                                                    Int(
+                                                                        U64,
+                                                                    ),
+                                                                ],
+                                                                param_spans: [
+                                                                    60..64,
+                                                                ],
+                                                                result: Unit,
+                                                                callee: Some(
+                                                                    Named(
+                                                                        NameId(3),
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        },
+                                                        TypedAbiMethodDecl {
+                                                            name: Identifier {
+                                                                name: "mult_mult",
+                                                                span: 79..88,
+                                                            },
+                                                            id: NameId(4),
+                                                            ty: FunctionType {
+                                                                kind: Normal,
+                                                                name_span: 79..88,
+                                                                params: [
+                                                                    Int(
+                                                                        U64,
+                                                                    ),
+                                                                ],
+                                                                param_spans: [
+                                                                    89..97,
+                                                                ],
+                                                                result: Unit,
+                                                                callee: Some(
+                                                                    Named(
+                                                                        NameId(4),
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        },
+                                                        TypedAbiMethodDecl {
+                                                            name: Identifier {
+                                                                name: "finish",
+                                                                span: 112..118,
+                                                            },
+                                                            id: NameId(5),
+                                                            ty: FunctionType {
+                                                                kind: Normal,
+                                                                name_span: 112..118,
+                                                                params: [],
+                                                                param_spans: [],
+                                                                result: Unit,
+                                                                callee: Some(
+                                                                    Named(
+                                                                        NameId(5),
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            ],
                                         },
                                     ),
                                     kind: Call {
@@ -1547,6 +1963,214 @@ TypedProgram {
                                                             UtxoType {
                                                                 name: "ScoreProgress",
                                                                 id: NameId(7),
+                                                                possible_abis: [
+                                                                    AbiType {
+                                                                        name: Identifier {
+                                                                            name: "Score",
+                                                                            span: 4..9,
+                                                                        },
+                                                                        methods: [
+                                                                            TypedAbiMethodDecl {
+                                                                                name: Identifier {
+                                                                                    name: "plus_chips",
+                                                                                    span: 19..29,
+                                                                                },
+                                                                                id: NameId(2),
+                                                                                ty: FunctionType {
+                                                                                    kind: Normal,
+                                                                                    name_span: 19..29,
+                                                                                    params: [
+                                                                                        Int(
+                                                                                            U64,
+                                                                                        ),
+                                                                                    ],
+                                                                                    param_spans: [
+                                                                                        30..35,
+                                                                                    ],
+                                                                                    result: Unit,
+                                                                                    callee: Some(
+                                                                                        Named(
+                                                                                            NameId(2),
+                                                                                        ),
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                            TypedAbiMethodDecl {
+                                                                                name: Identifier {
+                                                                                    name: "plus_mult",
+                                                                                    span: 50..59,
+                                                                                },
+                                                                                id: NameId(3),
+                                                                                ty: FunctionType {
+                                                                                    kind: Normal,
+                                                                                    name_span: 50..59,
+                                                                                    params: [
+                                                                                        Int(
+                                                                                            U64,
+                                                                                        ),
+                                                                                    ],
+                                                                                    param_spans: [
+                                                                                        60..64,
+                                                                                    ],
+                                                                                    result: Unit,
+                                                                                    callee: Some(
+                                                                                        Named(
+                                                                                            NameId(3),
+                                                                                        ),
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                            TypedAbiMethodDecl {
+                                                                                name: Identifier {
+                                                                                    name: "mult_mult",
+                                                                                    span: 79..88,
+                                                                                },
+                                                                                id: NameId(4),
+                                                                                ty: FunctionType {
+                                                                                    kind: Normal,
+                                                                                    name_span: 79..88,
+                                                                                    params: [
+                                                                                        Int(
+                                                                                            U64,
+                                                                                        ),
+                                                                                    ],
+                                                                                    param_spans: [
+                                                                                        89..97,
+                                                                                    ],
+                                                                                    result: Unit,
+                                                                                    callee: Some(
+                                                                                        Named(
+                                                                                            NameId(4),
+                                                                                        ),
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                            TypedAbiMethodDecl {
+                                                                                name: Identifier {
+                                                                                    name: "finish",
+                                                                                    span: 112..118,
+                                                                                },
+                                                                                id: NameId(5),
+                                                                                ty: FunctionType {
+                                                                                    kind: Normal,
+                                                                                    name_span: 112..118,
+                                                                                    params: [],
+                                                                                    param_spans: [],
+                                                                                    result: Unit,
+                                                                                    callee: Some(
+                                                                                        Named(
+                                                                                            NameId(5),
+                                                                                        ),
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                                always_abis: [
+                                                                    AbiType {
+                                                                        name: Identifier {
+                                                                            name: "Score",
+                                                                            span: 4..9,
+                                                                        },
+                                                                        methods: [
+                                                                            TypedAbiMethodDecl {
+                                                                                name: Identifier {
+                                                                                    name: "plus_chips",
+                                                                                    span: 19..29,
+                                                                                },
+                                                                                id: NameId(2),
+                                                                                ty: FunctionType {
+                                                                                    kind: Normal,
+                                                                                    name_span: 19..29,
+                                                                                    params: [
+                                                                                        Int(
+                                                                                            U64,
+                                                                                        ),
+                                                                                    ],
+                                                                                    param_spans: [
+                                                                                        30..35,
+                                                                                    ],
+                                                                                    result: Unit,
+                                                                                    callee: Some(
+                                                                                        Named(
+                                                                                            NameId(2),
+                                                                                        ),
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                            TypedAbiMethodDecl {
+                                                                                name: Identifier {
+                                                                                    name: "plus_mult",
+                                                                                    span: 50..59,
+                                                                                },
+                                                                                id: NameId(3),
+                                                                                ty: FunctionType {
+                                                                                    kind: Normal,
+                                                                                    name_span: 50..59,
+                                                                                    params: [
+                                                                                        Int(
+                                                                                            U64,
+                                                                                        ),
+                                                                                    ],
+                                                                                    param_spans: [
+                                                                                        60..64,
+                                                                                    ],
+                                                                                    result: Unit,
+                                                                                    callee: Some(
+                                                                                        Named(
+                                                                                            NameId(3),
+                                                                                        ),
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                            TypedAbiMethodDecl {
+                                                                                name: Identifier {
+                                                                                    name: "mult_mult",
+                                                                                    span: 79..88,
+                                                                                },
+                                                                                id: NameId(4),
+                                                                                ty: FunctionType {
+                                                                                    kind: Normal,
+                                                                                    name_span: 79..88,
+                                                                                    params: [
+                                                                                        Int(
+                                                                                            U64,
+                                                                                        ),
+                                                                                    ],
+                                                                                    param_spans: [
+                                                                                        89..97,
+                                                                                    ],
+                                                                                    result: Unit,
+                                                                                    callee: Some(
+                                                                                        Named(
+                                                                                            NameId(4),
+                                                                                        ),
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                            TypedAbiMethodDecl {
+                                                                                name: Identifier {
+                                                                                    name: "finish",
+                                                                                    span: 112..118,
+                                                                                },
+                                                                                id: NameId(5),
+                                                                                ty: FunctionType {
+                                                                                    kind: Normal,
+                                                                                    name_span: 112..118,
+                                                                                    params: [],
+                                                                                    param_spans: [],
+                                                                                    result: Unit,
+                                                                                    callee: Some(
+                                                                                        Named(
+                                                                                            NameId(5),
+                                                                                        ),
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
                                                             },
                                                         ),
                                                         callee: Some(

--- a/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
@@ -803,7 +803,7 @@ TypedProgram {
                                 name: "new",
                                 span: 263..266,
                             },
-                            id: NameId(7),
+                            id: NameId(8),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -1133,7 +1133,7 @@ TypedProgram {
                                     name: "plus_chips",
                                     span: 362..372,
                                 },
-                                id: NameId(8),
+                                id: NameId(9),
                                 params: [
                                     TypedFunctionParam {
                                         public: true,
@@ -1210,7 +1210,7 @@ TypedProgram {
                                     name: "plus_mult",
                                     span: 449..458,
                                 },
-                                id: NameId(9),
+                                id: NameId(10),
                                 params: [
                                     TypedFunctionParam {
                                         public: true,
@@ -1287,7 +1287,7 @@ TypedProgram {
                                     name: "mult_mult",
                                     span: 531..540,
                                 },
-                                id: NameId(10),
+                                id: NameId(11),
                                 params: [
                                     TypedFunctionParam {
                                         public: true,
@@ -1391,7 +1391,7 @@ TypedProgram {
                                     name: "finish",
                                     span: 625..631,
                                 },
-                                id: NameId(11),
+                                id: NameId(12),
                                 params: [],
                                 return_type: Unit,
                                 body: TypedBlock {
@@ -1407,6 +1407,7 @@ TypedProgram {
                 ty: Utxo(
                     UtxoType {
                         name: "ScoreProgress",
+                        id: NameId(7),
                     },
                 ),
             },
@@ -1420,7 +1421,7 @@ TypedProgram {
                     name: "example",
                     span: 685..692,
                 },
-                id: NameId(12),
+                id: NameId(13),
                 params: [],
                 return_type: Unit,
                 body: TypedBlock {
@@ -1437,6 +1438,7 @@ TypedProgram {
                                     ty: Utxo(
                                         UtxoType {
                                             name: "ScoreProgress",
+                                            id: NameId(7),
                                         },
                                     ),
                                     kind: Call {
@@ -1451,11 +1453,12 @@ TypedProgram {
                                                         result: Utxo(
                                                             UtxoType {
                                                                 name: "ScoreProgress",
+                                                                id: NameId(7),
                                                             },
                                                         ),
                                                         callee: Some(
                                                             Named(
-                                                                NameId(7),
+                                                                NameId(8),
                                                             ),
                                                         ),
                                                     },

--- a/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
@@ -570,15 +570,58 @@ Program {
                                         span: 712..732,
                                     },
                                 },
-                                span: 701..734,
+                                span: 701..738,
+                            },
+                            Spanned {
+                                node: Expression(
+                                    Spanned {
+                                        node: Call {
+                                            callee: Spanned {
+                                                node: FieldAccess {
+                                                    target: Spanned {
+                                                        node: ScopedName(
+                                                            [
+                                                                Identifier {
+                                                                    name: "prog",
+                                                                    span: 738..742,
+                                                                },
+                                                            ],
+                                                        ),
+                                                        span: 738..742,
+                                                    },
+                                                    field: Identifier {
+                                                        name: "plus_chips",
+                                                        span: 743..753,
+                                                    },
+                                                },
+                                                span: 738..753,
+                                            },
+                                            args: [
+                                                Spanned {
+                                                    node: Literal(
+                                                        Integer(
+                                                            IntegerLiteral {
+                                                                digits: "10",
+                                                                radix: Decimal,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    span: 754..756,
+                                                },
+                                            ],
+                                        },
+                                        span: 738..757,
+                                    },
+                                ),
+                                span: 738..759,
                             },
                         ],
                         tail_expression: None,
-                        span: 695..736,
+                        span: 695..761,
                     },
                 },
             ),
-            span: 675..736,
+            span: 675..761,
         },
     ],
 }
@@ -627,6 +670,12 @@ T-Fn: example => ()
   T-Let: {example: fn() -> ()} ⊢ let prog = ScoreProgress::new(); ⇒ ScoreProgress
     T-Call: {example: fn() -> ()} ⊢ ScoreProgress::new() ⇒ ScoreProgress
       T-Var: {example: fn() -> ()} ⊢ ScoreProgress::new ⇒ fn() -> ScoreProgress
+  T-Expr: {example: fn() -> (), prog: ScoreProgress} ⊢ prog.plus_chips(10); ⇒ ()
+    T-Call: {example: fn() -> (), prog: ScoreProgress} ⊢ prog.plus_chips(10) ⇒ ()
+      T-FieldAccess: {example: fn() -> (), prog: ScoreProgress} ⊢ prog.plus_chips ⇒ fn(u64) -> ()
+        T-Var: {example: fn() -> (), prog: ScoreProgress} ⊢ prog ⇒ ScoreProgress
+      T-Int: {example: fn() -> (), prog: ScoreProgress} ⊢ 10 ⇒ i64
+      Unify-Var: i64 ~ u64 => {u64/t4}
 
 ==== Typed AST ====
 TypedProgram {
@@ -2200,6 +2249,293 @@ TypedProgram {
                                 span: 712..730,
                             },
                         },
+                        Expression(
+                            Spanned {
+                                node: TypedExpr {
+                                    ty: Unit,
+                                    kind: Call {
+                                        callee: Spanned {
+                                            node: TypedExpr {
+                                                ty: Function(
+                                                    FunctionType {
+                                                        kind: Normal,
+                                                        name_span: 19..29,
+                                                        params: [
+                                                            Int(
+                                                                U64,
+                                                            ),
+                                                        ],
+                                                        param_spans: [
+                                                            30..35,
+                                                        ],
+                                                        result: Unit,
+                                                        callee: Some(
+                                                            Named(
+                                                                NameId(2),
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                                kind: FieldAccess {
+                                                    target: Spanned {
+                                                        node: TypedExpr {
+                                                            ty: Utxo(
+                                                                UtxoType {
+                                                                    name: "ScoreProgress",
+                                                                    id: NameId(7),
+                                                                    possible_abis: [
+                                                                        AbiType {
+                                                                            name: Identifier {
+                                                                                name: "Score",
+                                                                                span: 4..9,
+                                                                            },
+                                                                            methods: [
+                                                                                TypedAbiMethodDecl {
+                                                                                    name: Identifier {
+                                                                                        name: "plus_chips",
+                                                                                        span: 19..29,
+                                                                                    },
+                                                                                    id: NameId(2),
+                                                                                    ty: FunctionType {
+                                                                                        kind: Normal,
+                                                                                        name_span: 19..29,
+                                                                                        params: [
+                                                                                            Int(
+                                                                                                U64,
+                                                                                            ),
+                                                                                        ],
+                                                                                        param_spans: [
+                                                                                            30..35,
+                                                                                        ],
+                                                                                        result: Unit,
+                                                                                        callee: Some(
+                                                                                            Named(
+                                                                                                NameId(2),
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                },
+                                                                                TypedAbiMethodDecl {
+                                                                                    name: Identifier {
+                                                                                        name: "plus_mult",
+                                                                                        span: 50..59,
+                                                                                    },
+                                                                                    id: NameId(3),
+                                                                                    ty: FunctionType {
+                                                                                        kind: Normal,
+                                                                                        name_span: 50..59,
+                                                                                        params: [
+                                                                                            Int(
+                                                                                                U64,
+                                                                                            ),
+                                                                                        ],
+                                                                                        param_spans: [
+                                                                                            60..64,
+                                                                                        ],
+                                                                                        result: Unit,
+                                                                                        callee: Some(
+                                                                                            Named(
+                                                                                                NameId(3),
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                },
+                                                                                TypedAbiMethodDecl {
+                                                                                    name: Identifier {
+                                                                                        name: "mult_mult",
+                                                                                        span: 79..88,
+                                                                                    },
+                                                                                    id: NameId(4),
+                                                                                    ty: FunctionType {
+                                                                                        kind: Normal,
+                                                                                        name_span: 79..88,
+                                                                                        params: [
+                                                                                            Int(
+                                                                                                U64,
+                                                                                            ),
+                                                                                        ],
+                                                                                        param_spans: [
+                                                                                            89..97,
+                                                                                        ],
+                                                                                        result: Unit,
+                                                                                        callee: Some(
+                                                                                            Named(
+                                                                                                NameId(4),
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                },
+                                                                                TypedAbiMethodDecl {
+                                                                                    name: Identifier {
+                                                                                        name: "finish",
+                                                                                        span: 112..118,
+                                                                                    },
+                                                                                    id: NameId(5),
+                                                                                    ty: FunctionType {
+                                                                                        kind: Normal,
+                                                                                        name_span: 112..118,
+                                                                                        params: [],
+                                                                                        param_spans: [],
+                                                                                        result: Unit,
+                                                                                        callee: Some(
+                                                                                            Named(
+                                                                                                NameId(5),
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                },
+                                                                            ],
+                                                                        },
+                                                                    ],
+                                                                    always_abis: [
+                                                                        AbiType {
+                                                                            name: Identifier {
+                                                                                name: "Score",
+                                                                                span: 4..9,
+                                                                            },
+                                                                            methods: [
+                                                                                TypedAbiMethodDecl {
+                                                                                    name: Identifier {
+                                                                                        name: "plus_chips",
+                                                                                        span: 19..29,
+                                                                                    },
+                                                                                    id: NameId(2),
+                                                                                    ty: FunctionType {
+                                                                                        kind: Normal,
+                                                                                        name_span: 19..29,
+                                                                                        params: [
+                                                                                            Int(
+                                                                                                U64,
+                                                                                            ),
+                                                                                        ],
+                                                                                        param_spans: [
+                                                                                            30..35,
+                                                                                        ],
+                                                                                        result: Unit,
+                                                                                        callee: Some(
+                                                                                            Named(
+                                                                                                NameId(2),
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                },
+                                                                                TypedAbiMethodDecl {
+                                                                                    name: Identifier {
+                                                                                        name: "plus_mult",
+                                                                                        span: 50..59,
+                                                                                    },
+                                                                                    id: NameId(3),
+                                                                                    ty: FunctionType {
+                                                                                        kind: Normal,
+                                                                                        name_span: 50..59,
+                                                                                        params: [
+                                                                                            Int(
+                                                                                                U64,
+                                                                                            ),
+                                                                                        ],
+                                                                                        param_spans: [
+                                                                                            60..64,
+                                                                                        ],
+                                                                                        result: Unit,
+                                                                                        callee: Some(
+                                                                                            Named(
+                                                                                                NameId(3),
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                },
+                                                                                TypedAbiMethodDecl {
+                                                                                    name: Identifier {
+                                                                                        name: "mult_mult",
+                                                                                        span: 79..88,
+                                                                                    },
+                                                                                    id: NameId(4),
+                                                                                    ty: FunctionType {
+                                                                                        kind: Normal,
+                                                                                        name_span: 79..88,
+                                                                                        params: [
+                                                                                            Int(
+                                                                                                U64,
+                                                                                            ),
+                                                                                        ],
+                                                                                        param_spans: [
+                                                                                            89..97,
+                                                                                        ],
+                                                                                        result: Unit,
+                                                                                        callee: Some(
+                                                                                            Named(
+                                                                                                NameId(4),
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                },
+                                                                                TypedAbiMethodDecl {
+                                                                                    name: Identifier {
+                                                                                        name: "finish",
+                                                                                        span: 112..118,
+                                                                                    },
+                                                                                    id: NameId(5),
+                                                                                    ty: FunctionType {
+                                                                                        kind: Normal,
+                                                                                        name_span: 112..118,
+                                                                                        params: [],
+                                                                                        param_spans: [],
+                                                                                        result: Unit,
+                                                                                        callee: Some(
+                                                                                            Named(
+                                                                                                NameId(5),
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                },
+                                                                            ],
+                                                                        },
+                                                                    ],
+                                                                },
+                                                            ),
+                                                            kind: ScopedName {
+                                                                name: [
+                                                                    Identifier {
+                                                                        name: "prog",
+                                                                        span: 738..742,
+                                                                    },
+                                                                ],
+                                                                constant: None,
+                                                            },
+                                                        },
+                                                        span: 738..742,
+                                                    },
+                                                    field: Identifier {
+                                                        name: "plus_chips",
+                                                        span: 743..753,
+                                                    },
+                                                },
+                                            },
+                                            span: 738..753,
+                                        },
+                                        args: [
+                                            Spanned {
+                                                node: TypedExpr {
+                                                    ty: Int(
+                                                        U64,
+                                                    ),
+                                                    kind: Literal(
+                                                        Integer(
+                                                            IntegerLiteral {
+                                                                digits: "10",
+                                                                radix: Decimal,
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                                span: 754..756,
+                                            },
+                                        ],
+                                    },
+                                },
+                                span: 738..753,
+                            },
+                        ),
                     ],
                     tail_expression: None,
                 },
@@ -2215,9 +2551,9 @@ TypedProgram {
   (type (;2;) (func (param i32) (result i32)))
   (type (;3;) (func (param i32)))
   (type (;4;) (func (result i32)))
-  (type (;5;) (func))
-  (type (;6;) (func (param i64 i64) (result i64)))
-  (type (;7;) (func (param i32 i64)))
+  (type (;5;) (func (param i32 i64)))
+  (type (;6;) (func))
+  (type (;7;) (func (param i64 i64) (result i64)))
   (type (;8;) (func (param i32) (result i32 i64 i64 i32)))
   (type (;9;) (func (param i32 i64 i64 i32) (result i32)))
   (import "starstream:std/builtin" "implements-method" (func (;0;) (type 0)))
@@ -2225,30 +2561,34 @@ TypedProgram {
   (import "[export]score-progress" "[resource-new]utxo" (func (;2;) (type 2)))
   (import "[export]score-progress" "[resource-drop]utxo" (func (;3;) (type 3)))
   (import "score-progress" "[static]utxo.new" (func (;4;) (type 4)))
+  (import "score-progress" "[method]utxo.plus-chips" (func (;5;) (type 5)))
+  (import "score-progress" "[method]utxo.plus-mult" (func (;6;) (type 5)))
+  (import "score-progress" "[method]utxo.mult-mult" (func (;7;) (type 5)))
+  (import "score-progress" "[method]utxo.finish" (func (;8;) (type 3)))
   (memory (;0;) 1)
   (global (;0;) (mut i32) (i32.const 0))
   (global (;1;) (mut i64) (i64.const 0))
   (global (;2;) (mut i64) (i64.const 0))
   (global (;3;) (mut i32) (i32.const 0))
-  (export "score-progress#[static]utxo.new" (func 7))
-  (export "score-progress#[method]utxo.plus-chips" (func 10))
-  (export "score-progress#[method]utxo.plus-mult" (func 11))
-  (export "score-progress#[method]utxo.mult-mult" (func 12))
-  (export "score-progress#[method]utxo.finish" (func 13))
-  (export "score-progress#get-storage" (func 15))
-  (export "score-progress#set-storage" (func 16))
-  (export "example" (func 17))
+  (export "score-progress#[static]utxo.new" (func 11))
+  (export "score-progress#[method]utxo.plus-chips" (func 14))
+  (export "score-progress#[method]utxo.plus-mult" (func 15))
+  (export "score-progress#[method]utxo.mult-mult" (func 16))
+  (export "score-progress#[method]utxo.finish" (func 17))
+  (export "score-progress#get-storage" (func 19))
+  (export "score-progress#set-storage" (func 20))
+  (export "example" (func 21))
   (export "memory" (memory 0))
-  (func (;5;) (type 5)
+  (func (;9;) (type 6)
     (block ;; label = @1
       (br_if 0 (;@1;)
         (i32.ne
           (global.get 0)
           (i32.const 1)))
-      (return_call 8))
+      (return_call 12))
     (unreachable)
   )
-  (func (;6;) (type 6) (param i64 i64) (result i64)
+  (func (;10;) (type 7) (param i64 i64) (result i64)
     (local i64 i64 i64)
     (local.tee 2
       (i64.mul
@@ -2288,7 +2628,7 @@ TypedProgram {
           (then
             (unreachable)))))
   )
-  (func (;7;) (type 4) (result i32)
+  (func (;11;) (type 4) (result i32)
     (local i32)
     (local.set 0
       (call 2
@@ -2319,18 +2659,18 @@ TypedProgram {
       (i64.const -2683880554626369430))
     (local.get 0)
   )
-  (func (;8;) (type 5)
+  (func (;12;) (type 6)
     (local i32)
     (local.set 0
       (global.get 3))
     (global.set 3
       (i32.const 0))
     (call 1
-      (call 6
+      (call 10
         (global.get 1)
         (global.get 2)))
   )
-  (func (;9;) (type 6) (param i64 i64) (result i64)
+  (func (;13;) (type 7) (param i64 i64) (result i64)
     (local i64)
     (local.tee 2
       (i64.add
@@ -2353,40 +2693,40 @@ TypedProgram {
       (then
         (unreachable)))
   )
-  (func (;10;) (type 7) (param i32 i64)
+  (func (;14;) (type 5) (param i32 i64)
     (global.set 1
-      (call 9
+      (call 13
         (global.get 1)
         (local.get 1)))
   )
-  (func (;11;) (type 7) (param i32 i64)
+  (func (;15;) (type 5) (param i32 i64)
     (global.set 2
-      (call 9
+      (call 13
         (global.get 2)
         (local.get 1)))
   )
-  (func (;12;) (type 7) (param i32 i64)
+  (func (;16;) (type 5) (param i32 i64)
     (global.set 2
       (i64.div_u
-        (call 6
+        (call 10
           (global.get 2)
           (local.get 1))
         (i64.const 100)))
   )
-  (func (;13;) (type 3) (param i32)
-    (return_call 5)
+  (func (;17;) (type 3) (param i32)
+    (return_call 9)
   )
-  (func (;14;) (type 8) (param i32) (result i32 i64 i64 i32)
+  (func (;18;) (type 8) (param i32) (result i32 i64 i64 i32)
     (local i32)
     (global.get 0)
     (global.get 1)
     (global.get 2)
     (global.get 3)
   )
-  (func (;15;) (type 2) (param i32) (result i32)
+  (func (;19;) (type 2) (param i32) (result i32)
     (local i32 i32 i64 i64 i32)
     (i32.const 8)
-    (call 14
+    (call 18
       (local.get 0))
     (local.set 5)
     (local.set 4)
@@ -2407,7 +2747,7 @@ TypedProgram {
       (local.get 5))
     (i32.const 8)
   )
-  (func (;16;) (type 9) (param i32 i64 i64 i32) (result i32)
+  (func (;20;) (type 9) (param i32 i64 i64 i32) (result i32)
     (local i32 i64 i64 i32)
     (global.set 0
       (local.get 0))
@@ -2420,10 +2760,13 @@ TypedProgram {
     (return_call 2
       (i32.const 0))
   )
-  (func (;17;) (type 5)
+  (func (;21;) (type 6)
     (local i32)
     (local.set 0
       (call 4))
+    (call 5
+      (local.get 0)
+      (i64.const 10))
   )
   (@custom "component-type"
     (component
@@ -2514,6 +2857,10 @@ world root {
   import score-progress: interface {
     resource utxo {
       new: static func() -> utxo;
+      plus-chips: func(chips2: u64);
+      plus-mult: func(mult2: u64);
+      mult-mult: func(mult-pct: u64);
+      finish: func();
     }
   }
   import starstream:events/score;

--- a/starstream-to-wasm/tests/snapshots/inputs@struct_definition.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@struct_definition.star.snap
@@ -61,55 +61,32 @@ TypedProgram {
     definitions: [
         Struct(
             TypedStructDef {
-                name: Identifier {
-                    name: "Point",
-                    span: 7..12,
-                },
-                fields: [
-                    TypedStructField {
-                        name: Identifier {
-                            name: "x",
-                            span: 19..20,
-                        },
-                        ty: Int(
-                            I64,
-                        ),
-                    },
-                    TypedStructField {
-                        name: Identifier {
-                            name: "y",
-                            span: 31..32,
-                        },
-                        ty: Int(
-                            I64,
-                        ),
-                    },
-                ],
-                ty: Record(
-                    RecordType {
+                ty: RecordType {
+                    name: Identifier {
                         name: "Point",
-                        fields: [
-                            RecordFieldType {
-                                name: Identifier {
-                                    name: "x",
-                                    span: 19..20,
-                                },
-                                ty: Int(
-                                    I64,
-                                ),
-                            },
-                            RecordFieldType {
-                                name: Identifier {
-                                    name: "y",
-                                    span: 31..32,
-                                },
-                                ty: Int(
-                                    I64,
-                                ),
-                            },
-                        ],
+                        span: 7..12,
                     },
-                ),
+                    fields: [
+                        RecordFieldType {
+                            name: Identifier {
+                                name: "x",
+                                span: 19..20,
+                            },
+                            ty: Int(
+                                I64,
+                            ),
+                        },
+                        RecordFieldType {
+                            name: Identifier {
+                                name: "y",
+                                span: 31..32,
+                            },
+                            ty: Int(
+                                I64,
+                            ),
+                        },
+                    ],
+                },
             },
         ),
     ],

--- a/starstream-to-wasm/tests/snapshots/inputs@struct_param.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@struct_param.star.snap
@@ -150,7 +150,6 @@ Program {
 }
 
 ==== Inference trace ====
-
 T-Fn: total_value => i64
   T-ReturnTail: item.amount * item.price => i64
     T-Bin-Mul: {item: Item, total_value: fn(Item) -> i64} ⊢ item.amount * item.price ⇒ i64
@@ -166,55 +165,32 @@ TypedProgram {
     definitions: [
         Struct(
             TypedStructDef {
-                name: Identifier {
-                    name: "Item",
-                    span: 7..11,
-                },
-                fields: [
-                    TypedStructField {
-                        name: Identifier {
-                            name: "amount",
-                            span: 18..24,
-                        },
-                        ty: Int(
-                            I64,
-                        ),
-                    },
-                    TypedStructField {
-                        name: Identifier {
-                            name: "price",
-                            span: 35..40,
-                        },
-                        ty: Int(
-                            I64,
-                        ),
-                    },
-                ],
-                ty: Record(
-                    RecordType {
+                ty: RecordType {
+                    name: Identifier {
                         name: "Item",
-                        fields: [
-                            RecordFieldType {
-                                name: Identifier {
-                                    name: "amount",
-                                    span: 18..24,
-                                },
-                                ty: Int(
-                                    I64,
-                                ),
-                            },
-                            RecordFieldType {
-                                name: Identifier {
-                                    name: "price",
-                                    span: 35..40,
-                                },
-                                ty: Int(
-                                    I64,
-                                ),
-                            },
-                        ],
+                        span: 7..11,
                     },
-                ),
+                    fields: [
+                        RecordFieldType {
+                            name: Identifier {
+                                name: "amount",
+                                span: 18..24,
+                            },
+                            ty: Int(
+                                I64,
+                            ),
+                        },
+                        RecordFieldType {
+                            name: Identifier {
+                                name: "price",
+                                span: 35..40,
+                            },
+                            ty: Int(
+                                I64,
+                            ),
+                        },
+                    ],
+                },
             },
         ),
         Function(
@@ -236,7 +212,10 @@ TypedProgram {
                         },
                         ty: Record(
                             RecordType {
-                                name: "Item",
+                                name: Identifier {
+                                    name: "Item",
+                                    span: 7..11,
+                                },
                                 fields: [
                                     RecordFieldType {
                                         name: Identifier {
@@ -284,7 +263,10 @@ TypedProgram {
                                                     node: TypedExpr {
                                                         ty: Record(
                                                             RecordType {
-                                                                name: "Item",
+                                                                name: Identifier {
+                                                                    name: "Item",
+                                                                    span: 7..11,
+                                                                },
                                                                 fields: [
                                                                     RecordFieldType {
                                                                         name: Identifier {
@@ -337,7 +319,10 @@ TypedProgram {
                                                     node: TypedExpr {
                                                         ty: Record(
                                                             RecordType {
-                                                                name: "Item",
+                                                                name: Identifier {
+                                                                    name: "Item",
+                                                                    span: 7..11,
+                                                                },
                                                                 fields: [
                                                                     RecordFieldType {
                                                                         name: Identifier {

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
@@ -193,7 +193,7 @@ TypedProgram {
                                 name: "mint",
                                 span: 85..89,
                             },
-                            id: NameId(2),
+                            id: NameId(3),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -290,7 +290,7 @@ TypedProgram {
                                     name: "attach",
                                     span: 148..154,
                                 },
-                                id: NameId(3),
+                                id: NameId(4),
                                 params: [
                                     TypedFunctionParam {
                                         public: false,
@@ -313,7 +313,7 @@ TypedProgram {
                                     name: "detach",
                                     span: 180..186,
                                 },
-                                id: NameId(4),
+                                id: NameId(5),
                                 params: [
                                     TypedFunctionParam {
                                         public: false,
@@ -336,6 +336,7 @@ TypedProgram {
                 ty: Token(
                     TokenType {
                         name: "MyToken",
+                        id: NameId(2),
                     },
                 ),
             },

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
@@ -333,8 +333,10 @@ TypedProgram {
                         ],
                     },
                 ],
-                ty: TokenNamed(
-                    "MyToken",
+                ty: Token(
+                    TokenType {
+                        name: "MyToken",
+                    },
                 ),
             },
         ),

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
@@ -239,7 +239,7 @@ TypedProgram {
                                             name: "attach",
                                             span: 0..0,
                                         },
-                                        span: 0..0,
+                                        id: NameId(0),
                                         ty: FunctionType {
                                             kind: Normal,
                                             name_span: 0..0,
@@ -262,7 +262,7 @@ TypedProgram {
                                             name: "detach",
                                             span: 0..0,
                                         },
-                                        span: 0..0,
+                                        id: NameId(1),
                                         ty: FunctionType {
                                             kind: Normal,
                                             name_span: 0..0,

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
@@ -513,8 +513,10 @@ TypedProgram {
                         ],
                     },
                 ],
-                ty: TokenNamed(
-                    "MyToken",
+                ty: Token(
+                    TokenType {
+                        name: "MyToken",
+                    },
                 ),
             },
         ),

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
@@ -419,7 +419,7 @@ TypedProgram {
                                             name: "attach",
                                             span: 0..0,
                                         },
-                                        span: 0..0,
+                                        id: NameId(0),
                                         ty: FunctionType {
                                             kind: Normal,
                                             name_span: 0..0,
@@ -442,7 +442,7 @@ TypedProgram {
                                             name: "detach",
                                             span: 0..0,
                                         },
-                                        span: 0..0,
+                                        id: NameId(1),
                                         ty: FunctionType {
                                             kind: Normal,
                                             name_span: 0..0,

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
@@ -276,7 +276,7 @@ TypedProgram {
                                 name: "mint",
                                 span: 76..80,
                             },
-                            id: NameId(2),
+                            id: NameId(3),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -345,7 +345,7 @@ TypedProgram {
                                 name: "burn",
                                 span: 130..134,
                             },
-                            id: NameId(3),
+                            id: NameId(4),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -470,7 +470,7 @@ TypedProgram {
                                     name: "attach",
                                     span: 200..206,
                                 },
-                                id: NameId(4),
+                                id: NameId(5),
                                 params: [
                                     TypedFunctionParam {
                                         public: false,
@@ -493,7 +493,7 @@ TypedProgram {
                                     name: "detach",
                                     span: 232..238,
                                 },
-                                id: NameId(5),
+                                id: NameId(6),
                                 params: [
                                     TypedFunctionParam {
                                         public: false,
@@ -516,6 +516,7 @@ TypedProgram {
                 ty: Token(
                     TokenType {
                         name: "MyToken",
+                        id: NameId(2),
                     },
                 ),
             },

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
@@ -126,7 +126,6 @@ Program {
 }
 
 ==== Inference trace ====
-
 T-Utxo: MyUtxo => 
   T-Fn: private_fn => ()
     T-Expr: {private_fn: fn() -> ()} ⊢ emit HelloEvent(); ⇒ ()
@@ -142,21 +141,33 @@ TypedProgram {
     definitions: [
         Abi(
             TypedAbiDef {
-                name: Identifier {
-                    name: "FooAbi",
-                    span: 4..10,
+                ty: AbiType {
+                    name: Identifier {
+                        name: "FooAbi",
+                        span: 4..10,
+                    },
+                    methods: [],
                 },
-                parts: [
-                    Event(
-                        TypedEventDef {
-                            name: Identifier {
-                                name: "HelloEvent",
-                                span: 23..33,
-                            },
-                            id: NameId(2),
-                            params: [],
+                functions: [
+                    TypedAbiMethodDecl {
+                        name: Identifier {
+                            name: "HelloEvent",
+                            span: 23..33,
                         },
-                    ),
+                        id: NameId(2),
+                        ty: FunctionType {
+                            kind: Emit,
+                            name_span: 23..33,
+                            params: [],
+                            param_spans: [],
+                            result: Unit,
+                            callee: Some(
+                                Named(
+                                    NameId(2),
+                                ),
+                            ),
+                        },
+                    },
                 ],
             },
         ),

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
@@ -299,6 +299,8 @@ TypedProgram {
                     UtxoType {
                         name: "MyUtxo",
                         id: NameId(3),
+                        possible_abis: [],
+                        always_abis: [],
                     },
                 ),
             },

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
@@ -284,8 +284,10 @@ TypedProgram {
                         },
                     ),
                 ],
-                ty: UtxoNamed(
-                    "MyUtxo",
+                ty: Utxo(
+                    UtxoType {
+                        name: "MyUtxo",
+                    },
                 ),
             },
         ),

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
@@ -295,14 +295,12 @@ TypedProgram {
                         },
                     ),
                 ],
-                ty: Utxo(
-                    UtxoType {
-                        name: "MyUtxo",
-                        id: NameId(3),
-                        possible_abis: [],
-                        always_abis: [],
-                    },
-                ),
+                ty: UtxoType {
+                    name: "MyUtxo",
+                    id: NameId(3),
+                    possible_abis: [],
+                    always_abis: [],
+                },
             },
         ),
     ],

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
@@ -174,7 +174,7 @@ TypedProgram {
                                 name: "private_fn",
                                 span: 61..71,
                             },
-                            id: NameId(4),
+                            id: NameId(5),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -234,7 +234,7 @@ TypedProgram {
                                 name: "hello_utxo",
                                 span: 121..131,
                             },
-                            id: NameId(3),
+                            id: NameId(4),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -255,7 +255,7 @@ TypedProgram {
                                                                     result: Unit,
                                                                     callee: Some(
                                                                         Named(
-                                                                            NameId(4),
+                                                                            NameId(5),
                                                                         ),
                                                                     ),
                                                                 },
@@ -287,6 +287,7 @@ TypedProgram {
                 ty: Utxo(
                     UtxoType {
                         name: "MyUtxo",
+                        id: NameId(3),
                     },
                 ),
             },

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
@@ -221,8 +221,10 @@ TypedProgram {
                         ],
                     },
                 ],
-                ty: UtxoNamed(
-                    "MyUtxo",
+                ty: Utxo(
+                    UtxoType {
+                        name: "MyUtxo",
+                    },
                 ),
             },
         ),

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
@@ -175,37 +175,35 @@ TypedProgram {
                 parts: [
                     AbiImpl {
                         span: 61..66,
-                        abi: Abi(
-                            AbiType {
-                                name: Identifier {
-                                    name: "MyAbi",
-                                    span: 4..9,
-                                },
-                                methods: [
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "hello",
-                                            span: 19..24,
-                                        },
-                                        id: NameId(2),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 19..24,
-                                            params: [],
-                                            param_spans: [],
-                                            result: Int(
-                                                I32,
-                                            ),
-                                            callee: Some(
-                                                Named(
-                                                    NameId(2),
-                                                ),
-                                            ),
-                                        },
-                                    },
-                                ],
+                        abi: AbiType {
+                            name: Identifier {
+                                name: "MyAbi",
+                                span: 4..9,
                             },
-                        ),
+                            methods: [
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "hello",
+                                        span: 19..24,
+                                    },
+                                    id: NameId(2),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 19..24,
+                                        params: [],
+                                        param_spans: [],
+                                        result: Int(
+                                            I32,
+                                        ),
+                                        callee: Some(
+                                            Named(
+                                                NameId(2),
+                                            ),
+                                        ),
+                                    },
+                                },
+                            ],
+                        },
                         parts: [
                             TypedFunctionDef {
                                 export: None,

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
@@ -191,7 +191,7 @@ TypedProgram {
                                     name: "hello",
                                     span: 80..85,
                                 },
-                                id: NameId(3),
+                                id: NameId(4),
                                 params: [],
                                 return_type: Int(
                                     I32,
@@ -224,6 +224,7 @@ TypedProgram {
                 ty: Utxo(
                     UtxoType {
                         name: "MyUtxo",
+                        id: NameId(3),
                     },
                 ),
             },

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
@@ -241,44 +241,42 @@ TypedProgram {
                         ],
                     },
                 ],
-                ty: Utxo(
-                    UtxoType {
-                        name: "MyUtxo",
-                        id: NameId(3),
-                        possible_abis: [
-                            AbiType {
-                                name: Identifier {
-                                    name: "MyAbi",
-                                    span: 4..9,
-                                },
-                                methods: [
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "hello",
-                                            span: 19..24,
-                                        },
-                                        id: NameId(2),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 19..24,
-                                            params: [],
-                                            param_spans: [],
-                                            result: Int(
-                                                I32,
-                                            ),
-                                            callee: Some(
-                                                Named(
-                                                    NameId(2),
-                                                ),
-                                            ),
-                                        },
-                                    },
-                                ],
+                ty: UtxoType {
+                    name: "MyUtxo",
+                    id: NameId(3),
+                    possible_abis: [
+                        AbiType {
+                            name: Identifier {
+                                name: "MyAbi",
+                                span: 4..9,
                             },
-                        ],
-                        always_abis: [],
-                    },
-                ),
+                            methods: [
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "hello",
+                                        span: 19..24,
+                                    },
+                                    id: NameId(2),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 19..24,
+                                        params: [],
+                                        param_spans: [],
+                                        result: Int(
+                                            I32,
+                                        ),
+                                        callee: Some(
+                                            Named(
+                                                NameId(2),
+                                            ),
+                                        ),
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                    always_abis: [],
+                },
             },
         ),
     ],

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
@@ -247,6 +247,38 @@ TypedProgram {
                     UtxoType {
                         name: "MyUtxo",
                         id: NameId(3),
+                        possible_abis: [
+                            AbiType {
+                                name: Identifier {
+                                    name: "MyAbi",
+                                    span: 4..9,
+                                },
+                                methods: [
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "hello",
+                                            span: 19..24,
+                                        },
+                                        id: NameId(2),
+                                        ty: FunctionType {
+                                            kind: Normal,
+                                            name_span: 19..24,
+                                            params: [],
+                                            param_spans: [],
+                                            result: Int(
+                                                I32,
+                                            ),
+                                            callee: Some(
+                                                Named(
+                                                    NameId(2),
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
+                        always_abis: [],
                     },
                 ),
             },

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
@@ -101,7 +101,6 @@ Program {
 }
 
 ==== Inference trace ====
-
 T-Utxo: MyUtxo => 
   T-Fn: hello => i32
     T-ReturnTail: 17 => i32
@@ -113,18 +112,18 @@ TypedProgram {
     definitions: [
         Abi(
             TypedAbiDef {
-                name: Identifier {
-                    name: "MyAbi",
-                    span: 4..9,
-                },
-                parts: [
-                    FnDecl(
+                ty: AbiType {
+                    name: Identifier {
+                        name: "MyAbi",
+                        span: 4..9,
+                    },
+                    methods: [
                         TypedAbiMethodDecl {
                             name: Identifier {
                                 name: "hello",
                                 span: 19..24,
                             },
-                            span: 19..24,
+                            id: NameId(2),
                             ty: FunctionType {
                                 kind: Normal,
                                 name_span: 19..24,
@@ -140,7 +139,30 @@ TypedProgram {
                                 ),
                             },
                         },
-                    ),
+                    ],
+                },
+                functions: [
+                    TypedAbiMethodDecl {
+                        name: Identifier {
+                            name: "hello",
+                            span: 19..24,
+                        },
+                        id: NameId(2),
+                        ty: FunctionType {
+                            kind: Normal,
+                            name_span: 19..24,
+                            params: [],
+                            param_spans: [],
+                            result: Int(
+                                I32,
+                            ),
+                            callee: Some(
+                                Named(
+                                    NameId(2),
+                                ),
+                            ),
+                        },
+                    },
                 ],
             },
         ),
@@ -165,7 +187,7 @@ TypedProgram {
                                             name: "hello",
                                             span: 19..24,
                                         },
-                                        span: 19..24,
+                                        id: NameId(2),
                                         ty: FunctionType {
                                             kind: Normal,
                                             name_span: 19..24,

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
@@ -133,7 +133,7 @@ TypedProgram {
                                 name: "hello_utxo",
                                 span: 66..76,
                             },
-                            id: NameId(3),
+                            id: NameId(4),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -188,6 +188,7 @@ TypedProgram {
                 ty: Utxo(
                     UtxoType {
                         name: "MyUtxo",
+                        id: NameId(3),
                     },
                 ),
             },

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
@@ -200,6 +200,8 @@ TypedProgram {
                     UtxoType {
                         name: "MyUtxo",
                         id: NameId(3),
+                        possible_abis: [],
+                        always_abis: [],
                     },
                 ),
             },

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
@@ -87,7 +87,6 @@ Program {
 }
 
 ==== Inference trace ====
-
 T-Utxo: MyUtxo => 
   T-Fn: hello_utxo => ()
     T-Expr: {hello_utxo: fn() -> ()} ⊢ emit HelloEvent(); ⇒ ()
@@ -99,21 +98,33 @@ TypedProgram {
     definitions: [
         Abi(
             TypedAbiDef {
-                name: Identifier {
-                    name: "FooAbi",
-                    span: 4..10,
+                ty: AbiType {
+                    name: Identifier {
+                        name: "FooAbi",
+                        span: 4..10,
+                    },
+                    methods: [],
                 },
-                parts: [
-                    Event(
-                        TypedEventDef {
-                            name: Identifier {
-                                name: "HelloEvent",
-                                span: 23..33,
-                            },
-                            id: NameId(2),
-                            params: [],
+                functions: [
+                    TypedAbiMethodDecl {
+                        name: Identifier {
+                            name: "HelloEvent",
+                            span: 23..33,
                         },
-                    ),
+                        id: NameId(2),
+                        ty: FunctionType {
+                            kind: Emit,
+                            name_span: 23..33,
+                            params: [],
+                            param_spans: [],
+                            result: Unit,
+                            callee: Some(
+                                Named(
+                                    NameId(2),
+                                ),
+                            ),
+                        },
+                    },
                 ],
             },
         ),

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
@@ -185,8 +185,10 @@ TypedProgram {
                         },
                     ),
                 ],
-                ty: UtxoNamed(
-                    "MyUtxo",
+                ty: Utxo(
+                    UtxoType {
+                        name: "MyUtxo",
+                    },
                 ),
             },
         ),

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
@@ -196,14 +196,12 @@ TypedProgram {
                         },
                     ),
                 ],
-                ty: Utxo(
-                    UtxoType {
-                        name: "MyUtxo",
-                        id: NameId(3),
-                        possible_abis: [],
-                        always_abis: [],
-                    },
-                ),
+                ty: UtxoType {
+                    name: "MyUtxo",
+                    id: NameId(3),
+                    possible_abis: [],
+                    always_abis: [],
+                },
             },
         ),
     ],

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
@@ -226,7 +226,7 @@ TypedProgram {
                                 name: "increment",
                                 span: 109..118,
                             },
-                            id: NameId(2),
+                            id: NameId(3),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -295,7 +295,7 @@ TypedProgram {
                                 name: "increment_mult",
                                 span: 172..186,
                             },
-                            id: NameId(3),
+                            id: NameId(4),
                             params: [],
                             return_type: Unit,
                             body: TypedBlock {
@@ -359,6 +359,7 @@ TypedProgram {
                 ty: Utxo(
                     UtxoType {
                         name: "MyUtxo",
+                        id: NameId(2),
                     },
                 ),
             },

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
@@ -356,14 +356,12 @@ TypedProgram {
                         },
                     ),
                 ],
-                ty: Utxo(
-                    UtxoType {
-                        name: "MyUtxo",
-                        id: NameId(2),
-                        possible_abis: [],
-                        always_abis: [],
-                    },
-                ),
+                ty: UtxoType {
+                    name: "MyUtxo",
+                    id: NameId(2),
+                    possible_abis: [],
+                    always_abis: [],
+                },
             },
         ),
     ],

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
@@ -356,8 +356,10 @@ TypedProgram {
                         },
                     ),
                 ],
-                ty: UtxoNamed(
-                    "MyUtxo",
+                ty: Utxo(
+                    UtxoType {
+                        name: "MyUtxo",
+                    },
                 ),
             },
         ),

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
@@ -360,6 +360,8 @@ TypedProgram {
                     UtxoType {
                         name: "MyUtxo",
                         id: NameId(2),
+                        possible_abis: [],
+                        always_abis: [],
                     },
                 ),
             },

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
@@ -93,6 +93,7 @@ TypedProgram {
                 ty: Utxo(
                     UtxoType {
                         name: "MyUtxo",
+                        id: NameId(2),
                     },
                 ),
             },
@@ -106,7 +107,7 @@ TypedProgram {
                     name: "script_accepts_utxos",
                     span: 28..48,
                 },
-                id: NameId(2),
+                id: NameId(3),
                 params: [
                     TypedFunctionParam {
                         public: false,
@@ -125,6 +126,7 @@ TypedProgram {
                         ty: Utxo(
                             UtxoType {
                                 name: "MyUtxo",
+                                id: NameId(2),
                             },
                         ),
                     },

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
@@ -90,8 +90,10 @@ TypedProgram {
                     span: 5..11,
                 },
                 parts: [],
-                ty: UtxoNamed(
-                    "MyUtxo",
+                ty: Utxo(
+                    UtxoType {
+                        name: "MyUtxo",
+                    },
                 ),
             },
         ),
@@ -120,8 +122,10 @@ TypedProgram {
                             name: "my_utxo",
                             span: 61..68,
                         },
-                        ty: UtxoNamed(
-                            "MyUtxo",
+                        ty: Utxo(
+                            UtxoType {
+                                name: "MyUtxo",
+                            },
                         ),
                     },
                 ],

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
@@ -90,14 +90,12 @@ TypedProgram {
                     span: 5..11,
                 },
                 parts: [],
-                ty: Utxo(
-                    UtxoType {
-                        name: "MyUtxo",
-                        id: NameId(2),
-                        possible_abis: [],
-                        always_abis: [],
-                    },
-                ),
+                ty: UtxoType {
+                    name: "MyUtxo",
+                    id: NameId(2),
+                    possible_abis: [],
+                    always_abis: [],
+                },
             },
         ),
         Function(

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
@@ -94,6 +94,8 @@ TypedProgram {
                     UtxoType {
                         name: "MyUtxo",
                         id: NameId(2),
+                        possible_abis: [],
+                        always_abis: [],
                     },
                 ),
             },
@@ -127,6 +129,8 @@ TypedProgram {
                             UtxoType {
                                 name: "MyUtxo",
                                 id: NameId(2),
+                                possible_abis: [],
+                                always_abis: [],
                             },
                         ),
                     },

--- a/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
@@ -184,7 +184,7 @@ TypedProgram {
                                 name: "hello_utxo",
                                 span: 53..63,
                             },
-                            id: NameId(3),
+                            id: NameId(4),
                             params: [
                                 TypedFunctionParam {
                                     public: false,
@@ -282,7 +282,7 @@ TypedProgram {
                                     name: "foo",
                                     span: 126..129,
                                 },
-                                id: NameId(4),
+                                id: NameId(5),
                                 params: [],
                                 return_type: Unit,
                                 body: TypedBlock {
@@ -298,6 +298,7 @@ TypedProgram {
                 ty: Utxo(
                     UtxoType {
                         name: "MyUtxo",
+                        id: NameId(3),
                     },
                 ),
             },

--- a/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
@@ -126,7 +126,6 @@ Program {
 }
 
 ==== Inference trace ====
-
 T-Utxo: MyUtxo => 
   T-Fn: hello_utxo => ()
     T-Expr: {hello_utxo: fn(i32) -> (), x: i32} ⊢ yield(Foo); ⇒ ()
@@ -139,18 +138,18 @@ TypedProgram {
     definitions: [
         Abi(
             TypedAbiDef {
-                name: Identifier {
-                    name: "Foo",
-                    span: 4..7,
-                },
-                parts: [
-                    FnDecl(
+                ty: AbiType {
+                    name: Identifier {
+                        name: "Foo",
+                        span: 4..7,
+                    },
+                    methods: [
                         TypedAbiMethodDecl {
                             name: Identifier {
                                 name: "foo",
                                 span: 17..20,
                             },
-                            span: 17..20,
+                            id: NameId(2),
                             ty: FunctionType {
                                 kind: Normal,
                                 name_span: 17..20,
@@ -164,7 +163,28 @@ TypedProgram {
                                 ),
                             },
                         },
-                    ),
+                    ],
+                },
+                functions: [
+                    TypedAbiMethodDecl {
+                        name: Identifier {
+                            name: "foo",
+                            span: 17..20,
+                        },
+                        id: NameId(2),
+                        ty: FunctionType {
+                            kind: Normal,
+                            name_span: 17..20,
+                            params: [],
+                            param_spans: [],
+                            result: Unit,
+                            callee: Some(
+                                Named(
+                                    NameId(2),
+                                ),
+                            ),
+                        },
+                    },
                 ],
             },
         ),
@@ -217,7 +237,7 @@ TypedProgram {
                                                                         name: "foo",
                                                                         span: 17..20,
                                                                     },
-                                                                    span: 17..20,
+                                                                    id: NameId(2),
                                                                     ty: FunctionType {
                                                                         kind: Normal,
                                                                         name_span: 17..20,
@@ -258,7 +278,7 @@ TypedProgram {
                                             name: "foo",
                                             span: 17..20,
                                         },
-                                        span: 17..20,
+                                        id: NameId(2),
                                         ty: FunctionType {
                                             kind: Normal,
                                             name_span: 17..20,

--- a/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
@@ -266,35 +266,33 @@ TypedProgram {
                     ),
                     AbiImpl {
                         span: 109..112,
-                        abi: Abi(
-                            AbiType {
-                                name: Identifier {
-                                    name: "Foo",
-                                    span: 4..7,
-                                },
-                                methods: [
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "foo",
-                                            span: 17..20,
-                                        },
-                                        id: NameId(2),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 17..20,
-                                            params: [],
-                                            param_spans: [],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(2),
-                                                ),
-                                            ),
-                                        },
-                                    },
-                                ],
+                        abi: AbiType {
+                            name: Identifier {
+                                name: "Foo",
+                                span: 4..7,
                             },
-                        ),
+                            methods: [
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "foo",
+                                        span: 17..20,
+                                    },
+                                    id: NameId(2),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 17..20,
+                                        params: [],
+                                        param_spans: [],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(2),
+                                            ),
+                                        ),
+                                    },
+                                },
+                            ],
+                        },
                         parts: [
                             TypedFunctionDef {
                                 export: None,

--- a/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
@@ -319,6 +319,64 @@ TypedProgram {
                     UtxoType {
                         name: "MyUtxo",
                         id: NameId(3),
+                        possible_abis: [
+                            AbiType {
+                                name: Identifier {
+                                    name: "Foo",
+                                    span: 4..7,
+                                },
+                                methods: [
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "foo",
+                                            span: 17..20,
+                                        },
+                                        id: NameId(2),
+                                        ty: FunctionType {
+                                            kind: Normal,
+                                            name_span: 17..20,
+                                            params: [],
+                                            param_spans: [],
+                                            result: Unit,
+                                            callee: Some(
+                                                Named(
+                                                    NameId(2),
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
+                        always_abis: [
+                            AbiType {
+                                name: Identifier {
+                                    name: "Foo",
+                                    span: 4..7,
+                                },
+                                methods: [
+                                    TypedAbiMethodDecl {
+                                        name: Identifier {
+                                            name: "foo",
+                                            span: 17..20,
+                                        },
+                                        id: NameId(2),
+                                        ty: FunctionType {
+                                            kind: Normal,
+                                            name_span: 17..20,
+                                            params: [],
+                                            param_spans: [],
+                                            result: Unit,
+                                            callee: Some(
+                                                Named(
+                                                    NameId(2),
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
                     },
                 ),
             },

--- a/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
@@ -313,70 +313,68 @@ TypedProgram {
                         ],
                     },
                 ],
-                ty: Utxo(
-                    UtxoType {
-                        name: "MyUtxo",
-                        id: NameId(3),
-                        possible_abis: [
-                            AbiType {
-                                name: Identifier {
-                                    name: "Foo",
-                                    span: 4..7,
-                                },
-                                methods: [
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "foo",
-                                            span: 17..20,
-                                        },
-                                        id: NameId(2),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 17..20,
-                                            params: [],
-                                            param_spans: [],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(2),
-                                                ),
-                                            ),
-                                        },
-                                    },
-                                ],
+                ty: UtxoType {
+                    name: "MyUtxo",
+                    id: NameId(3),
+                    possible_abis: [
+                        AbiType {
+                            name: Identifier {
+                                name: "Foo",
+                                span: 4..7,
                             },
-                        ],
-                        always_abis: [
-                            AbiType {
-                                name: Identifier {
-                                    name: "Foo",
-                                    span: 4..7,
-                                },
-                                methods: [
-                                    TypedAbiMethodDecl {
-                                        name: Identifier {
-                                            name: "foo",
-                                            span: 17..20,
-                                        },
-                                        id: NameId(2),
-                                        ty: FunctionType {
-                                            kind: Normal,
-                                            name_span: 17..20,
-                                            params: [],
-                                            param_spans: [],
-                                            result: Unit,
-                                            callee: Some(
-                                                Named(
-                                                    NameId(2),
-                                                ),
-                                            ),
-                                        },
+                            methods: [
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "foo",
+                                        span: 17..20,
                                     },
-                                ],
+                                    id: NameId(2),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 17..20,
+                                        params: [],
+                                        param_spans: [],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(2),
+                                            ),
+                                        ),
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                    always_abis: [
+                        AbiType {
+                            name: Identifier {
+                                name: "Foo",
+                                span: 4..7,
                             },
-                        ],
-                    },
-                ),
+                            methods: [
+                                TypedAbiMethodDecl {
+                                    name: Identifier {
+                                        name: "foo",
+                                        span: 17..20,
+                                    },
+                                    id: NameId(2),
+                                    ty: FunctionType {
+                                        kind: Normal,
+                                        name_span: 17..20,
+                                        params: [],
+                                        param_spans: [],
+                                        result: Unit,
+                                        callee: Some(
+                                            Named(
+                                                NameId(2),
+                                            ),
+                                        ),
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
             },
         ),
     ],

--- a/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
@@ -392,25 +392,26 @@ TypedProgram {
   (import "[export]my-utxo" "[resource-new]utxo" (func (;1;) (type 1)))
   (import "[export]my-utxo" "[resource-drop]utxo" (func (;2;) (type 2)))
   (import "my-utxo" "[static]utxo.hello-utxo" (func (;3;) (type 1)))
+  (import "my-utxo" "[method]utxo.foo" (func (;4;) (type 2)))
   (memory (;0;) 1)
   (global (;0;) (mut i32) (i32.const 0))
   (global (;1;) (mut i32) (i32.const 0))
   (global (;2;) (mut i32) (i32.const 0))
-  (export "my-utxo#[static]utxo.hello-utxo" (func 5))
-  (export "my-utxo#[method]utxo.foo" (func 7))
-  (export "my-utxo#get-storage" (func 9))
-  (export "my-utxo#set-storage" (func 10))
+  (export "my-utxo#[static]utxo.hello-utxo" (func 6))
+  (export "my-utxo#[method]utxo.foo" (func 8))
+  (export "my-utxo#get-storage" (func 10))
+  (export "my-utxo#set-storage" (func 11))
   (export "memory" (memory 0))
-  (func (;4;) (type 3)
+  (func (;5;) (type 3)
     (block ;; label = @1
       (br_if 0 (;@1;)
         (i32.ne
           (global.get 0)
           (i32.const 1)))
-      (return_call 6))
+      (return_call 7))
     (unreachable)
   )
-  (func (;5;) (type 1) (param i32) (result i32)
+  (func (;6;) (type 1) (param i32) (result i32)
     (local i32)
     (local.set 1
       (call 1
@@ -428,7 +429,7 @@ TypedProgram {
       (i64.const -5843589418109203719))
     (local.get 1)
   )
-  (func (;6;) (type 3)
+  (func (;7;) (type 3)
     (local i32 i32)
     (local.set 0
       (global.get 1))
@@ -439,19 +440,19 @@ TypedProgram {
     (global.set 2
       (i32.const 0))
   )
-  (func (;7;) (type 2) (param i32)
-    (return_call 4)
+  (func (;8;) (type 2) (param i32)
+    (return_call 5)
   )
-  (func (;8;) (type 4) (param i32) (result i32 i32 i32)
+  (func (;9;) (type 4) (param i32) (result i32 i32 i32)
     (local i32)
     (global.get 0)
     (global.get 1)
     (global.get 2)
   )
-  (func (;9;) (type 1) (param i32) (result i32)
+  (func (;10;) (type 1) (param i32) (result i32)
     (local i32 i32 i32 i32)
     (i32.const 4)
-    (call 8
+    (call 9
       (local.get 0))
     (local.set 4)
     (local.set 3)
@@ -468,7 +469,7 @@ TypedProgram {
       (local.get 4))
     (i32.const 4)
   )
-  (func (;10;) (type 5) (param i32 i32 i32) (result i32)
+  (func (;11;) (type 5) (param i32 i32 i32) (result i32)
     (local i32 i32 i32)
     (global.set 0
       (local.get 0))
@@ -547,6 +548,7 @@ world root {
   import my-utxo: interface {
     resource utxo {
       hello-utxo: static func(x: s32) -> utxo;
+      foo: func();
     }
   }
   import starstream:std/builtin;

--- a/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
@@ -295,8 +295,10 @@ TypedProgram {
                         ],
                     },
                 ],
-                ty: UtxoNamed(
-                    "MyUtxo",
+                ty: Utxo(
+                    UtxoType {
+                        name: "MyUtxo",
+                    },
                 ),
             },
         ),

--- a/starstream-types/src/ast.rs
+++ b/starstream-types/src/ast.rs
@@ -132,6 +132,12 @@ impl std::cmp::PartialEq for Identifier {
     }
 }
 
+impl<'a> std::cmp::PartialEq<&'a str> for Identifier {
+    fn eq(&self, other: &&str) -> bool {
+        self.name == *other
+    }
+}
+
 impl std::hash::Hash for Identifier {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.name.hash(state);

--- a/starstream-types/src/ast.rs
+++ b/starstream-types/src/ast.rs
@@ -132,7 +132,7 @@ impl std::cmp::PartialEq for Identifier {
     }
 }
 
-impl<'a> std::cmp::PartialEq<&'a str> for Identifier {
+impl std::cmp::PartialEq<&str> for Identifier {
     fn eq(&self, other: &&str) -> bool {
         self.name == *other
     }

--- a/starstream-types/src/typed_ast.rs
+++ b/starstream-types/src/typed_ast.rs
@@ -90,7 +90,7 @@ pub enum TypedUtxoPart {
     Function(Box<TypedFunctionDef>),
     AbiImpl {
         span: Span,
-        abi: Type,
+        abi: Arc<AbiType>,
         parts: Vec<TypedFunctionDef>,
     },
 }

--- a/starstream-types/src/typed_ast.rs
+++ b/starstream-types/src/typed_ast.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use crate::{
     AbiType, DUMMY_SPAN, EnumType, FunctionExport, ImportSource, RecordType, ScopedName, Span,
-    Spanned, TypedAbiMethodDecl,
+    Spanned, TypedAbiMethodDecl, UtxoType,
     ast::{BinaryOp, Identifier, Literal, UnaryOp},
     types::Type,
 };
@@ -81,7 +81,7 @@ pub struct TypedEnumDef {
 pub struct TypedUtxoDef {
     pub name: Identifier,
     pub parts: Vec<TypedUtxoPart>,
-    pub ty: Type,
+    pub ty: Arc<UtxoType>,
 }
 
 #[derive(Clone, Debug)]

--- a/starstream-types/src/typed_ast.rs
+++ b/starstream-types/src/typed_ast.rs
@@ -8,7 +8,8 @@
 use std::sync::Arc;
 
 use crate::{
-    AbiType, DUMMY_SPAN, FunctionExport, FunctionType, ImportSource, ScopedName, Span, Spanned,
+    AbiType, DUMMY_SPAN, EnumType, FunctionExport, ImportSource, RecordType, ScopedName, Span,
+    Spanned, TypedAbiMethodDecl,
     ast::{BinaryOp, Identifier, Literal, UnaryOp},
     types::Type,
 };
@@ -68,28 +69,12 @@ pub struct TypedFunctionParam {
 
 #[derive(Clone, Debug)]
 pub struct TypedStructDef {
-    pub name: Identifier,
-    pub fields: Vec<TypedStructField>,
-    pub ty: Type,
-}
-
-#[derive(Clone, Debug)]
-pub struct TypedStructField {
-    pub name: Identifier,
-    pub ty: Type,
+    pub ty: Arc<RecordType>,
 }
 
 #[derive(Clone, Debug)]
 pub struct TypedEnumDef {
-    pub name: Identifier,
-    pub variants: Vec<TypedEnumVariant>,
-    pub ty: Type,
-}
-
-#[derive(Clone, Debug)]
-pub struct TypedEnumVariant {
-    pub name: Identifier,
-    pub payload: TypedEnumVariantPayload,
+    pub ty: Arc<EnumType>,
 }
 
 #[derive(Clone, Debug)]
@@ -144,46 +129,9 @@ pub struct TypedTokenGlobal {
 
 #[derive(Clone, Debug)]
 pub struct TypedAbiDef {
-    pub name: Identifier,
-    pub parts: Vec<TypedAbiPart>,
-}
-
-#[derive(Clone, Debug)]
-pub enum TypedAbiPart {
-    Event(TypedEventDef),
-    Effect(TypedEffectDef),
-    FnDecl(TypedAbiMethodDecl),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct TypedAbiMethodDecl {
-    pub name: Identifier,
-    pub span: Span,
-    pub ty: Arc<FunctionType>,
-}
-
-impl TypedAbiMethodDecl {
-    /// Get the stable hashable identity of this method type.
-    #[must_use]
-    pub fn identity(&self) -> &str {
-        // TODO: specify hashing for types and include real type signature here
-        self.name.as_str()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct TypedEventDef {
-    pub name: Identifier,
-    pub id: NameId,
-    pub params: Vec<TypedFunctionParam>,
-}
-
-#[derive(Clone, Debug)]
-pub struct TypedEffectDef {
-    pub name: Identifier,
-    pub id: NameId,
-    pub params: Vec<TypedFunctionParam>,
-    pub return_type: Type,
+    pub ty: Arc<AbiType>,
+    /// All functions. If you only want methods, use [AbiType::methods].
+    pub functions: Vec<TypedAbiMethodDecl>,
 }
 
 /// Typed statements.
@@ -394,13 +342,6 @@ pub enum TypedPattern {
     },
     /// `Enum::UnitVariant` constant.
     Constant { name: ScopedName, variant: usize },
-}
-
-#[derive(Clone, Debug)]
-pub enum TypedEnumVariantPayload {
-    Unit,
-    Tuple(Vec<Type>),
-    Struct(Vec<TypedStructField>),
 }
 
 #[derive(Clone, Debug)]

--- a/starstream-types/src/types.rs
+++ b/starstream-types/src/types.rs
@@ -151,6 +151,10 @@ pub enum EnumVariantKind {
 pub struct UtxoType {
     pub name: String,
     pub id: NameId,
+    /// All [AbiType]s that this Utxo sometimes implements.
+    pub possible_abis: Vec<Arc<AbiType>>,
+    /// [AbiType]s that this Utxo implements at all of its yield points.
+    pub always_abis: Vec<Arc<AbiType>>,
 }
 
 /// Type of a `token`.

--- a/starstream-types/src/types.rs
+++ b/starstream-types/src/types.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::fmt::{self, Display};
 use std::sync::Arc;
 
-use crate::{Identifier, NameId, Span, TypedAbiMethodDecl};
+use crate::{Identifier, NameId, Span};
 
 // ----------------------------------------------------------------------------
 // Core `Type` data structure and its parts.
@@ -111,7 +111,7 @@ pub enum StaticFunction {
 /// Structural: interchangeable with other `struct`s and tuples with the same field type order.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct RecordType {
-    pub name: String,
+    pub name: Identifier,
     pub fields: Vec<RecordFieldType>,
 }
 
@@ -125,7 +125,7 @@ pub struct RecordFieldType {
 /// Structural: interchangeable with other `enum`s with the same variant counts and types.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EnumType {
-    pub name: String,
+    pub name: Identifier,
     pub variants: Vec<EnumVariantType>,
     /// Instantiated type arguments for generic enums (e.g., `[i64]` for `Option<i64>`).
     /// Empty for non-generic enums.
@@ -134,7 +134,7 @@ pub struct EnumType {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EnumVariantType {
-    pub name: String,
+    pub name: Identifier,
     pub kind: EnumVariantKind,
 }
 
@@ -167,6 +167,22 @@ pub struct TokenType {
 pub struct AbiType {
     pub name: Identifier,
     pub methods: Vec<TypedAbiMethodDecl>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TypedAbiMethodDecl {
+    pub name: Identifier,
+    pub id: NameId,
+    pub ty: Arc<FunctionType>,
+}
+
+impl TypedAbiMethodDecl {
+    /// Get the stable hashable identity of this method type.
+    #[must_use]
+    pub fn identity(&self) -> &str {
+        // TODO: specify hashing for types and include real type signature here
+        self.name.as_str()
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -354,24 +370,30 @@ impl RecordFieldType {
     }
 }
 
+impl EnumType {
+    pub fn get_variant(&self, name: &str) -> Option<&EnumVariantType> {
+        self.variants.iter().find(|v| v.name.as_str() == name)
+    }
+}
+
 impl EnumVariantType {
-    pub fn unit(name: impl Into<String>) -> Self {
+    pub fn unit(name: Identifier) -> Self {
         Self {
-            name: name.into(),
+            name,
             kind: EnumVariantKind::Unit,
         }
     }
 
-    pub fn tuple(name: impl Into<String>, payload: Vec<Type>) -> Self {
+    pub fn tuple(name: Identifier, payload: Vec<Type>) -> Self {
         Self {
-            name: name.into(),
+            name,
             kind: EnumVariantKind::Tuple(payload),
         }
     }
 
-    pub fn struct_variant(name: impl Into<String>, fields: Vec<RecordFieldType>) -> Self {
+    pub fn struct_variant(name: Identifier, fields: Vec<RecordFieldType>) -> Self {
         Self {
-            name: name.into(),
+            name,
             kind: EnumVariantKind::Struct(fields),
         }
     }
@@ -572,7 +594,7 @@ enum TypeDocMode {
 
 fn record_doc(record: &RecordType, params: &HashMap<TypeVarId, String>) -> RcDoc<'static, ()> {
     if record.fields.is_empty() {
-        RcDoc::text("struct ").append(RcDoc::text(record.name.clone()))
+        RcDoc::text("struct ").append(RcDoc::as_string(&record.name))
     } else {
         let fields = RcDoc::intersperse(
             record.fields.iter().map(|field| {
@@ -585,7 +607,7 @@ fn record_doc(record: &RecordType, params: &HashMap<TypeVarId, String>) -> RcDoc
         );
 
         RcDoc::text("struct ")
-            .append(RcDoc::text(record.name.clone()))
+            .append(RcDoc::as_string(&record.name))
             .append(RcDoc::space())
             .append("{")
             .append(RcDoc::hardline().append(fields).nest(4))
@@ -595,7 +617,7 @@ fn record_doc(record: &RecordType, params: &HashMap<TypeVarId, String>) -> RcDoc
 }
 
 fn enum_name_doc(enum_type: &EnumType, params: &HashMap<TypeVarId, String>) -> RcDoc<'static, ()> {
-    let name = RcDoc::text(enum_type.name.clone());
+    let name = RcDoc::as_string(&enum_type.name);
     if enum_type.type_args.is_empty() {
         name
     } else {
@@ -621,8 +643,8 @@ fn enum_doc(enum_type: &EnumType, params: &HashMap<TypeVarId, String>) -> RcDoc<
                 .variants
                 .iter()
                 .map(|variant| match &variant.kind {
-                    EnumVariantKind::Unit => RcDoc::text(variant.name.clone()).append(","),
-                    EnumVariantKind::Tuple(payload) => RcDoc::text(variant.name.clone())
+                    EnumVariantKind::Unit => RcDoc::as_string(&variant.name).append(","),
+                    EnumVariantKind::Tuple(payload) => RcDoc::as_string(&variant.name)
                         .append("(")
                         .append(RcDoc::intersperse(
                             payload
@@ -632,7 +654,7 @@ fn enum_doc(enum_type: &EnumType, params: &HashMap<TypeVarId, String>) -> RcDoc<
                         ))
                         .append("),"),
                     EnumVariantKind::Struct(fields) => {
-                        enum_variant_struct_doc(&variant.name, fields, params)
+                        enum_variant_struct_doc(variant.name.as_str(), fields, params)
                     }
                 }),
             RcDoc::hardline(),

--- a/starstream-types/src/types.rs
+++ b/starstream-types/src/types.rs
@@ -150,6 +150,7 @@ pub enum EnumVariantKind {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct UtxoType {
     pub name: String,
+    pub id: NameId,
 }
 
 /// Type of a `token`.
@@ -157,6 +158,7 @@ pub struct UtxoType {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TokenType {
     pub name: String,
+    pub id: NameId,
 }
 
 /// Type of an `abi`.

--- a/starstream-types/src/types.rs
+++ b/starstream-types/src/types.rs
@@ -38,11 +38,11 @@ pub enum Type {
     /// The built-in `Utxo` type.
     UtxoAny,
     /// The type created by a `utxo` definition.
-    UtxoNamed(String),
+    Utxo(Arc<UtxoType>),
     /// The built-in `Token` type.
     TokenAny,
     /// The type created by a `token` definition.
-    TokenNamed(String),
+    Token(Arc<TokenType>),
     /// The type created by an `abi` definition. Also the type of a Utxo
     /// narrowed via `if x is AbiName`.
     Abi(Arc<AbiType>),
@@ -108,6 +108,7 @@ pub enum StaticFunction {
 }
 
 /// Type of a `struct`.
+/// Structural: interchangeable with other `struct`s and tuples with the same field type order.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct RecordType {
     pub name: String,
@@ -121,6 +122,7 @@ pub struct RecordFieldType {
 }
 
 /// Type of an `enum`.
+/// Structural: interchangeable with other `enum`s with the same variant counts and types.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EnumType {
     pub name: String,
@@ -143,7 +145,22 @@ pub enum EnumVariantKind {
     Struct(Vec<RecordFieldType>),
 }
 
+/// Type of a `utxo`.
+/// Nominal: encodes the source contract hash.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct UtxoType {
+    pub name: String,
+}
+
+/// Type of a `token`.
+/// Nominal: encodes the source contract hash.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TokenType {
+    pub name: String,
+}
+
 /// Type of an `abi`.
+/// Structural: compatible with similar interfaces.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct AbiType {
     pub name: Identifier,
@@ -528,9 +545,9 @@ impl Type {
                 TypeDocMode::Expanded => enum_doc(enum_type, params),
             },
             Type::UtxoAny => RcDoc::text("Utxo"),
-            Type::UtxoNamed(id) => RcDoc::text(id.to_owned()),
+            Type::Utxo(utxo) => RcDoc::text(utxo.name.to_owned()),
             Type::TokenAny => RcDoc::text("Token"),
-            Type::TokenNamed(id) => RcDoc::text(id.to_owned()),
+            Type::Token(token) => RcDoc::text(token.name.to_owned()),
             Type::Abi(abi) => RcDoc::text(abi.name.to_string()),
         }
     }


### PR DESCRIPTION
In the typechecker:
* Expand `Type::Utxo` and `Token` to contain an `Arc` with details rather than just the string name.
* On some types, store `Identifier` rather than `String`.
* On some typed AST definitions, store `Type` or `Arc<XType>` rather than duplicate, parallel structures.
* Fix Utxo, Token, and Abi types not unifying with themselves.
* Track which Abis a Utxo always implements (included in every `yield` point).
* Use that information to allow `utxo_var.abi_method()` to typecheck.
* To support this, change the order that top-level definitions are processed in.

In the Wasm compiler:
* Include always-implemented Abi methods on both the exported and imported versions of the `resource utxo` in the WIT.
* Compile `utxo_var.abi_method()` in coordination scripts to call said imported version.

Future work:
* Allow calling methods on Abi types ("dynamic Utxos").
* Compile `if x is MyAbi` checked downcasts.

Fixes #179.