### PR TITLE
rt-next: integrate the new ABI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,6 +1461,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,6 +3738,7 @@ dependencies = [
  "sha2",
  "starstream-compiler",
  "starstream-to-wasm",
+ "test-log",
  "tokio",
  "tracing",
  "wasmparser 0.252.0",
@@ -3888,6 +3910,38 @@ checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9c218384242b5c89b68303ab6f6fc53a312d923f0c14dc6bb860c6aeee40f1"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-core"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
+dependencies = [
+ "syn 2.0.106",
+ "test-log-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ starstream-language-server = { path = "starstream-language-server" }
 starstream-runtime-next = { path = "starstream-runtime-next" }
 starstream-to-wasm = { path = "starstream-to-wasm" }
 starstream-types = { path = "starstream-types" }
+test-log = { version = "0.2.18", default-features = false }
 thiserror = "2.0.17"
 tokio = { version = "1.47.1", default-features = false }
 tower-lsp-server = { version = "0.22.1", default-features = false, features = [

--- a/examples/score.star
+++ b/examples/score.star
@@ -35,4 +35,7 @@ utxo ScoreProgress {
 
 script fn example() {
     let prog = ScoreProgress::new();
+    prog.plus_chips(42);
+    prog.plus_mult(2);
+    prog.mult_mult(200);
 }

--- a/starstream-runtime-next/Cargo.toml
+++ b/starstream-runtime-next/Cargo.toml
@@ -28,4 +28,5 @@ wit-component = { workspace = true }
 sha2 = { workspace = true }
 starstream-compiler = { workspace = true }
 starstream-to-wasm = { workspace = true }
+test-log = { workspace = true, features = ["color", "trace"] }
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -172,8 +172,6 @@ fn link_utxo_function<T: Host>(
             linker.func_new_async(name, move |mut store, _ty, params, results| {
                 let contract = contract.clone();
                 Box::new(async move {
-                    ensure!(results.len() == 1);
-
                     let contract = contract.unwrap_or_else(|| T::contract(store.as_context_mut()));
                     let instance = contract.instantiate(&mut store).await?;
 

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -68,7 +68,7 @@ pub trait Host:
 
     fn emit_event(
         store: StoreContextMut<Self>,
-        instance: &str,
+        abi_name: &str,
         name: &str,
         params: &[Val],
     ) -> wasmtime::Result<()>;
@@ -98,33 +98,34 @@ fn load_component(engine: &Engine, wasm: impl AsRef<[u8]>) -> wasmtime::Result<C
 
 /// Link ABI event [`types::ComponentFunc`] in a [`LinkerInstance`]
 #[instrument(level = "trace", skip_all)]
-fn link_abi_event_function<T: Host>(
+fn link_event_function<T: Host>(
     linker: &mut LinkerInstance<T>,
-    _ty: types::ComponentFunc,
-    instance: &str,
+    ty: types::ComponentFunc,
+    abi_name: &str,
     name: &str,
 ) -> wasmtime::Result<()> {
-    debug!(instance, name, "linking ABI instance event function");
-    let instance = Arc::<str>::from(instance);
+    debug!(abi_name, name, "linking ABI instance event function");
+    let abi_name = Arc::<str>::from(abi_name);
     let name = Arc::<str>::from(name);
+    ensure!(ty.results().len() == 0);
     linker.func_new(&Arc::clone(&name), move |store, _ty, params, _results| {
-        T::emit_event(store, &instance, &name, params)
+        T::emit_event(store, &abi_name, &name, params)
     })
 }
 
 /// Link dynamic imported ABI instance in a [`LinkerInstance`].
 #[instrument(level = "trace", skip_all)]
-fn link_abi_import<T: Host>(
+fn link_event_instance_import<T: Host>(
     engine: &Engine,
     linker: &mut LinkerInstance<T>,
     ty: &types::ComponentInstance,
-    instance: &str,
+    abi_name: &str,
 ) -> wasmtime::Result<()> {
     for (name, types::ComponentExtern { ty, .. }) in ty.exports(engine) {
         debug!(name, "linking ABI instance item");
         match ty {
             types::ComponentItem::ComponentFunc(ty) => {
-                link_abi_event_function(linker, ty, instance, name)?;
+                link_event_function(linker, ty, abi_name, name)?;
             }
             types::ComponentItem::CoreFunc(..) => {
                 bail!("ABI instance core function imports unsupported")
@@ -228,7 +229,7 @@ fn link_utxo_function<T: Host>(
 
 /// Link dynamic imported UTXO instance in a [`LinkerInstance`].
 #[instrument(level = "trace", skip_all)]
-fn link_utxo_import<T: Host>(
+fn link_utxo_instance_import<T: Host>(
     contract: Option<Contract<T>>,
     component: &Component,
     linker: &mut LinkerInstance<T>,
@@ -284,41 +285,66 @@ fn link_instance_import<T: Host>(
 
     let engine = component.engine();
     match (
+        instance.split_once('/'),
         ty.get_export(engine, "utxo"),
         ty.get_export(engine, "token"),
     ) {
+        (Some(("starstream:utxo", _name)), ..) => {
+            // TODO: Use external-id to lookup the contract
+            bail!("cross-contract UTXO imports unsupported")
+        }
+
         (
-            Some(types::ComponentExtern {
-                ty: types::ComponentItem::Resource(..),
-                ..
-            }),
-            Some(types::ComponentExtern {
-                ty: types::ComponentItem::Resource(..),
-                ..
-            }),
-        ) => bail!("both `utxo` and `token` resources exported by `{instance}`"),
-        (
+            Some(("starstream:self", name)),
             Some(types::ComponentExtern {
                 ty: types::ComponentItem::Resource(..),
                 ..
             }),
             None,
-        ) => match instance.split_once('/') {
-            Some(("starstream:self", name)) => link_utxo_import(None, component, linker, ty, name),
-            Some(("starstream:utxo", _name)) => {
-                // TODO: Use external-id to lookup the contract
-                bail!("cross-contract UTXO imports unsupported")
-            }
-            _ => bail!("unsupported UTXO instance import name `{instance}`"),
-        },
+        ) => link_utxo_instance_import(None, component, linker, ty, name),
+
         (
+            Some(("starstream:self", ..)),
             None,
             Some(types::ComponentExtern {
                 ty: types::ComponentItem::Resource(..),
                 ..
             }),
         ) => bail!("token imports unsupported"),
-        _ => link_abi_import(engine, linker, ty, instance),
+
+        (
+            Some(("starstream:self", ..)),
+            Some(types::ComponentExtern {
+                ty: types::ComponentItem::Resource(..),
+                ..
+            }),
+            Some(types::ComponentExtern {
+                ty: types::ComponentItem::Resource(..),
+                ..
+            }),
+        ) => bail!("both `utxo` and `token` resources exported by instance `{instance}` import"),
+
+        (Some(("starstream:self", ..)), ..) => {
+            bail!("failed to classify `starstream:self` instance import")
+        }
+
+        (Some(("starstream:events", name)), ..) => {
+            link_event_instance_import(engine, linker, ty, name)
+        }
+
+        (Some(("starstream:effects", ..)), ..) => {
+            bail!("effect imports unsupported")
+        }
+
+        (Some(("starstream:contract", "dynamic-utxo")), ..) => {
+            bail!("dynamic UTXO imports unsupported")
+        }
+
+        (Some(("starstream:contract", "scripts")), ..) => {
+            bail!("coordination script imports unsupported")
+        }
+
+        _ => bail!("unexpected instance import `{instance}`"),
     }
 }
 

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -29,59 +29,49 @@ pub mod bindings {
     });
 }
 
-pub trait ResourceView {
-    fn table(&mut self) -> &mut ResourceTable;
-}
-
-impl<T: ResourceView> ResourceView for &mut T {
-    fn table(&mut self) -> &mut ResourceTable {
-        T::table(self)
-    }
-}
-
-/// Utxo handler
-pub trait UtxoHandler: ResourceView + Send + Sized {
-    type Context: Send;
-
-    fn construct_utxo(
-        store: StoreContextMut<Self>,
-        instance: &Arc<str>,
-        name: &Arc<str>,
-        params: &[Val],
-    ) -> impl Future<Output = wasmtime::Result<Utxo>> + Send;
-
-    fn implements_method(
-        store: StoreContextMut<Self>,
-        cx: Resource<Self::Context>,
-        hash: (u64, u64, u64, u64),
-    ) -> wasmtime::Result<()>;
-
-    fn resume(store: StoreContextMut<Self>, cx: Resource<Self::Context>) -> wasmtime::Result<()>;
-
-    fn drop(store: StoreContextMut<Self>, cx: Resource<Self::Context>) -> wasmtime::Result<()>;
-}
-
-/// ABI event handler
-pub trait EventHandler {
-    fn emit_event(&mut self, instance: &str, name: &str, params: &[Val]);
-}
-
 pub trait Host:
     bindings::starstream::std::builtin::Host
     + bindings::starstream::std::cardano::Host
-    + EventHandler
-    + UtxoHandler
+    + Send
+    + Sized
     + 'static
 {
-}
+    type UtxoContext: Send;
 
-impl<T> Host for T where
-    T: bindings::starstream::std::builtin::Host
-        + bindings::starstream::std::cardano::Host
-        + EventHandler
-        + UtxoHandler
-        + 'static
-{
+    fn table(&mut self) -> &mut ResourceTable;
+
+    fn contract(store: StoreContextMut<Self>) -> Contract<Self>;
+
+    fn new_utxo_context(store: StoreContextMut<Self>) -> Self::UtxoContext;
+
+    fn output(
+        store: StoreContextMut<Self>,
+        utxo: Utxo,
+        cx: Resource<Self::UtxoContext>,
+    ) -> wasmtime::Result<()>;
+
+    fn implements_method(
+        store: StoreContextMut<Self>,
+        cx: Resource<Self::UtxoContext>,
+        hash: (u64, u64, u64, u64),
+    ) -> wasmtime::Result<()>;
+
+    fn resume(
+        store: StoreContextMut<Self>,
+        cx: Resource<Self::UtxoContext>,
+    ) -> wasmtime::Result<()>;
+
+    fn drop_utxo_context(
+        store: StoreContextMut<Self>,
+        cx: Resource<Self::UtxoContext>,
+    ) -> wasmtime::Result<()>;
+
+    fn emit_event(
+        store: StoreContextMut<Self>,
+        instance: &str,
+        name: &str,
+        params: &[Val],
+    ) -> wasmtime::Result<()>;
 }
 
 pub fn componentize(wasm: impl AsRef<[u8]>) -> anyhow::Result<Vec<u8>> {
@@ -108,7 +98,7 @@ fn load_component(engine: &Engine, wasm: impl AsRef<[u8]>) -> wasmtime::Result<C
 
 /// Link ABI event [`types::ComponentFunc`] in a [`LinkerInstance`]
 #[instrument(level = "trace", skip_all)]
-pub fn link_abi_event_function<T: EventHandler>(
+fn link_abi_event_function<T: Host>(
     linker: &mut LinkerInstance<T>,
     _ty: types::ComponentFunc,
     instance: &str,
@@ -117,18 +107,14 @@ pub fn link_abi_event_function<T: EventHandler>(
     debug!(instance, name, "linking ABI instance event function");
     let instance = Arc::<str>::from(instance);
     let name = Arc::<str>::from(name);
-    linker.func_new(
-        &Arc::clone(&name),
-        move |mut store, _ty, params, _results| {
-            store.data_mut().emit_event(&instance, &name, params);
-            Ok(())
-        },
-    )
+    linker.func_new(&Arc::clone(&name), move |store, _ty, params, _results| {
+        T::emit_event(store, &instance, &name, params)
+    })
 }
 
 /// Link dynamic imported ABI instance in a [`LinkerInstance`].
 #[instrument(level = "trace", skip_all)]
-pub fn link_abi_instance<T: EventHandler>(
+fn link_abi_import<T: Host>(
     engine: &Engine,
     linker: &mut LinkerInstance<T>,
     ty: &types::ComponentInstance,
@@ -160,16 +146,18 @@ pub fn link_abi_instance<T: EventHandler>(
 }
 
 /// Link UTXO [`types::ComponentFunc`] in a [`LinkerInstance`]
-#[instrument(level = "trace", skip_all)]
-pub fn link_utxo_function<T: UtxoHandler>(
+#[instrument(level = "trace", skip(component, contract, linker, ty, instance))]
+fn link_utxo_function<T: Host>(
+    contract: Option<Contract<T>>,
+    component: &Component,
     linker: &mut LinkerInstance<T>,
     ty: types::ComponentFunc,
-    instance: &str,
+    instance: &ComponentExportIndex,
     name: &str,
 ) -> wasmtime::Result<()> {
-    debug!(instance, name, "linking UTXO instance function");
-    let instance = Arc::<str>::from(instance);
-    let name = Arc::<str>::from(name);
+    let idx = component
+        .get_export_index(Some(instance), name)
+        .with_context(|| format!("`{name}` export was not found"))?;
     match name.split_once(']') {
         Some(("[static", ..)) => {
             let (Some(Type::Own(..)), None) = ({
@@ -178,62 +166,83 @@ pub fn link_utxo_function<T: UtxoHandler>(
             }) else {
                 bail!("function does not return a single resource value")
             };
-            linker.func_new_async(
-                &Arc::clone(&name),
-                move |mut store, _ty, params, results| {
-                    let instance = Arc::clone(&instance);
-                    let name = Arc::clone(&name);
-                    Box::new(async move {
-                        ensure!(results.len() == 1);
-                        let utxo =
-                            T::construct_utxo(store.as_context_mut(), &instance, &name, params)
-                                .await?;
+            linker.func_new_async(name, move |mut store, _ty, params, results| {
+                let contract = contract.clone();
+                Box::new(async move {
+                    ensure!(results.len() == 1);
+
+                    let contract = contract.unwrap_or_else(|| T::contract(store.as_context_mut()));
+                    let cx = T::new_utxo_context(store.as_context_mut());
+                    let cx = store.data_mut().table().push(cx)?;
+                    let cx_rep = cx.rep();
+                    let cx = cx.try_into_resource_any(&mut store)?;
+
+                    let instance = contract.instantiate(&mut store).await?;
+
+                    let params = {
+                        let mut ps = Vec::with_capacity(params.len().saturating_add(1));
+                        ps.push(Val::Resource(cx));
+                        for p in params {
+                            ps.push(p.clone());
+                        }
+                        ps
+                    };
+                    let utxo = instance.construct_utxo(&mut store, idx, params).await?;
+                    {
                         let utxo = store.data_mut().table().push(utxo)?;
-                        let utxo = utxo.try_into_resource_any(store)?;
+                        let utxo = utxo.try_into_resource_any(store.as_context_mut())?;
                         results[0] = Val::Resource(utxo);
-                        Ok(())
-                    })
-                },
-            )
+                    }
+                    T::output(store, utxo, Resource::new_borrow(cx_rep))
+                })
+            })
         }
         Some(("[method", ..)) => {
             let Some((_, Type::Borrow(..))) = ty.params().next() else {
                 bail!("function does not take borrowed resource type as first parameter");
             };
-            linker.func_new_async(
-                &Arc::clone(&name),
-                move |mut store, _ty, params, results| {
-                    let name = Arc::clone(&name);
-                    Box::new(async move {
-                        let Some(Val::Resource(utxo)) = params.first() else {
-                            bail!("first parameter is not a resource")
-                        };
-                        let utxo = utxo.try_into_resource::<Utxo>(&mut store)?;
-                        let utxo = store.data_mut().table().get(&utxo).copied()?;
-                        let f = utxo.get_function_export(&mut store, &*name)?;
-                        f.call_async(&mut store, params, results).await?;
-                        Ok(())
-                    })
-                },
-            )
+            linker.func_new_async(name, move |mut store, _ty, params, results| {
+                Box::new(async move {
+                    let Some(Val::Resource(utxo)) = params.first() else {
+                        bail!("first parameter is not a resource")
+                    };
+                    let utxo = utxo.try_into_resource::<Utxo>(&mut store)?;
+                    let utxo = store.data_mut().table().get(&utxo).copied()?;
+                    let f = utxo.get_function_export(&mut store, idx)?;
+                    let params = {
+                        let mut ps = Vec::with_capacity(params.len());
+                        ps.push(Val::Resource(utxo.resource()));
+                        for p in &params[1..] {
+                            ps.push(p.clone());
+                        }
+                        ps
+                    };
+                    f.call_async(&mut store, &params, results).await?;
+                    Ok(())
+                })
+            })
         }
-        _ => bail!("unexpected UTXO instance function import `{name}` from instance `{instance}`"),
+        _ => bail!("unexpected UTXO instance function import `{name}`"),
     }
 }
 
 /// Link dynamic imported UTXO instance in a [`LinkerInstance`].
 #[instrument(level = "trace", skip_all)]
-pub fn link_utxo_instance<T: UtxoHandler>(
-    engine: &Engine,
+fn link_utxo_import<T: Host>(
+    contract: Option<Contract<T>>,
+    component: &Component,
     linker: &mut LinkerInstance<T>,
     ty: &types::ComponentInstance,
-    instance: &str,
+    name: &str,
 ) -> wasmtime::Result<()> {
-    for (name, types::ComponentExtern { ty, .. }) in ty.exports(engine) {
+    let idx = component
+        .get_export_index(None, name)
+        .with_context(|| format!("`{name}` export was not found"))?;
+    for (name, types::ComponentExtern { ty, .. }) in ty.exports(component.engine()) {
         debug!(name, "linking UTXO instance item");
         match ty {
             types::ComponentItem::ComponentFunc(ty) => {
-                link_utxo_function(linker, ty, instance, name)?;
+                link_utxo_function(contract.clone(), component, linker, ty, &idx, name)?;
             }
             types::ComponentItem::CoreFunc(..) => {
                 bail!("UTXO instance core function imports unsupported")
@@ -264,56 +273,64 @@ pub fn link_utxo_instance<T: UtxoHandler>(
 }
 
 /// Link dynamic imported instance in a [`LinkerInstance`].
-#[instrument(level = "trace", skip_all)]
-pub fn link_instance<T: Host>(
-    engine: &Engine,
+#[instrument(level = "trace", skip(component, linker, ty))]
+fn link_instance_import<T: Host>(
+    component: &Component,
     linker: &mut LinkerInstance<T>,
     ty: &types::ComponentInstance,
     instance: &str,
 ) -> wasmtime::Result<()> {
-    if ty.get_export(engine, "utxo").is_some() {
-        link_utxo_instance(engine, linker, ty, instance)
-    } else {
-        link_abi_instance(engine, linker, ty, instance)
-    }
-}
+    debug_assert!(!instance.starts_with("starstream:std"));
 
-pub fn link_utxo_context<T: UtxoHandler>(linker: &mut LinkerInstance<T>) -> wasmtime::Result<()> {
-    linker.resource(
-        "utxo-context",
-        ResourceType::host::<T::Context>(),
-        |store, cx| T::drop(store, Resource::new_own(cx)),
-    )?;
-    linker.func_wrap(
-        "[method]utxo-context.implements-method",
-        |store, (cx, hash)| T::implements_method(store, cx, hash),
-    )?;
-    linker.func_wrap("[method]utxo-context.resume", |store, (cx,)| {
-        T::resume(store, cx)
-    })?;
-    Ok(())
+    let engine = component.engine();
+    match (
+        ty.get_export(engine, "utxo"),
+        ty.get_export(engine, "token"),
+    ) {
+        (
+            Some(types::ComponentExtern {
+                ty: types::ComponentItem::Resource(..),
+                ..
+            }),
+            Some(types::ComponentExtern {
+                ty: types::ComponentItem::Resource(..),
+                ..
+            }),
+        ) => bail!("both `utxo` and `token` resources exported by `{instance}`"),
+        (
+            Some(types::ComponentExtern {
+                ty: types::ComponentItem::Resource(..),
+                ..
+            }),
+            None,
+        ) => match instance.split_once('/') {
+            Some(("starstream:self", name)) => link_utxo_import(None, component, linker, ty, name),
+            Some(("starstream:utxo", _name)) => {
+                // TODO: Use external-id to lookup the contract
+                bail!("cross-contract UTXO imports unsupported")
+            }
+            _ => bail!("unsupported UTXO instance import name `{instance}`"),
+        },
+        (
+            None,
+            Some(types::ComponentExtern {
+                ty: types::ComponentItem::Resource(..),
+                ..
+            }),
+        ) => bail!("token imports unsupported"),
+        _ => link_abi_import(engine, linker, ty, instance),
+    }
 }
 
 /// Link dynamic imports of the contract
 #[instrument(level = "trace", skip_all)]
-pub fn link_dynamic_imports<T: Host>(
-    engine: &Engine,
+fn link_dynamic_imports<T: Host>(
+    component: &Component,
     linker: &mut Linker<T>,
-    ty: &types::Component,
 ) -> wasmtime::Result<()> {
-    for (name, types::ComponentExtern { ty, .. }) in ty.imports(engine) {
-        if let Some(("starstream:std", interface)) = name.split_once('/') {
-            match interface {
-                "utxo-context" => {
-                    let mut linker = linker
-                        .instance("starstream:std/utxo-context")
-                        .context("failed to instantiate `utxo-context` in the linker")?;
-                    link_utxo_context(&mut linker)?
-                }
-                _ => debug!(?name, "skipping builtin instance import"),
-            };
-            continue;
-        }
+    for (name, types::ComponentExtern { ty, .. }) in
+        component.component_type().imports(component.engine())
+    {
         match ty {
             types::ComponentItem::ComponentFunc(..) => {
                 bail!("root instance function imports unsupported")
@@ -324,11 +341,15 @@ pub fn link_dynamic_imports<T: Host>(
             types::ComponentItem::Module(..) => bail!("module imports unsupported"),
             types::ComponentItem::Component(..) => bail!("component imports unsupported"),
             types::ComponentItem::ComponentInstance(ty) => {
+                if name.starts_with("starstream:std") {
+                    debug!(?name, "skipping `starstream:std` import");
+                    continue;
+                }
                 let mut linker = linker
                     .instance(name)
                     .with_context(|| format!("failed to instantiate `{name}` in the linker"))?;
                 debug!(?name, "linking root instance");
-                link_instance(engine, &mut linker, &ty, name)?;
+                link_instance_import(component, &mut linker, &ty, name)?;
             }
             types::ComponentItem::Type(..) => {}
             types::ComponentItem::Resource(..) => {
@@ -354,6 +375,26 @@ impl<T: 'static> Clone for Contract<T> {
     }
 }
 
+fn link_utxo_context<T: Host>(linker: &mut Linker<T>) -> wasmtime::Result<()> {
+    let mut linker = linker
+        .instance("starstream:std/utxo-context")
+        .context("failed to instantiate `utxo-context` in the linker")?;
+
+    linker.resource(
+        "utxo-context",
+        ResourceType::host::<T::UtxoContext>(),
+        |store, cx| T::drop_utxo_context(store, Resource::new_own(cx)),
+    )?;
+    linker.func_wrap(
+        "[method]utxo-context.implements-method",
+        |store, (cx, hash)| T::implements_method(store, cx, hash),
+    )?;
+    linker.func_wrap("[method]utxo-context.resume", |store, (cx,)| {
+        T::resume(store, cx)
+    })?;
+    Ok(())
+}
+
 impl<T: Host> Contract<T> {
     /// Compile and pre-instantiate a Starstream [Contract]
     #[instrument(level = "trace", skip_all)]
@@ -368,7 +409,8 @@ impl<T: Host> Contract<T> {
         debug!("linking component imports");
         bindings::Host_::add_to_linker::<_, HasSelf<_>>(&mut linker, |cx| cx)
             .context("failed to link builtins")?;
-        link_dynamic_imports(engine, &mut linker, &component.component_type())?;
+        link_utxo_context(&mut linker).context("failed to link `utxo-context`")?;
+        link_dynamic_imports(&component, &mut linker)?;
 
         let ty = linker
             .substituted_component_type(&component)

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -1,3 +1,4 @@
+use std::pin::Pin;
 use std::sync::Arc;
 
 use tracing::{debug, instrument};
@@ -42,13 +43,15 @@ pub trait Host:
 
     fn contract(store: StoreContextMut<Self>) -> Contract<Self>;
 
-    fn new_utxo_context(store: StoreContextMut<Self>) -> Self::UtxoContext;
-
-    fn output(
+    fn call_utxo_main(
         store: StoreContextMut<Self>,
-        utxo: Utxo,
-        cx: Resource<Self::UtxoContext>,
-    ) -> wasmtime::Result<()>;
+        f: impl for<'a> FnOnce(
+            StoreContextMut<'a, Self>,
+            Self::UtxoContext,
+        )
+            -> Pin<Box<dyn Future<Output = wasmtime::Result<Utxo>> + Send + 'a>>
+        + Send,
+    ) -> impl Future<Output = wasmtime::Result<Utxo>> + Send;
 
     fn implements_method(
         store: StoreContextMut<Self>,
@@ -104,7 +107,6 @@ fn link_event_function<T: Host>(
     abi_name: &str,
     name: &str,
 ) -> wasmtime::Result<()> {
-    debug!(abi_name, name, "linking ABI instance event function");
     let abi_name = Arc::<str>::from(abi_name);
     let name = Arc::<str>::from(name);
     ensure!(ty.results().len() == 0);
@@ -122,24 +124,24 @@ fn link_event_instance_import<T: Host>(
     abi_name: &str,
 ) -> wasmtime::Result<()> {
     for (name, types::ComponentExtern { ty, .. }) in ty.exports(engine) {
-        debug!(name, "linking ABI instance item");
+        debug!(name, "linking event instance item");
         match ty {
             types::ComponentItem::ComponentFunc(ty) => {
                 link_event_function(linker, ty, abi_name, name)?;
             }
             types::ComponentItem::CoreFunc(..) => {
-                bail!("ABI instance core function imports unsupported")
+                bail!("event instance core function imports unsupported")
             }
-            types::ComponentItem::Module(..) => bail!("ABI instance module imports unsupported"),
+            types::ComponentItem::Module(..) => bail!("event instance module imports unsupported"),
             types::ComponentItem::Component(..) => {
-                bail!("ABI instance component imports unsupported")
+                bail!("event instance component imports unsupported")
             }
             types::ComponentItem::ComponentInstance(..) => {
-                bail!("ABI instance component instance imports unsupported")
+                bail!("event instance component instance imports unsupported")
             }
             types::ComponentItem::Type(..) => {}
             types::ComponentItem::Resource(..) => {
-                bail!("ABI instance resource imports unsupported")
+                bail!("event instance resource imports unsupported")
             }
         }
     }
@@ -173,28 +175,29 @@ fn link_utxo_function<T: Host>(
                     ensure!(results.len() == 1);
 
                     let contract = contract.unwrap_or_else(|| T::contract(store.as_context_mut()));
-                    let cx = T::new_utxo_context(store.as_context_mut());
-                    let cx = store.data_mut().table().push(cx)?;
-                    let cx_rep = cx.rep();
-                    let cx = cx.try_into_resource_any(&mut store)?;
-
                     let instance = contract.instantiate(&mut store).await?;
 
-                    let params = {
+                    let mut params = {
                         let mut ps = Vec::with_capacity(params.len().saturating_add(1));
-                        ps.push(Val::Resource(cx));
+                        ps.push(Val::Bool(false));
                         for p in params {
                             ps.push(p.clone());
                         }
                         ps
                     };
-                    let utxo = instance.construct_utxo(&mut store, idx, params).await?;
-                    {
-                        let utxo = store.data_mut().table().push(utxo)?;
-                        let utxo = utxo.try_into_resource_any(store.as_context_mut())?;
-                        results[0] = Val::Resource(utxo);
-                    }
-                    T::output(store, utxo, Resource::new_borrow(cx_rep))
+                    let utxo = T::call_utxo_main(store.as_context_mut(), move |mut store, cx| {
+                        Box::pin(async move {
+                            let cx = store.data_mut().table().push(cx)?;
+                            let cx = cx.try_into_resource_any(&mut store)?;
+                            params[0] = Val::Resource(cx);
+                            instance.construct_utxo(&mut store, idx, params).await
+                        })
+                    })
+                    .await?;
+                    let utxo = store.data_mut().table().push(utxo)?;
+                    let utxo = utxo.try_into_resource_any(store.as_context_mut())?;
+                    results[0] = Val::Resource(utxo);
+                    Ok(())
                 })
             })
         }
@@ -577,12 +580,12 @@ impl<T: Host> Contract<T> {
     }
 
     #[instrument(level = "trace", skip_all)]
-    fn get_utxo_constructor_typed(
+    fn get_utxo_main_typed(
         &self,
         utxo: &UtxoExport,
         name: &str,
         ty: types::ComponentFunc,
-    ) -> wasmtime::Result<ConstructorExport> {
+    ) -> wasmtime::Result<UtxoMainExport> {
         let idx = self
             .pre
             .component()
@@ -598,16 +601,12 @@ impl<T: Host> Contract<T> {
         if resource_ty != utxo.resource_ty {
             bail!("function return value does not match UTXO resource type");
         }
-        Ok(ConstructorExport { ty, idx })
+        Ok(UtxoMainExport { ty, idx })
     }
 
-    /// Get a constructor of an exported UTXO by name
+    /// Get a `main fn` of an exported UTXO by name
     #[instrument(level = "trace", skip_all)]
-    pub fn get_utxo_constructor(
-        &self,
-        utxo: &UtxoExport,
-        name: &str,
-    ) -> wasmtime::Result<ConstructorExport> {
+    pub fn get_utxo_main(&self, utxo: &UtxoExport, name: &str) -> wasmtime::Result<UtxoMainExport> {
         let types::ComponentExtern { ty, .. } = utxo
             .instance_ty
             .get_export(self.pre.engine(), name)
@@ -615,15 +614,15 @@ impl<T: Host> Contract<T> {
         let types::ComponentItem::ComponentFunc(ty) = ty else {
             bail!("export is not a function")
         };
-        self.get_utxo_constructor_typed(utxo, name, ty)
+        self.get_utxo_main_typed(utxo, name, ty)
     }
 
-    /// Iterate over exported UTXO constructors along with their names
+    /// Iterate over exported UTXO `main fn`s along with their names
     #[instrument(level = "trace", skip_all)]
-    pub fn utxo_constructors<'a>(
+    pub fn utxo_mains<'a>(
         &'a self,
         utxo: &'a UtxoExport,
-    ) -> impl Iterator<Item = (&'a str, wasmtime::Result<ConstructorExport>)> {
+    ) -> impl Iterator<Item = (&'a str, wasmtime::Result<UtxoMainExport>)> {
         utxo.instance_ty
             .exports(self.pre.engine())
             .filter_map(move |(name, ty)| match ty {
@@ -631,7 +630,7 @@ impl<T: Host> Contract<T> {
                     ty: types::ComponentItem::ComponentFunc(ty),
                     ..
                 } if name.starts_with("[static]") => {
-                    Some((name, self.get_utxo_constructor_typed(utxo, name, ty)))
+                    Some((name, self.get_utxo_main_typed(utxo, name, ty)))
                 }
                 _ => None,
             })
@@ -793,10 +792,10 @@ impl ContractInstance {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub async fn create_utxo<T>(
+    pub async fn call_utxo_main<T>(
         &self,
         store: impl AsContextMut<Data = T>,
-        ConstructorExport { idx, .. }: &ConstructorExport,
+        UtxoMainExport { idx, .. }: &UtxoMainExport,
         params: impl AsRef<[Val]>,
     ) -> wasmtime::Result<Utxo>
     where
@@ -872,12 +871,12 @@ impl UtxoExport {
 }
 
 #[derive(Clone, Debug)]
-pub struct ConstructorExport {
+pub struct UtxoMainExport {
     ty: types::ComponentFunc,
     idx: ComponentExportIndex,
 }
 
-impl ConstructorExport {
+impl UtxoMainExport {
     #[must_use]
     pub fn ty(&self) -> &types::ComponentFunc {
         &self.ty

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -41,7 +41,7 @@ impl<T: ResourceView> ResourceView for &mut T {
 
 /// Utxo handler
 pub trait UtxoHandler: ResourceView + Send + Sized {
-    type Context;
+    type Context: Send;
 
     fn construct_utxo(
         store: StoreContextMut<Self>,
@@ -273,15 +273,17 @@ pub fn link_instance<T: Host>(
 }
 
 pub fn link_utxo_context<T: UtxoHandler>(linker: &mut LinkerInstance<T>) -> wasmtime::Result<()> {
+    linker.resource(
+        "utxo-context",
+        ResourceType::host::<T::Context>(),
+        |store, cx| T::drop(store, Resource::new_own(cx)),
+    )?;
     linker.func_wrap(
         "[method]utxo-context.implements-method",
         |store, (cx, hash)| T::implements_method(store, cx, hash),
     )?;
     linker.func_wrap("[method]utxo-context.resume", |store, (cx,)| {
         T::resume(store, cx)
-    })?;
-    linker.func_wrap("[resource-drop]utxo-context", |store, (cx,)| {
-        T::drop(store, cx)
     })?;
     Ok(())
 }
@@ -295,11 +297,13 @@ pub fn link_dynamic_imports<T: Host>(
 ) -> wasmtime::Result<()> {
     for (name, types::ComponentExtern { ty, .. }) in ty.imports(engine) {
         if let Some(("starstream:std", interface)) = name.split_once('/') {
-            let mut linker = linker
-                .instance("utxo-context")
-                .context("failed to instantiate `utxo-context` in the linker")?;
             match interface {
-                "utxo-context" => link_utxo_context(&mut linker)?,
+                "utxo-context" => {
+                    let mut linker = linker
+                        .instance("starstream:std/utxo-context")
+                        .context("failed to instantiate `utxo-context` in the linker")?;
+                    link_utxo_context(&mut linker)?
+                }
                 _ => debug!(?name, "skipping builtin instance import"),
             };
             continue;
@@ -322,7 +326,7 @@ pub fn link_dynamic_imports<T: Host>(
             }
             types::ComponentItem::Type(..) => {}
             types::ComponentItem::Resource(..) => {
-                bail!("root instance resource imports unsupported")
+                debug!(?name, "skip root instance resource import")
             }
         }
     }

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -247,7 +247,13 @@ pub fn link_utxo_instance<T: UtxoHandler>(
             }
             types::ComponentItem::Type(..) => {}
             types::ComponentItem::Resource(..) if name == "utxo" => {
-                linker.resource("utxo", ResourceType::host::<Utxo>(), |_, _| Ok(()))?;
+                linker.resource("utxo", ResourceType::host::<Utxo>(), |mut store, rep| {
+                    store
+                        .data_mut()
+                        .table()
+                        .delete::<Utxo>(Resource::new_own(rep))?;
+                    Ok(())
+                })?;
             }
             types::ComponentItem::Resource(..) => {
                 bail!("UTXO instance resource imports unsupported")

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -68,8 +68,8 @@ pub trait Host:
 
     fn emit_event(
         store: StoreContextMut<Self>,
-        abi_name: &str,
-        name: &str,
+        abi_name: &Arc<str>,
+        name: &Arc<str>,
         params: &[Val],
     ) -> wasmtime::Result<()>;
 }

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -57,6 +57,7 @@ struct Ctx {
 #[derive(Debug, Default)]
 pub struct UtxoCtx {
     methods: Vec<(u64, u64, u64, u64)>,
+    dropped: bool,
 }
 
 impl bindings::starstream::std::builtin::Host for Ctx {}
@@ -139,7 +140,8 @@ impl Host for Ctx {
         cx: Resource<Self::UtxoContext>,
     ) -> wasmtime::Result<()> {
         let Ctx { table, .. } = store.data_mut();
-        table.delete(cx)?;
+        let cx = table.delete(cx)?;
+        cx.lock().unwrap().dropped = true;
         Ok(())
     }
 
@@ -420,11 +422,12 @@ async fn score_main_new() -> wasmtime::Result<()> {
             params: [Val::U64(3 * 4 * 2)].into()
         }]
     );
-    let UtxoCtx { methods } = Arc::into_inner(utxo_cx)
+    let UtxoCtx { methods, dropped } = Arc::into_inner(utxo_cx)
         .expect("UTXO context must have been dropped")
         .into_inner()
         .unwrap();
     assert_eq!(methods, []);
+    assert!(dropped);
     Ok(())
 }
 
@@ -462,8 +465,11 @@ async fn score_script_example() -> wasmtime::Result<()> {
         (Some((utxo, utxo_cx)), None) => (*utxo, utxo_cx),
         _ => bail!("unexpected outputs created: {outputs:?}"),
     };
-    assert_eq!(utxo_cx.lock().unwrap().methods, *METHODS);
-    assert_eq!(Arc::strong_count(utxo_cx), 2);
+    {
+        let utxo_cx = utxo_cx.lock().unwrap();
+        assert_eq!(utxo_cx.methods, *METHODS);
+        assert!(!utxo_cx.dropped);
+    }
     assert!(events.is_empty());
 
     let ProgressStorage {

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -1,17 +1,17 @@
 use std::collections::BTreeMap;
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 
 use sha2::{Digest as _, Sha256};
 use starstream_compiler::{TypecheckOptions, parse_program, typecheck_program};
 use starstream_runtime_next::{
-    ConstructorExport, Contract, CoordinationScriptExport, EventHandler, Host, MethodExport,
-    ResourceView, Utxo, UtxoHandler, UtxoStorageExport, bindings,
+    ConstructorExport, Contract, CoordinationScriptExport, Host, MethodExport, Utxo,
+    UtxoStorageExport, bindings,
 };
 use starstream_to_wasm::compile;
 use tracing::{Instrument as _, info_span, instrument};
 use wasmtime::component::{Resource, ResourceTable, Val};
 use wasmtime::error::Context as _;
-use wasmtime::{Store, bail};
+use wasmtime::{Store, StoreContextMut, bail};
 
 /// Compile a single Starstream contract source to a core Wasm module in-process.
 ///
@@ -39,24 +39,17 @@ static EXAMPLE_SCORE: LazyLock<Vec<u8>> =
 
 struct Ctx {
     contract: Contract<Self>,
-    ty: ProgressUtxo,
 
     table: ResourceTable,
     events: Vec<(String, String, Box<[Val]>)>,
 
-    outputs: Vec<(Utxo, u32)>,
+    outputs: Vec<(Utxo, Resource<UtxoCtx>)>,
     dropped_utxo_cxs: Vec<UtxoCtx>,
 }
 
 #[derive(Debug, Default)]
 pub struct UtxoCtx {
     methods: Vec<(u64, u64, u64, u64)>,
-}
-
-impl ResourceView for Ctx {
-    fn table(&mut self) -> &mut ResourceTable {
-        &mut self.table
-    }
 }
 
 impl bindings::starstream::std::builtin::Host for Ctx {}
@@ -86,57 +79,33 @@ impl bindings::starstream::std::cardano::Host for Ctx {
     }
 }
 
-impl EventHandler for Ctx {
-    fn emit_event(&mut self, instance: &str, name: &str, params: &[Val]) {
-        self.events
-            .push((instance.into(), name.into(), params.into()));
+impl Host for Ctx {
+    type UtxoContext = UtxoCtx;
+
+    fn table(&mut self) -> &mut ResourceTable {
+        &mut self.table
     }
-}
 
-impl UtxoHandler for Ctx {
-    type Context = UtxoCtx;
+    fn contract(store: StoreContextMut<Self>) -> Contract<Self> {
+        store.data().contract.clone()
+    }
 
-    #[instrument(skip(store), ret)]
-    async fn construct_utxo(
-        mut store: wasmtime::StoreContextMut<'_, Self>,
-        instance: &Arc<str>,
-        name: &Arc<str>,
-        params: &[Val],
-    ) -> wasmtime::Result<Utxo>
-    where
-        Self: Sized,
-    {
-        match (instance.as_ref(), name.as_ref()) {
-            ("starstream:self/score-progress", "[static]utxo.new") => {
-                let Ctx {
-                    contract,
-                    ty,
-                    table,
-                    ..
-                } = store.data_mut();
-                let contract = contract.clone();
-                let ty = ty.clone();
-                let cx = table.push(UtxoCtx::default())?;
-                let cx_rep = cx.rep();
-                let cx = cx.try_into_resource_any(&mut store)?;
-                let instance = contract.instantiate(&mut store).await?;
+    fn new_utxo_context(_store: StoreContextMut<Self>) -> Self::UtxoContext {
+        Self::UtxoContext::default()
+    }
 
-                let mut ps = Vec::with_capacity(params.len().saturating_add(1));
-                ps.push(Val::Resource(cx));
-                for p in params {
-                    ps.push(p.clone());
-                }
-                let utxo = instance.create_utxo(&mut store, &ty.new, ps).await?;
-                store.data_mut().outputs.push((utxo, cx_rep));
-                Ok(utxo)
-            }
-            _ => panic!("unexpected UTXO constructor call `{instance}#{name}`"),
-        }
+    fn output(
+        mut store: StoreContextMut<Self>,
+        utxo: Utxo,
+        cx: Resource<Self::UtxoContext>,
+    ) -> wasmtime::Result<()> {
+        store.data_mut().outputs.push((utxo, cx));
+        Ok(())
     }
 
     #[instrument(skip(store, cx), ret)]
     fn implements_method(
-        mut store: wasmtime::StoreContextMut<'_, Self>,
+        mut store: StoreContextMut<Self>,
         cx: Resource<UtxoCtx>,
         hash: (u64, u64, u64, u64),
     ) -> wasmtime::Result<()> {
@@ -146,18 +115,15 @@ impl UtxoHandler for Ctx {
     }
 
     #[instrument(skip(store, cx), ret)]
-    fn resume(
-        mut store: wasmtime::StoreContextMut<'_, Self>,
-        cx: Resource<UtxoCtx>,
-    ) -> wasmtime::Result<()> {
+    fn resume(mut store: StoreContextMut<Self>, cx: Resource<UtxoCtx>) -> wasmtime::Result<()> {
         let UtxoCtx { methods } = store.data_mut().table.get_mut(&cx)?;
         methods.clear();
         Ok(())
     }
 
     #[instrument(skip(store, cx), ret)]
-    fn drop(
-        mut store: wasmtime::StoreContextMut<'_, Self>,
+    fn drop_utxo_context(
+        mut store: StoreContextMut<Self>,
         cx: Resource<UtxoCtx>,
     ) -> wasmtime::Result<()> {
         let Ctx {
@@ -167,6 +133,20 @@ impl UtxoHandler for Ctx {
         } = store.data_mut();
         let cx = table.delete(cx)?;
         dropped_utxo_cxs.push(cx);
+        Ok(())
+    }
+
+    #[instrument(skip(store), ret)]
+    fn emit_event(
+        mut store: StoreContextMut<Self>,
+        instance: &str,
+        name: &str,
+        params: &[Val],
+    ) -> wasmtime::Result<()> {
+        store
+            .data_mut()
+            .events
+            .push((instance.into(), name.into(), params.into()));
         Ok(())
     }
 }
@@ -336,7 +316,6 @@ async fn score_main_new() -> wasmtime::Result<()> {
         &engine,
         Ctx {
             contract: contract.clone(),
-            ty: ty.clone(),
             table,
             events: Vec::default(),
             outputs: Vec::default(),
@@ -456,7 +435,6 @@ async fn score_script_example() -> wasmtime::Result<()> {
         &engine,
         Ctx {
             contract: contract.clone(),
-            ty: ty.clone(),
             table: ResourceTable::default(),
             events: Vec::default(),
             outputs: Vec::default(),
@@ -481,15 +459,28 @@ async fn score_script_example() -> wasmtime::Result<()> {
         ..
     } = store.data();
     let mut outputs = outputs.iter();
-    let (utxo, utxo_cx_rep) = match (outputs.next(), outputs.next()) {
-        (Some(output), None) => output,
+    let (utxo, utxo_cx) = match (outputs.next(), outputs.next()) {
+        (Some((utxo, utxo_cx)), None) => (*utxo, utxo_cx),
         _ => bail!("unexpected outputs created: {outputs:?}"),
     };
 
-    let UtxoCtx { methods } = table.get(&Resource::new_borrow(*utxo_cx_rep))?;
+    let UtxoCtx { methods } = table.get(utxo_cx)?;
     assert_eq!(methods.as_slice(), *METHODS);
     assert!(dropped_utxo_cxs.is_empty());
     assert!(events.is_empty());
+
+    let ProgressStorage {
+        chips,
+        mult,
+        r#yield,
+        yield1,
+        yield1_v1,
+    } = get_progress_storage(&mut store, &utxo, &ty.storage).await?;
+    assert_eq!(chips, 42);
+    assert_eq!(mult, 4);
+    assert_eq!(r#yield, 1);
+    assert_eq!(yield1, 1);
+    assert_eq!(yield1_v1, 2);
 
     utxo.drop(&mut store).await.context("failed to drop UTXO")?;
 

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use sha2::{Digest as _, Sha256};
 use starstream_compiler::{TypecheckOptions, parse_program, typecheck_program};
@@ -41,7 +41,7 @@ struct Ctx {
     contract: Contract<Self>,
 
     table: ResourceTable,
-    events: Vec<(String, String, Box<[Val]>)>,
+    events: Vec<(Arc<str>, Arc<str>, Box<[Val]>)>,
 
     outputs: Vec<(Utxo, Resource<UtxoCtx>)>,
     dropped_utxo_cxs: Vec<UtxoCtx>,
@@ -139,14 +139,14 @@ impl Host for Ctx {
     #[instrument(skip(store), ret)]
     fn emit_event(
         mut store: StoreContextMut<Self>,
-        abi_name: &str,
-        name: &str,
+        abi_name: &Arc<str>,
+        name: &Arc<str>,
         params: &[Val],
     ) -> wasmtime::Result<()> {
         store
             .data_mut()
             .events
-            .push((abi_name.into(), name.into(), params.into()));
+            .push((Arc::clone(abi_name), Arc::clone(name), params.into()));
         Ok(())
     }
 }

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -1,6 +1,3 @@
-use core::array;
-use core::iter::zip;
-
 use std::collections::BTreeMap;
 use std::sync::{Arc, LazyLock};
 
@@ -11,6 +8,7 @@ use starstream_runtime_next::{
     ResourceView, Utxo, UtxoHandler, UtxoStorageExport, bindings,
 };
 use starstream_to_wasm::compile;
+use tracing::{Instrument as _, info_span, instrument};
 use wasmtime::component::{Resource, ResourceTable, Val};
 use wasmtime::error::Context as _;
 use wasmtime::{Store, bail};
@@ -46,9 +44,11 @@ struct Ctx {
     table: ResourceTable,
     events: Vec<(String, String, Box<[Val]>)>,
 
-    utxo_cx: Option<UtxoCtx>,
+    outputs: Vec<(Utxo, u32)>,
+    dropped_utxo_cxs: Vec<UtxoCtx>,
 }
 
+#[derive(Debug, Default)]
 pub struct UtxoCtx {
     methods: Vec<(u64, u64, u64, u64)>,
 }
@@ -96,6 +96,7 @@ impl EventHandler for Ctx {
 impl UtxoHandler for Ctx {
     type Context = UtxoCtx;
 
+    #[instrument(skip(store), ret)]
     async fn construct_utxo(
         mut store: wasmtime::StoreContextMut<'_, Self>,
         instance: &Arc<str>,
@@ -106,43 +107,66 @@ impl UtxoHandler for Ctx {
         Self: Sized,
     {
         match (instance.as_ref(), name.as_ref()) {
-            ("score-progress", "[static]utxo.new") => {
-                let Ctx { contract, ty, .. } = store.data();
+            ("starstream:self/score-progress", "[static]utxo.new") => {
+                let Ctx {
+                    contract,
+                    ty,
+                    table,
+                    ..
+                } = store.data_mut();
                 let contract = contract.clone();
                 let ty = ty.clone();
+                let cx = table.push(UtxoCtx::default())?;
+                let cx_rep = cx.rep();
+                let cx = cx.try_into_resource_any(&mut store)?;
                 let instance = contract.instantiate(&mut store).await?;
-                instance.create_utxo(store, &ty.new, params).await
+
+                let mut ps = Vec::with_capacity(params.len().saturating_add(1));
+                ps.push(Val::Resource(cx));
+                for p in params {
+                    ps.push(p.clone());
+                }
+                let utxo = instance.create_utxo(&mut store, &ty.new, ps).await?;
+                store.data_mut().outputs.push((utxo, cx_rep));
+                Ok(utxo)
             }
             _ => panic!("unexpected UTXO constructor call `{instance}#{name}`"),
         }
     }
 
-    fn resume(
-        mut store: wasmtime::StoreContextMut<'_, Self>,
-        cx: Resource<UtxoCtx>,
-    ) -> wasmtime::Result<()> {
-        let _cx = store.data_mut().table.get_mut(&cx)?;
-        // TODO: handle resume
-        Ok(())
-    }
-
+    #[instrument(skip(store, cx), ret)]
     fn implements_method(
         mut store: wasmtime::StoreContextMut<'_, Self>,
         cx: Resource<UtxoCtx>,
         hash: (u64, u64, u64, u64),
     ) -> wasmtime::Result<()> {
-        let cx = store.data_mut().table.get_mut(&cx)?;
-        cx.methods.push(hash);
+        let UtxoCtx { methods } = store.data_mut().table.get_mut(&cx)?;
+        methods.push(hash);
         Ok(())
     }
 
+    #[instrument(skip(store, cx), ret)]
+    fn resume(
+        mut store: wasmtime::StoreContextMut<'_, Self>,
+        cx: Resource<UtxoCtx>,
+    ) -> wasmtime::Result<()> {
+        let UtxoCtx { methods } = store.data_mut().table.get_mut(&cx)?;
+        methods.clear();
+        Ok(())
+    }
+
+    #[instrument(skip(store, cx), ret)]
     fn drop(
         mut store: wasmtime::StoreContextMut<'_, Self>,
         cx: Resource<UtxoCtx>,
     ) -> wasmtime::Result<()> {
-        let data = store.data_mut();
-        let cx = data.table.delete(cx)?;
-        assert!(data.utxo_cx.replace(cx).is_none());
+        let Ctx {
+            table,
+            dropped_utxo_cxs,
+            ..
+        } = store.data_mut();
+        let cx = table.delete(cx)?;
+        dropped_utxo_cxs.push(cx);
         Ok(())
     }
 }
@@ -252,6 +276,7 @@ struct ProgressStorage {
     mult: i64,
     r#yield: i32,
     yield1: i32,
+    yield1_v1: i32,
 }
 
 impl<'a> FromIterator<&'a (String, Val)> for ProgressStorage {
@@ -263,18 +288,21 @@ impl<'a> FromIterator<&'a (String, Val)> for ProgressStorage {
             fields.next(),
             fields.next(),
             fields.next(),
+            fields.next(),
         ) {
             (
                 Some(("yield", Val::S32(r#yield))),
                 Some(("chips", Val::S64(chips))),
                 Some(("mult", Val::S64(mult))),
                 Some(("yield1", Val::S32(yield1))),
+                Some(("yield1-v1", Val::S32(yield1_v1))),
                 None,
             ) => ProgressStorage {
                 chips: *chips,
                 mult: *mult,
                 r#yield: *r#yield,
                 yield1: *yield1,
+                yield1_v1: *yield1_v1,
             },
             fields => panic!("unexpected progress UTXO storage fields: {fields:?}"),
         }
@@ -294,115 +322,135 @@ async fn get_progress_storage<T: Send + 'static>(
     Ok(storage.iter().collect())
 }
 
-#[ignore = "compiler does not support the new WIT shape yet"]
-#[tokio::test]
-async fn score() -> wasmtime::Result<()> {
+#[test_log::test(tokio::test)]
+async fn score_main_new() -> wasmtime::Result<()> {
     let engine = wasmtime::Engine::default();
     let contract =
         Contract::new(&engine, EXAMPLE_SCORE.as_slice()).context("failed to create contract")?;
     let ty = assert_progress_utxo(&contract)?;
 
-    let [utxo0, utxo1, utxo2, utxo3, utxo4] = array::from_fn(|_| async {
-        let mut store = wasmtime::Store::new(
-            &engine,
-            Ctx {
-                contract: contract.clone(),
-                ty: ty.clone(),
-                table: ResourceTable::default(),
-                utxo_cx: None,
-                events: Vec::default(),
-            },
-        );
-        let instance = contract.instantiate(&mut store).await?;
-        instance
-            .create_utxo(&mut store, &ty.new, [])
-            .await
-            .map(|utxo| (store, utxo))
-    });
-    let (utxo0, utxo1, utxo2, utxo3, utxo4) =
-        tokio::try_join!(utxo0, utxo1, utxo2, utxo3, utxo4).context("failed to construct UTXOs")?;
-
-    for (i, (mut store, utxo)) in zip(0.., [utxo0, utxo1, utxo2, utxo3, utxo4]) {
-        let Ctx {
-            events, utxo_cx, ..
-        } = store.data();
-        assert_eq!(events.as_ref(), []);
-        assert!(utxo_cx.is_none());
-
-        let ProgressStorage {
-            chips,
-            mult,
-            r#yield,
-            yield1,
-        } = get_progress_storage(&mut store, &utxo, &ty.storage).await?;
-        assert_eq!(chips, 0);
-        assert_eq!(mult, 0);
-        assert_eq!(r#yield, 1);
-        assert_eq!(yield1, 1);
-
-        utxo.call(
-            &mut store,
-            &ty.plus_chips,
-            [Val::Resource(utxo.resource()), Val::U64(i)],
-            [],
-        )
-        .await
-        .context("failed to call `plus-chips`")?;
-
-        utxo.call(
-            &mut store,
-            &ty.plus_mult,
-            [Val::Resource(utxo.resource()), Val::U64(i)],
-            [],
-        )
-        .await
-        .context("failed to call `plus-mult`")?;
-
-        utxo.call(
-            &mut store,
-            &ty.mult_mult,
-            [Val::Resource(utxo.resource()), Val::U64(200)],
-            [],
-        )
-        .await
-        .context("failed to call `mult-mult`")?;
-
-        let ProgressStorage {
-            chips,
-            mult,
-            r#yield,
-            yield1,
-        } = get_progress_storage(&mut store, &utxo, &ty.storage).await?;
-        assert_eq!(chips, i as i64);
-        assert_eq!(mult, (i * 2) as i64);
-        assert_eq!(r#yield, 1);
-        assert_eq!(yield1, 1);
-
-        utxo.call(&mut store, &ty.finish, [Val::Resource(utxo.resource())], [])
-            .await
-            .context("failed to call `finish`")?;
-
-        utxo.drop(&mut store).await.context("failed to drop UTXO")?;
-        let Ctx {
+    let mut table = ResourceTable::default();
+    let utxo_cx = table.push(UtxoCtx::default())?;
+    let utxo_cx_rep = utxo_cx.rep();
+    let mut store = wasmtime::Store::new(
+        &engine,
+        Ctx {
+            contract: contract.clone(),
+            ty: ty.clone(),
             table,
-            events,
-            utxo_cx,
-            ..
-        } = store.into_data();
-        assert!(table.is_empty());
-        assert!(utxo_cx.is_none());
-        // TODO: Assert methods on the context
-        //assert_eq!(methods, *METHODS);
-        assert_eq!(
-            events,
-            [(
-                "starstream:events/score".into(),
-                "finish".into(),
-                [Val::U64(i * i * 2)].into()
-            )]
-        );
-        assert!(utxo_cx.is_none());
-    }
+            events: Vec::default(),
+            outputs: Vec::default(),
+            dropped_utxo_cxs: Vec::default(),
+        },
+    );
+    let utxo_cx = utxo_cx.try_into_resource_any(&mut store)?;
+    let instance = contract.instantiate(&mut store).await?;
+    let utxo = instance
+        .create_utxo(&mut store, &ty.new, [Val::Resource(utxo_cx)])
+        .instrument(info_span!("new"))
+        .await
+        .context("failed to construct UTXO")?;
+
+    let Ctx { events, table, .. } = store.data();
+    assert_eq!(events.as_ref(), []);
+    let UtxoCtx { methods } = table.get(&Resource::new_borrow(utxo_cx_rep))?;
+    assert_eq!(methods.as_slice(), *METHODS);
+
+    let ProgressStorage {
+        chips,
+        mult,
+        r#yield,
+        yield1,
+        yield1_v1,
+    } = get_progress_storage(&mut store, &utxo, &ty.storage).await?;
+    assert_eq!(chips, 0);
+    assert_eq!(mult, 0);
+    assert_eq!(r#yield, 1);
+    assert_eq!(yield1, 1);
+    assert_eq!(yield1_v1, 2);
+
+    utxo.call(
+        &mut store,
+        &ty.plus_chips,
+        [Val::Resource(utxo.resource()), Val::U64(3)],
+        [],
+    )
+    .instrument(info_span!("plus-chips"))
+    .await
+    .context("failed to call `plus-chips`")?;
+
+    utxo.call(
+        &mut store,
+        &ty.plus_mult,
+        [Val::Resource(utxo.resource()), Val::U64(4)],
+        [],
+    )
+    .instrument(info_span!("plus-mult"))
+    .await
+    .context("failed to call `plus-mult`")?;
+
+    utxo.call(
+        &mut store,
+        &ty.mult_mult,
+        [Val::Resource(utxo.resource()), Val::U64(200)],
+        [],
+    )
+    .instrument(info_span!("mult-mult"))
+    .await
+    .context("failed to call `mult-mult`")?;
+
+    let ProgressStorage {
+        chips,
+        mult,
+        r#yield,
+        yield1,
+        yield1_v1,
+    } = get_progress_storage(&mut store, &utxo, &ty.storage).await?;
+    assert_eq!(chips, 3);
+    assert_eq!(mult, 4 * 2);
+    assert_eq!(r#yield, 1);
+    assert_eq!(yield1, 1);
+    assert_eq!(yield1_v1, 2);
+
+    utxo.call(&mut store, &ty.finish, [Val::Resource(utxo.resource())], [])
+        .instrument(info_span!("finish"))
+        .await
+        .context("failed to call `finish`")?;
+
+    utxo.drop(&mut store).await.context("failed to drop UTXO")?;
+
+    let Ctx {
+        table,
+        events,
+        outputs,
+        dropped_utxo_cxs,
+        ..
+    } = store.into_data();
+    assert!(outputs.is_empty());
+    assert!(table.is_empty());
+    assert_eq!(
+        events,
+        [(
+            "starstream:events/score".into(),
+            "finish".into(),
+            [Val::U64(3 * 4 * 2)].into()
+        )]
+    );
+    let mut dropped_utxo_cxs = dropped_utxo_cxs.iter();
+    let UtxoCtx { methods } = match (dropped_utxo_cxs.next(), dropped_utxo_cxs.next()) {
+        (Some(utxo), None) => utxo,
+        _ => bail!("unexpected UTXO contexts dropped `{dropped_utxo_cxs:?}`"),
+    };
+    assert_eq!(methods, &[]);
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn score_script_example() -> wasmtime::Result<()> {
+    let engine = wasmtime::Engine::default();
+    let contract =
+        Contract::new(&engine, EXAMPLE_SCORE.as_slice()).context("failed to create contract")?;
+    let ty = assert_progress_utxo(&contract)?;
 
     let mut store = wasmtime::Store::new(
         &engine,
@@ -411,7 +459,8 @@ async fn score() -> wasmtime::Result<()> {
             ty: ty.clone(),
             table: ResourceTable::default(),
             events: Vec::default(),
-            utxo_cx: None,
+            outputs: Vec::default(),
+            dropped_utxo_cxs: Vec::default(),
         },
     );
     let instance = contract
@@ -420,23 +469,29 @@ async fn score() -> wasmtime::Result<()> {
         .context("failed to instantiate contract")?;
     instance
         .call_coordination_script(&mut store, &ty.example, [], [])
+        .instrument(info_span!("example"))
         .await
         .context("failed to call `example` coordination script")?;
-    let data = store.data_mut();
-    let utxo = {
-        let mut resources = data.table.iter_mut();
-        match (resources.next(), resources.next()) {
-            (Some(utxo), None) => utxo,
-            _ => bail!("unexpected resources in table"),
-        }
+
+    let Ctx {
+        table,
+        events,
+        outputs,
+        dropped_utxo_cxs,
+        ..
+    } = store.data();
+    let mut outputs = outputs.iter();
+    let (utxo, utxo_cx_rep) = match (outputs.next(), outputs.next()) {
+        (Some(output), None) => output,
+        _ => bail!("unexpected outputs created: {outputs:?}"),
     };
-    let UtxoCtx { methods } = data.utxo_cx.take().context("UTXO context missing")?;
+
+    let UtxoCtx { methods } = table.get(&Resource::new_borrow(*utxo_cx_rep))?;
     assert_eq!(methods.as_slice(), *METHODS);
-    assert!(data.events.is_empty());
-    let utxo = utxo
-        .downcast_mut::<Utxo>()
-        .context("failed to downcast UTXO")
-        .copied()?;
+    assert!(dropped_utxo_cxs.is_empty());
+    assert!(events.is_empty());
+
     utxo.drop(&mut store).await.context("failed to drop UTXO")?;
+
     Ok(())
 }

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -1,17 +1,18 @@
 use std::collections::BTreeMap;
-use std::sync::{Arc, LazyLock};
+use std::pin::Pin;
+use std::sync::{Arc, LazyLock, Mutex};
 
 use sha2::{Digest as _, Sha256};
 use starstream_compiler::{TypecheckOptions, parse_program, typecheck_program};
 use starstream_runtime_next::{
-    ConstructorExport, Contract, CoordinationScriptExport, Host, MethodExport, Utxo,
+    Contract, CoordinationScriptExport, Host, MethodExport, Utxo, UtxoMainExport,
     UtxoStorageExport, bindings,
 };
 use starstream_to_wasm::compile;
 use tracing::{Instrument as _, info_span, instrument};
 use wasmtime::component::{Resource, ResourceTable, Val};
 use wasmtime::error::Context as _;
-use wasmtime::{Store, StoreContextMut, bail};
+use wasmtime::{AsContextMut as _, Store, StoreContextMut, bail};
 
 /// Compile a single Starstream contract source to a core Wasm module in-process.
 ///
@@ -43,8 +44,8 @@ struct Ctx {
     table: ResourceTable,
     events: Vec<(Arc<str>, Arc<str>, Box<[Val]>)>,
 
-    outputs: Vec<(Utxo, Resource<UtxoCtx>)>,
-    dropped_utxo_cxs: Vec<UtxoCtx>,
+    outputs: Vec<(Utxo, Arc<Mutex<UtxoCtx>>)>,
+    dropped_utxo_cxs: Vec<Arc<Mutex<UtxoCtx>>>,
 }
 
 #[derive(Debug, Default)]
@@ -80,7 +81,7 @@ impl bindings::starstream::std::cardano::Host for Ctx {
 }
 
 impl Host for Ctx {
-    type UtxoContext = UtxoCtx;
+    type UtxoContext = Arc<Mutex<UtxoCtx>>;
 
     fn table(&mut self) -> &mut ResourceTable {
         &mut self.table
@@ -90,41 +91,46 @@ impl Host for Ctx {
         store.data().contract.clone()
     }
 
-    fn new_utxo_context(_store: StoreContextMut<Self>) -> Self::UtxoContext {
-        Self::UtxoContext::default()
-    }
-
-    fn output(
-        mut store: StoreContextMut<Self>,
-        utxo: Utxo,
-        cx: Resource<Self::UtxoContext>,
-    ) -> wasmtime::Result<()> {
+    async fn call_utxo_main(
+        mut store: StoreContextMut<'_, Self>,
+        f: impl for<'a> FnOnce(
+            StoreContextMut<'a, Self>,
+            Self::UtxoContext,
+        )
+            -> Pin<Box<dyn Future<Output = wasmtime::Result<Utxo>> + Send + 'a>>
+        + Send,
+    ) -> wasmtime::Result<Utxo> {
+        let cx = Self::UtxoContext::default();
+        let utxo = f(store.as_context_mut(), Arc::clone(&cx)).await?;
         store.data_mut().outputs.push((utxo, cx));
-        Ok(())
+        Ok(utxo)
     }
 
     #[instrument(skip(store, cx), ret)]
     fn implements_method(
         mut store: StoreContextMut<Self>,
-        cx: Resource<UtxoCtx>,
+        cx: Resource<Self::UtxoContext>,
         hash: (u64, u64, u64, u64),
     ) -> wasmtime::Result<()> {
-        let UtxoCtx { methods } = store.data_mut().table.get_mut(&cx)?;
-        methods.push(hash);
+        let cx = store.data_mut().table.get_mut(&cx)?;
+        cx.lock().unwrap().methods.push(hash);
         Ok(())
     }
 
     #[instrument(skip(store, cx), ret)]
-    fn resume(mut store: StoreContextMut<Self>, cx: Resource<UtxoCtx>) -> wasmtime::Result<()> {
-        let UtxoCtx { methods } = store.data_mut().table.get_mut(&cx)?;
-        methods.clear();
+    fn resume(
+        mut store: StoreContextMut<Self>,
+        cx: Resource<Self::UtxoContext>,
+    ) -> wasmtime::Result<()> {
+        let cx = store.data_mut().table.get_mut(&cx)?;
+        cx.lock().unwrap().methods.clear();
         Ok(())
     }
 
     #[instrument(skip(store, cx), ret)]
     fn drop_utxo_context(
         mut store: StoreContextMut<Self>,
-        cx: Resource<UtxoCtx>,
+        cx: Resource<Self::UtxoContext>,
     ) -> wasmtime::Result<()> {
         let Ctx {
             table,
@@ -176,7 +182,7 @@ static METHODS: LazyLock<[(u64, u64, u64, u64); 4]> =
 #[derive(Clone)]
 struct ProgressUtxo {
     storage: UtxoStorageExport,
-    new: ConstructorExport,
+    new: UtxoMainExport,
     finish: MethodExport,
     mult_mult: MethodExport,
     plus_chips: MethodExport,
@@ -195,16 +201,16 @@ fn assert_progress_utxo<T: Host>(contract: &Contract<T>) -> wasmtime::Result<Pro
         .context("failed to get `score-progress` UTXO export by name")?;
 
     let new = {
-        let mut exports = contract.utxo_constructors(&utxo);
+        let mut exports = contract.utxo_mains(&utxo);
         match (exports.next(), exports.next()) {
             (Some(("[static]utxo.new", Ok(new))), None) => new,
-            exports => bail!("unexpected UTXO constructor exports: {exports:?}"),
+            exports => bail!("unexpected UTXO main exports: {exports:?}"),
         }
     };
 
     let _named = contract
-        .get_utxo_constructor(&utxo, "[static]utxo.new")
-        .context("failed to get `[static]utxo.new` UTXO constructor export by name")?;
+        .get_utxo_main(&utxo, "[static]utxo.new")
+        .context("failed to get `[static]utxo.new` UTXO main export by name")?;
 
     let methods = contract.utxo_methods(&utxo);
     let methods: BTreeMap<_, _> = methods
@@ -310,7 +316,7 @@ async fn score_main_new() -> wasmtime::Result<()> {
     let ty = assert_progress_utxo(&contract)?;
 
     let mut table = ResourceTable::default();
-    let utxo_cx = table.push(UtxoCtx::default())?;
+    let utxo_cx = table.push(Arc::new(Mutex::new(UtxoCtx::default())))?;
     let utxo_cx_rep = utxo_cx.rep();
     let mut store = wasmtime::Store::new(
         &engine,
@@ -325,15 +331,15 @@ async fn score_main_new() -> wasmtime::Result<()> {
     let utxo_cx = utxo_cx.try_into_resource_any(&mut store)?;
     let instance = contract.instantiate(&mut store).await?;
     let utxo = instance
-        .create_utxo(&mut store, &ty.new, [Val::Resource(utxo_cx)])
+        .call_utxo_main(&mut store, &ty.new, [Val::Resource(utxo_cx)])
         .instrument(info_span!("new"))
         .await
         .context("failed to construct UTXO")?;
 
     let Ctx { events, table, .. } = store.data();
     assert_eq!(events.as_ref(), []);
-    let UtxoCtx { methods } = table.get(&Resource::new_borrow(utxo_cx_rep))?;
-    assert_eq!(methods.as_slice(), *METHODS);
+    let utxo_cx: &Arc<Mutex<UtxoCtx>> = table.get(&Resource::new_borrow(utxo_cx_rep))?;
+    assert_eq!(utxo_cx.lock().unwrap().methods, *METHODS);
 
     let ProgressStorage {
         chips,
@@ -416,11 +422,11 @@ async fn score_main_new() -> wasmtime::Result<()> {
         )]
     );
     let mut dropped_utxo_cxs = dropped_utxo_cxs.iter();
-    let UtxoCtx { methods } = match (dropped_utxo_cxs.next(), dropped_utxo_cxs.next()) {
-        (Some(utxo), None) => utxo,
+    let cx = match (dropped_utxo_cxs.next(), dropped_utxo_cxs.next()) {
+        (Some(cx), None) => cx,
         _ => bail!("unexpected UTXO contexts dropped `{dropped_utxo_cxs:?}`"),
     };
-    assert_eq!(methods, &[]);
+    assert_eq!(cx.lock().unwrap().methods, []);
     Ok(())
 }
 
@@ -452,7 +458,6 @@ async fn score_script_example() -> wasmtime::Result<()> {
         .context("failed to call `example` coordination script")?;
 
     let Ctx {
-        table,
         events,
         outputs,
         dropped_utxo_cxs,
@@ -463,9 +468,7 @@ async fn score_script_example() -> wasmtime::Result<()> {
         (Some((utxo, utxo_cx)), None) => (*utxo, utxo_cx),
         _ => bail!("unexpected outputs created: {outputs:?}"),
     };
-
-    let UtxoCtx { methods } = table.get(utxo_cx)?;
-    assert_eq!(methods.as_slice(), *METHODS);
+    assert_eq!(utxo_cx.lock().unwrap().methods, *METHODS);
     assert!(dropped_utxo_cxs.is_empty());
     assert!(events.is_empty());
 

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -38,11 +38,18 @@ fn compile_contract(source: &str) -> Vec<u8> {
 static EXAMPLE_SCORE: LazyLock<Vec<u8>> =
     LazyLock::new(|| compile_contract(include_str!("../../examples/score.star")));
 
+#[derive(Debug, Eq, PartialEq)]
+struct Event {
+    abi_name: Arc<str>,
+    name: Arc<str>,
+    params: Box<[Val]>,
+}
+
 struct Ctx {
     contract: Contract<Self>,
 
     table: ResourceTable,
-    events: Vec<(Arc<str>, Arc<str>, Box<[Val]>)>,
+    events: Vec<Event>,
 
     outputs: Vec<(Utxo, Arc<Mutex<UtxoCtx>>)>,
     dropped_utxo_cxs: Vec<Arc<Mutex<UtxoCtx>>>,
@@ -149,10 +156,11 @@ impl Host for Ctx {
         name: &Arc<str>,
         params: &[Val],
     ) -> wasmtime::Result<()> {
-        store
-            .data_mut()
-            .events
-            .push((Arc::clone(abi_name), Arc::clone(name), params.into()));
+        store.data_mut().events.push(Event {
+            abi_name: Arc::clone(abi_name),
+            name: Arc::clone(name),
+            params: params.into(),
+        });
         Ok(())
     }
 }
@@ -415,11 +423,11 @@ async fn score_main_new() -> wasmtime::Result<()> {
     assert!(table.is_empty());
     assert_eq!(
         events,
-        [(
-            "score".into(),
-            "finish".into(),
-            [Val::U64(3 * 4 * 2)].into()
-        )]
+        [Event {
+            abi_name: "score".into(),
+            name: "finish".into(),
+            params: [Val::U64(3 * 4 * 2)].into()
+        }]
     );
     let mut dropped_utxo_cxs = dropped_utxo_cxs.iter();
     let cx = match (dropped_utxo_cxs.next(), dropped_utxo_cxs.next()) {

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -52,7 +52,6 @@ struct Ctx {
     events: Vec<Event>,
 
     outputs: Vec<(Utxo, Arc<Mutex<UtxoCtx>>)>,
-    dropped_utxo_cxs: Vec<Arc<Mutex<UtxoCtx>>>,
 }
 
 #[derive(Debug, Default)]
@@ -139,13 +138,8 @@ impl Host for Ctx {
         mut store: StoreContextMut<Self>,
         cx: Resource<Self::UtxoContext>,
     ) -> wasmtime::Result<()> {
-        let Ctx {
-            table,
-            dropped_utxo_cxs,
-            ..
-        } = store.data_mut();
-        let cx = table.delete(cx)?;
-        dropped_utxo_cxs.push(cx);
+        let Ctx { table, .. } = store.data_mut();
+        table.delete(cx)?;
         Ok(())
     }
 
@@ -324,8 +318,8 @@ async fn score_main_new() -> wasmtime::Result<()> {
     let ty = assert_progress_utxo(&contract)?;
 
     let mut table = ResourceTable::default();
-    let utxo_cx = table.push(Arc::new(Mutex::new(UtxoCtx::default())))?;
-    let utxo_cx_rep = utxo_cx.rep();
+    let utxo_cx = Arc::new(Mutex::new(UtxoCtx::default()));
+    let utxo_cx_res = table.push(Arc::clone(&utxo_cx))?;
     let mut store = wasmtime::Store::new(
         &engine,
         Ctx {
@@ -333,20 +327,18 @@ async fn score_main_new() -> wasmtime::Result<()> {
             table,
             events: Vec::default(),
             outputs: Vec::default(),
-            dropped_utxo_cxs: Vec::default(),
         },
     );
-    let utxo_cx = utxo_cx.try_into_resource_any(&mut store)?;
+    let utxo_cx_res = utxo_cx_res.try_into_resource_any(&mut store)?;
     let instance = contract.instantiate(&mut store).await?;
     let utxo = instance
-        .call_utxo_main(&mut store, &ty.new, [Val::Resource(utxo_cx)])
+        .call_utxo_main(&mut store, &ty.new, [Val::Resource(utxo_cx_res)])
         .instrument(info_span!("new"))
         .await
         .context("failed to construct UTXO")?;
 
-    let Ctx { events, table, .. } = store.data();
+    let Ctx { events, .. } = store.data();
     assert_eq!(events.as_ref(), []);
-    let utxo_cx: &Arc<Mutex<UtxoCtx>> = table.get(&Resource::new_borrow(utxo_cx_rep))?;
     assert_eq!(utxo_cx.lock().unwrap().methods, *METHODS);
 
     let ProgressStorage {
@@ -416,7 +408,6 @@ async fn score_main_new() -> wasmtime::Result<()> {
         table,
         events,
         outputs,
-        dropped_utxo_cxs,
         ..
     } = store.into_data();
     assert!(outputs.is_empty());
@@ -429,12 +420,11 @@ async fn score_main_new() -> wasmtime::Result<()> {
             params: [Val::U64(3 * 4 * 2)].into()
         }]
     );
-    let mut dropped_utxo_cxs = dropped_utxo_cxs.iter();
-    let cx = match (dropped_utxo_cxs.next(), dropped_utxo_cxs.next()) {
-        (Some(cx), None) => cx,
-        _ => bail!("unexpected UTXO contexts dropped `{dropped_utxo_cxs:?}`"),
-    };
-    assert_eq!(cx.lock().unwrap().methods, []);
+    let UtxoCtx { methods } = Arc::into_inner(utxo_cx)
+        .expect("UTXO context must have been dropped")
+        .into_inner()
+        .unwrap();
+    assert_eq!(methods, []);
     Ok(())
 }
 
@@ -452,7 +442,6 @@ async fn score_script_example() -> wasmtime::Result<()> {
             table: ResourceTable::default(),
             events: Vec::default(),
             outputs: Vec::default(),
-            dropped_utxo_cxs: Vec::default(),
         },
     );
     let instance = contract
@@ -466,10 +455,7 @@ async fn score_script_example() -> wasmtime::Result<()> {
         .context("failed to call `example` coordination script")?;
 
     let Ctx {
-        events,
-        outputs,
-        dropped_utxo_cxs,
-        ..
+        events, outputs, ..
     } = store.data();
     let mut outputs = outputs.iter();
     let (utxo, utxo_cx) = match (outputs.next(), outputs.next()) {
@@ -477,7 +463,7 @@ async fn score_script_example() -> wasmtime::Result<()> {
         _ => bail!("unexpected outputs created: {outputs:?}"),
     };
     assert_eq!(utxo_cx.lock().unwrap().methods, *METHODS);
-    assert!(dropped_utxo_cxs.is_empty());
+    assert_eq!(Arc::strong_count(utxo_cx), 2);
     assert!(events.is_empty());
 
     let ProgressStorage {

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -139,14 +139,14 @@ impl Host for Ctx {
     #[instrument(skip(store), ret)]
     fn emit_event(
         mut store: StoreContextMut<Self>,
-        instance: &str,
+        abi_name: &str,
         name: &str,
         params: &[Val],
     ) -> wasmtime::Result<()> {
         store
             .data_mut()
             .events
-            .push((instance.into(), name.into(), params.into()));
+            .push((abi_name.into(), name.into(), params.into()));
         Ok(())
     }
 }
@@ -410,7 +410,7 @@ async fn score_main_new() -> wasmtime::Result<()> {
     assert_eq!(
         events,
         [(
-            "starstream:events/score".into(),
+            "score".into(),
             "finish".into(),
             [Val::U64(3 * 4 * 2)].into()
         )]


### PR DESCRIPTION
- integrate the new ABI in `rt-next` and re-enable tests
- extend `score` example coordination script with method calls

~Blocked on #200~

Closes #176 