### PR TITLE
Add codegen for `if x is MyAbi` blocks

### DIFF
--- a/docs/wit-worlds.mdx
+++ b/docs/wit-worlds.mdx
@@ -153,15 +153,10 @@ world root {
 }
 ```
 
-## Exporting coordination scripts
+### ABI casting
 
-Coordination scripts are top-level function exports:
-
-```wit
-world root {
-    export my-coordination-script: func();
-}
-```
+To test whether methods exist before calling them, call `has-method` on
+the `starstream:std/builtin#utxo` resource.
 
 ## Importing coordination scripts
 

--- a/docs/wit-worlds.mdx
+++ b/docs/wit-worlds.mdx
@@ -158,6 +158,16 @@ world root {
 To test whether methods exist before calling them, call `has-method` on
 the `starstream:std/builtin#utxo` resource.
 
+## Exporting coordination scripts
+
+Coordination scripts are top-level function exports:
+
+```wit
+world root {
+    export my-coordination-script: func();
+}
+```
+
 ## Importing coordination scripts
 
 Cross-contract coordination scripts are imported from an interface named

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -324,7 +324,6 @@ async fn get_progress_storage<T: Send + 'static>(
 }
 
 #[test_log::test(tokio::test)]
-#[ignore = "dynamic UTXO imports unsupported"]
 async fn score_main_new() -> wasmtime::Result<()> {
     let engine = wasmtime::Engine::default();
     let contract =
@@ -444,7 +443,6 @@ async fn score_main_new() -> wasmtime::Result<()> {
 }
 
 #[test_log::test(tokio::test)]
-#[ignore = "dynamic UTXO imports unsupported"]
 async fn score_script_example() -> wasmtime::Result<()> {
     let engine = wasmtime::Engine::default();
     let contract =

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -322,6 +322,7 @@ async fn get_progress_storage<T: Send + 'static>(
 }
 
 #[test_log::test(tokio::test)]
+#[ignore] // Due to "dynamic UTXO imports unsupported"
 async fn score_main_new() -> wasmtime::Result<()> {
     let engine = wasmtime::Engine::default();
     let contract =
@@ -441,6 +442,7 @@ async fn score_main_new() -> wasmtime::Result<()> {
 }
 
 #[test_log::test(tokio::test)]
+#[ignore] // Due to "dynamic UTXO imports unsupported"
 async fn score_script_example() -> wasmtime::Result<()> {
     let engine = wasmtime::Engine::default();
     let contract =

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -322,7 +322,7 @@ async fn get_progress_storage<T: Send + 'static>(
 }
 
 #[test_log::test(tokio::test)]
-#[ignore] // Due to "dynamic UTXO imports unsupported"
+#[ignore = "dynamic UTXO imports unsupported"]
 async fn score_main_new() -> wasmtime::Result<()> {
     let engine = wasmtime::Engine::default();
     let contract =
@@ -442,7 +442,7 @@ async fn score_main_new() -> wasmtime::Result<()> {
 }
 
 #[test_log::test(tokio::test)]
-#[ignore] // Due to "dynamic UTXO imports unsupported"
+#[ignore = "dynamic UTXO imports unsupported"]
 async fn score_script_example() -> wasmtime::Result<()> {
     let engine = wasmtime::Engine::default();
     let contract =

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -66,6 +66,15 @@ impl bindings::starstream::std::builtin::HostUtxo for Ctx {
     fn drop(&mut self, _utxo: Resource<Utxo>) -> wasmtime::Result<()> {
         Ok(())
     }
+
+    fn has_method(
+        &mut self,
+        _utxo: Resource<Utxo>,
+        _hash: (u64, u64, u64, u64),
+    ) -> wasmtime::Result<bool> {
+        // TODO
+        Ok(false)
+    }
 }
 
 impl bindings::starstream::std::builtin::HostToken for Ctx {

--- a/starstream-to-wasm/src/component_encoder.rs
+++ b/starstream-to-wasm/src/component_encoder.rs
@@ -287,14 +287,12 @@ impl TypeBuilder<ComponentType> {
 }
 
 impl TypeBuilder<InstanceType> {
-    pub fn new_interface() -> Self {
-        Self::default()
-    }
-
-    pub fn inherit_parent(&mut self, parent: &TypeBuilder<ComponentType>) {
+    pub fn new_interface(parent: &TypeBuilder<ComponentType>) -> Self {
+        let mut this = Self::default();
         // Lower resources declared in the parent interface.
-        self.on_demand_resources
+        this.on_demand_resources
             .extend(parent.resources.iter().cloned());
+        this
     }
 }
 

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -966,17 +966,17 @@ impl Compiler {
         }
     }
 
-    fn star_count_core_types(&mut self, ty: &Type) -> u32 {
+    fn star_count_core_types(ty: &Type) -> u32 {
         match ty {
             Type::Unit => 0,
             Type::Bool => 1,
             Type::Int(_) => 1,
-            Type::UtxoAny | Type::Utxo(_) | Type::TokenAny | Type::Token(_) => 1,
-            Type::Tuple(items) => items.iter().map(|t| self.star_count_core_types(t)).sum(),
+            Type::UtxoAny | Type::Utxo(_) | Type::TokenAny | Type::Token(_) | Type::Abi(_) => 1,
+            Type::Tuple(items) => items.iter().map(|t| Self::star_count_core_types(t)).sum(),
             Type::Record(record) => record
                 .fields
                 .iter()
-                .map(|f| self.star_count_core_types(&f.ty))
+                .map(|f| Self::star_count_core_types(&f.ty))
                 .sum(),
             Type::Enum(enum_) => {
                 // discriminator + the max number of slots used by any variant
@@ -986,19 +986,18 @@ impl Compiler {
                     .map(|v| match &v.kind {
                         EnumVariantKind::Unit => 0,
                         EnumVariantKind::Tuple(fields) => {
-                            fields.iter().map(|t| self.star_count_core_types(t)).sum()
+                            fields.iter().map(|t| Self::star_count_core_types(t)).sum()
                         }
                         EnumVariantKind::Struct(fields) => fields
                             .iter()
-                            .map(|f| self.star_count_core_types(&f.ty))
+                            .map(|f| Self::star_count_core_types(&f.ty))
                             .sum(),
                     })
                     .max()
                     .unwrap_or(0)
             }
             Type::Function { .. } => todo!(),
-            Type::Var(_) => todo!(),
-            Type::Abi(_) => 0,
+            Type::Var(_) => unreachable!(),
         }
     }
 
@@ -1893,20 +1892,7 @@ impl Compiler {
                         {
                             let mut types = Vec::new();
                             _ = self.star_to_core_types(value.span, &mut types, &value.node.ty);
-
-                            // Pop from stack to set locals in reverse order.
-                            match var {
-                                Var::Local(local) => {
-                                    for i in (0..types.len()).rev() {
-                                        func.instructions(bb).local_set(local + (i as u32));
-                                    }
-                                }
-                                Var::Global(global) => {
-                                    for i in (0..types.len()).rev() {
-                                        func.instructions(bb).global_set(global + (i as u32));
-                                    }
-                                }
-                            }
+                            var.store(func.instructions(bb), types.len() as u32);
                         }
                     } else {
                         self.push_error(
@@ -2162,8 +2148,40 @@ impl Compiler {
                             // False branch is to continue evaluating conditions.
                             *bb = bb_false;
                         }
-                        TypedIfCondition::Is { .. } => {
-                            todo!("codegen for if...is not yet implemented")
+                        TypedIfCondition::Is {
+                            name,
+                            original_type,
+                            abi,
+                            abi_name_span,
+                        } => {
+                            let var = locals.get(name.as_str()).unwrap();
+
+                            // TODO ...
+                            var.load(
+                                func.instructions(bb),
+                                Self::star_count_core_types(original_type),
+                            );
+
+                            // Inner block for each condition.
+                            let bb_true = func.cfg.add_block();
+                            let bb_false = func.cfg.add_block();
+                            func.cfg.fill(
+                                *bb,
+                                Out::If {
+                                    f: bb_false,
+                                    t: bb_true,
+                                },
+                            );
+                            func.cfg.seal(bb_true, BlockType::Empty);
+                            func.cfg.seal(bb_false, BlockType::Empty);
+                            *bb = bb_true;
+
+                            // True branch.
+                            self.visit_block_drop(func, bb, locals, block)?;
+                            func.cfg.fill(*bb, Out::Next(bb_end));
+
+                            // False branch is to continue evaluating conditions.
+                            *bb = bb_false;
                         }
                     }
                 }
@@ -2190,7 +2208,7 @@ impl Compiler {
                 // Function calls could have any side effect, so always really
                 // call them then drop whatever they might have returned.
                 self.visit_expr_stack(func, bb, locals, span, expr)?;
-                for _ in 0..self.star_count_core_types(&expr.ty) {
+                for _ in 0..Self::star_count_core_types(&expr.ty) {
                     func.instructions(bb).drop();
                 }
             }
@@ -2217,18 +2235,7 @@ impl Compiler {
                 if let [solo] = &name[..]
                     && let Some(var) = locals.get(solo.as_str())
                 {
-                    match var {
-                        Var::Local(local) => {
-                            for i in 0..self.star_count_core_types(&expr.ty) {
-                                func.instructions(bb).local_get(local + i);
-                            }
-                        }
-                        Var::Global(global) => {
-                            for i in 0..self.star_count_core_types(&expr.ty) {
-                                func.instructions(bb).global_get(global + i);
-                            }
-                        }
-                    }
+                    var.load(func.instructions(bb), Self::star_count_core_types(&expr.ty));
                     Ok(())
                 } else if let Type::Enum(enum_) = &expr.ty
                     && let Some(variant) = *constant
@@ -2758,7 +2765,7 @@ impl Compiler {
                             if f.name.as_str() == field.as_str() {
                                 ty = Some(&f.ty);
                             }
-                            let slots = self.star_count_core_types(&f.ty);
+                            let slots = Self::star_count_core_types(&f.ty);
                             total += slots;
                             if ty.is_none() {
                                 offset += slots;
@@ -2865,8 +2872,41 @@ impl Compiler {
                             // False branch is to continue evaluating conditions.
                             *bb = bb_false;
                         }
-                        TypedIfCondition::Is { .. } => {
-                            todo!("codegen for if...is not yet implemented")
+                        TypedIfCondition::Is {
+                            name,
+                            original_type,
+                            abi,
+                            abi_name_span,
+                        } => {
+                            let var = locals.get(name.as_str()).unwrap();
+
+                            // TODO ...
+                            var.load(
+                                func.instructions(bb),
+                                Self::star_count_core_types(original_type),
+                            );
+
+                            // Inner block for each condition.
+                            let bb_true = func.cfg.add_block();
+                            let bb_false = func.cfg.add_block();
+                            func.cfg.fill(
+                                *bb,
+                                Out::If {
+                                    f: bb_false,
+                                    t: bb_true,
+                                },
+                            );
+                            func.cfg.seal(bb_true, BlockType::Empty);
+                            func.cfg.seal(bb_false, BlockType::Empty);
+                            *bb = bb_true;
+
+                            // True branch.
+                            self.visit_block_stack(func, bb, locals, block)?;
+                            bulk.store(func, bb);
+                            func.cfg.fill(*bb, Out::Next(bb_end));
+
+                            // False branch is to continue evaluating conditions.
+                            *bb = bb_false;
                         }
                     }
                 }
@@ -3781,7 +3821,7 @@ impl Compiler {
         result.extend_from_slice(&col_locals[..column]);
         let mut offset = base_local;
         for ft in field_types {
-            let count = self.star_count_core_types(ft);
+            let count = Self::star_count_core_types(ft);
             result.push((offset, ft.clone()));
             offset += count;
         }
@@ -3794,6 +3834,39 @@ impl Compiler {
 enum Var {
     Local(u32),
     Global(u32),
+}
+
+impl Var {
+    fn load(&self, mut sink: InstructionSink, count: u32) {
+        match self {
+            Var::Local(local) => {
+                for i in 0..count {
+                    sink.local_get(local + i);
+                }
+            }
+            Var::Global(global) => {
+                for i in 0..count {
+                    sink.global_get(global + i);
+                }
+            }
+        }
+    }
+
+    /// Pop from stack to set locals in reverse order.
+    fn store(&self, mut sink: InstructionSink, count: u32) {
+        match self {
+            Var::Local(local) => {
+                for i in (0..count).rev() {
+                    sink.local_set(local + i);
+                }
+            }
+            Var::Global(global) => {
+                for i in (0..count).rev() {
+                    sink.global_set(global + i);
+                }
+            }
+        }
+    }
 }
 
 // Probably inefficient, but fun. Fix later?

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -974,7 +974,7 @@ impl Compiler {
             Type::Bool => 1,
             Type::Int(_) => 1,
             Type::UtxoAny | Type::Utxo(_) | Type::TokenAny | Type::Token(_) | Type::Abi(_) => 1,
-            Type::Tuple(items) => items.iter().map(|t| Self::star_count_core_types(t)).sum(),
+            Type::Tuple(items) => items.iter().map(Self::star_count_core_types).sum(),
             Type::Record(record) => record
                 .fields
                 .iter()
@@ -988,7 +988,7 @@ impl Compiler {
                     .map(|v| match &v.kind {
                         EnumVariantKind::Unit => 0,
                         EnumVariantKind::Tuple(fields) => {
-                            fields.iter().map(|t| Self::star_count_core_types(t)).sum()
+                            fields.iter().map(Self::star_count_core_types).sum()
                         }
                         EnumVariantKind::Struct(fields) => fields
                             .iter()

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -1127,8 +1127,10 @@ impl Compiler {
                             &func_ty.params,
                             &func_ty.result,
                         );
-                        let iface = imported_interfaces.entry(def.from.to_string()).or_default();
-                        iface.export_fn(&kebab, &sig);
+                        imported_interfaces
+                            .entry(def.from.to_string())
+                            .or_insert_with(|| TypeBuilder::new_interface(&self.world_type))
+                            .export_fn(&kebab, &sig);
                     }
                 }
                 _ => todo!(),

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -384,7 +384,7 @@ impl Compiler {
 
     fn push_error(&mut self, span: Span, message: impl Into<String>) -> ErrorToken {
         self.errors.push(CompileError {
-            message: message.into(),
+            message: dbg!(message.into()),
             span,
         });
         self.fatal = true;
@@ -813,8 +813,10 @@ impl Compiler {
             Type::Utxo(utxo) => panic!("referencing unregistered utxo {utxo:?}"),
             Type::TokenAny => unreachable!(), // Always preregistered.
             Type::Token(token) => panic!("referencing unregistered token {token:?}"),
-            // ABI handle types aren't implemented yet.
-            Type::Abi(_) => todo!(),
+            // ABI handle types currently decompose to `utxo`.
+            Type::Abi(_) => {
+                return Some(self.star_to_component.get(&Type::UtxoAny).unwrap().clone());
+            }
         };
 
         let cat = Rc::new(cat);
@@ -1162,7 +1164,15 @@ impl Compiler {
                     self.callables.insert(part.id, func);
                 }
                 FunctionKind::Normal => {
-                    // ABI method codegen not yet implemented.
+                    let func = self.declare_dynamic_method(
+                        imported_interfaces,
+                        &def.ty,
+                        &part.name,
+                        &part.ty.params,
+                        &part.ty.result,
+                    );
+                    self.method_callables
+                        .insert((Type::Abi(def.ty.clone()), part.id), func);
                 }
                 FunctionKind::Runtime => unreachable!(),
             }
@@ -1225,7 +1235,7 @@ impl Compiler {
                 .global_set(self.context_global.unwrap());
         }
 
-        let _ = self.visit_block_stack(&mut func, &mut bb, &(parent, &locals), &function.body);
+        _ = self.visit_block_stack(&mut func, &mut bb, &(parent, &locals), &function.body);
         if bb != usize::MAX {
             self.visit_return(&mut func, &bb);
             func.cfg.fill(bb, Out::Return);
@@ -1292,8 +1302,7 @@ impl Compiler {
         let import_interface_name = format!("starstream:self/{}", export_interface_name);
         let resource_name = "utxo";
 
-        let mut iface = TypeBuilder::new_interface();
-        iface.inherit_parent(&self.world_type);
+        let mut iface = TypeBuilder::new_interface(&self.world_type);
 
         // Declare the resource type.
         let this_ty = Type::Utxo(utxo.ty.clone());
@@ -1429,8 +1438,7 @@ impl Compiler {
         let export_interface_name = to_kebab_case(utxo.name.as_str());
         let resource_name = "utxo";
 
-        let mut iface = TypeBuilder::new_interface();
-        iface.inherit_parent(&self.world_type);
+        let mut iface = TypeBuilder::new_interface(&self.world_type);
 
         // Declare the resource type.
         let this_ty = Type::Utxo(utxo.ty.clone());
@@ -1599,8 +1607,7 @@ impl Compiler {
         let import_interface_name = format!("starstream:self/{}", export_interface_name);
         let resource_name = "token";
 
-        let mut iface = TypeBuilder::new_interface();
-        iface.inherit_parent(&self.world_type);
+        let mut iface = TypeBuilder::new_interface(&self.world_type);
 
         // Declare the resource type.
         let this_ty = Type::Token(token.ty.clone());
@@ -1638,8 +1645,7 @@ impl Compiler {
         let export_interface_name = to_kebab_case(token.name.as_str());
         let resource_name = "token";
 
-        let mut iface = TypeBuilder::new_interface();
-        iface.inherit_parent(&self.world_type);
+        let mut iface = TypeBuilder::new_interface(&self.world_type);
 
         // Declare the resource type.
         let this_ty = Type::Token(token.ty.clone());
@@ -1908,7 +1914,7 @@ impl Compiler {
                     func.cfg.fill(*bb, Out::Next(bb_condition));
 
                     let mut bb_condition_2 = bb_condition;
-                    let _ = self.visit_expr_stack(
+                    _ = self.visit_expr_stack(
                         func,
                         &mut bb_condition_2,
                         &(parent, &locals),
@@ -1940,8 +1946,7 @@ impl Compiler {
                     *bb = bb_exit;
                 }
                 TypedStatement::Return(Some(expr)) => {
-                    let _ =
-                        self.visit_expr_stack(func, bb, &(parent, &locals), expr.span, &expr.node);
+                    _ = self.visit_expr_stack(func, bb, &(parent, &locals), expr.span, &expr.node);
                     self.visit_return(func, bb);
                     func.cfg.fill(*bb, Out::Return);
                     *bb = usize::MAX;
@@ -2118,7 +2123,7 @@ impl Compiler {
                     match condition {
                         TypedIfCondition::Bool(condition) => {
                             // Evaluate condition.
-                            let _ = self.visit_expr_stack(
+                            _ = self.visit_expr_stack(
                                 func,
                                 bb,
                                 locals,
@@ -2151,8 +2156,8 @@ impl Compiler {
                         TypedIfCondition::Is {
                             name,
                             original_type,
-                            abi,
-                            abi_name_span,
+                            abi: _,
+                            abi_name_span: _,
                         } => {
                             let var = locals.get(name.as_str()).unwrap();
 
@@ -2841,7 +2846,7 @@ impl Compiler {
                     match condition {
                         TypedIfCondition::Bool(condition) => {
                             // Evaluate condition.
-                            let _ = self.visit_expr_stack(
+                            _ = self.visit_expr_stack(
                                 func,
                                 bb,
                                 locals,
@@ -2875,8 +2880,8 @@ impl Compiler {
                         TypedIfCondition::Is {
                             name,
                             original_type,
-                            abi,
-                            abi_name_span,
+                            abi: _,
+                            abi_name_span: _,
                         } => {
                             let var = locals.get(name.as_str()).unwrap();
 
@@ -3149,7 +3154,7 @@ impl Compiler {
         core_fn_idx: u32,
         args: &[Spanned<TypedExpr>],
     ) -> Result<()> {
-        let _ = span;
+        _ = span;
         for arg in args {
             self.visit_expr_stack(func, bb, locals, arg.span, &arg.node)?;
         }
@@ -3463,14 +3468,14 @@ impl Compiler {
                 }
 
                 if bulk.is_empty() {
-                    let _ = self.visit_block_drop(
+                    _ = self.visit_block_drop(
                         func,
                         bb,
                         &(locals, &arm_locals),
                         &arms[*action].body,
                     );
                 } else {
-                    let _ = self.visit_block_stack(
+                    _ = self.visit_block_stack(
                         func,
                         bb,
                         &(locals, &arm_locals),

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -8,13 +8,13 @@ use std::{borrow::Cow, collections::HashMap, rc::Rc};
 use miette::{Diagnostic, LabeledSpan};
 use sha2::Digest;
 use starstream_types::{
-    BinaryOp, EnumType, EnumVariantKind, FunctionExport, IntWidth, Literal, Span, Spanned,
-    StaticFunction, Type, TypedAbiDef, TypedBlock, TypedDefinition, TypedEnumDef, TypedExpr,
-    TypedExprKind, TypedFunctionDef, TypedFunctionParam, TypedIfCondition, TypedImportDef,
-    TypedMatchArm, TypedPattern, TypedProgram, TypedStatement, TypedStructDef, TypedTokenDef,
-    TypedTokenPart, TypedUtxoDef, TypedUtxoPart, UnaryOp, ast::Identifier,
+    AbiType, BinaryOp, EnumType, EnumVariantKind, FunctionExport, FunctionKind, ImportSource,
+    IntWidth, Literal, NameId, Span, Spanned, StaticFunction, Type, TypedAbiDef,
+    TypedAbiMethodDecl, TypedBlock, TypedDefinition, TypedEnumDef, TypedExpr, TypedExprKind,
+    TypedFunctionDef, TypedFunctionParam, TypedIfCondition, TypedImportDef, TypedMatchArm,
+    TypedPattern, TypedProgram, TypedStatement, TypedStructDef, TypedTokenDef, TypedTokenPart,
+    TypedUtxoDef, TypedUtxoPart, UnaryOp, ast::Identifier,
 };
-use starstream_types::{FunctionKind, ImportSource, NameId};
 use thiserror::Error;
 use wasm_encoder::{
     BlockType, CodeSection, Component, ComponentExportKind, ComponentExportSection, ComponentType,
@@ -2131,64 +2131,38 @@ impl Compiler {
                                 &condition.node,
                             );
                             assert_eq!(condition.node.ty, Type::Bool);
-
-                            // Inner block for each condition.
-                            let bb_true = func.cfg.add_block();
-                            let bb_false = func.cfg.add_block();
-                            func.cfg.fill(
-                                *bb,
-                                Out::If {
-                                    f: bb_false,
-                                    t: bb_true,
-                                },
-                            );
-                            func.cfg.seal(bb_true, BlockType::Empty);
-                            func.cfg.seal(bb_false, BlockType::Empty);
-                            *bb = bb_true;
-
-                            // True branch.
-                            self.visit_block_drop(func, bb, locals, block)?;
-                            func.cfg.fill(*bb, Out::Next(bb_end));
-
-                            // False branch is to continue evaluating conditions.
-                            *bb = bb_false;
                         }
                         TypedIfCondition::Is {
                             name,
-                            original_type,
-                            abi: _,
+                            original_type: _,
+                            abi,
                             abi_name_span: _,
                         } => {
                             let var = locals.get(name.as_str()).unwrap();
-
-                            // TODO ...
-                            var.load(
-                                func.instructions(bb),
-                                Self::star_count_core_types(original_type),
-                            );
-
-                            // Inner block for each condition.
-                            let bb_true = func.cfg.add_block();
-                            let bb_false = func.cfg.add_block();
-                            func.cfg.fill(
-                                *bb,
-                                Out::If {
-                                    f: bb_false,
-                                    t: bb_true,
-                                },
-                            );
-                            func.cfg.seal(bb_true, BlockType::Empty);
-                            func.cfg.seal(bb_false, BlockType::Empty);
-                            *bb = bb_true;
-
-                            // True branch.
-                            self.visit_block_drop(func, bb, locals, block)?;
-                            func.cfg.fill(*bb, Out::Next(bb_end));
-
-                            // False branch is to continue evaluating conditions.
-                            *bb = bb_false;
+                            self.check_implements_abi(func, bb, &var, abi);
                         }
                     }
+
+                    // Inner block for each condition.
+                    let bb_true = func.cfg.add_block();
+                    let bb_false = func.cfg.add_block();
+                    func.cfg.fill(
+                        *bb,
+                        Out::If {
+                            f: bb_false,
+                            t: bb_true,
+                        },
+                    );
+                    func.cfg.seal(bb_true, BlockType::Empty);
+                    func.cfg.seal(bb_false, BlockType::Empty);
+                    *bb = bb_true;
+
+                    // True branch.
+                    self.visit_block_drop(func, bb, locals, block)?;
+                    func.cfg.fill(*bb, Out::Next(bb_end));
+
+                    // False branch is to continue evaluating conditions.
+                    *bb = bb_false;
                 }
 
                 // Final `else` branch is just inline.
@@ -2854,66 +2828,39 @@ impl Compiler {
                                 &condition.node,
                             );
                             assert_eq!(condition.node.ty, Type::Bool);
-
-                            // Inner block for each condition.
-                            let bb_true = func.cfg.add_block();
-                            let bb_false = func.cfg.add_block();
-                            func.cfg.fill(
-                                *bb,
-                                Out::If {
-                                    f: bb_false,
-                                    t: bb_true,
-                                },
-                            );
-                            func.cfg.seal(bb_true, BlockType::Empty);
-                            func.cfg.seal(bb_false, BlockType::Empty);
-                            *bb = bb_true;
-
-                            // True branch.
-                            self.visit_block_stack(func, bb, locals, block)?;
-                            bulk.store(func, bb);
-                            func.cfg.fill(*bb, Out::Next(bb_end));
-
-                            // False branch is to continue evaluating conditions.
-                            *bb = bb_false;
                         }
                         TypedIfCondition::Is {
                             name,
-                            original_type,
-                            abi: _,
+                            original_type: _,
+                            abi,
                             abi_name_span: _,
                         } => {
                             let var = locals.get(name.as_str()).unwrap();
-
-                            // TODO ...
-                            var.load(
-                                func.instructions(bb),
-                                Self::star_count_core_types(original_type),
-                            );
-
-                            // Inner block for each condition.
-                            let bb_true = func.cfg.add_block();
-                            let bb_false = func.cfg.add_block();
-                            func.cfg.fill(
-                                *bb,
-                                Out::If {
-                                    f: bb_false,
-                                    t: bb_true,
-                                },
-                            );
-                            func.cfg.seal(bb_true, BlockType::Empty);
-                            func.cfg.seal(bb_false, BlockType::Empty);
-                            *bb = bb_true;
-
-                            // True branch.
-                            self.visit_block_stack(func, bb, locals, block)?;
-                            bulk.store(func, bb);
-                            func.cfg.fill(*bb, Out::Next(bb_end));
-
-                            // False branch is to continue evaluating conditions.
-                            *bb = bb_false;
+                            self.check_implements_abi(func, bb, &var, abi);
                         }
                     }
+
+                    // Inner block for each condition.
+                    let bb_true = func.cfg.add_block();
+                    let bb_false = func.cfg.add_block();
+                    func.cfg.fill(
+                        *bb,
+                        Out::If {
+                            f: bb_false,
+                            t: bb_true,
+                        },
+                    );
+                    func.cfg.seal(bb_true, BlockType::Empty);
+                    func.cfg.seal(bb_false, BlockType::Empty);
+                    *bb = bb_true;
+
+                    // True branch.
+                    self.visit_block_stack(func, bb, locals, block)?;
+                    bulk.store(func, bb);
+                    func.cfg.fill(*bb, Out::Next(bb_end));
+
+                    // False branch is to continue evaluating conditions.
+                    *bb = bb_false;
                 }
 
                 // Final `else` branch is just inline.
@@ -3104,14 +3051,9 @@ impl Compiler {
                 // Calls to indicate ABIs exposed
                 for abi in abis {
                     for method in &abi.methods {
-                        let digest = sha2::Sha256::digest(method.identity());
-                        assert_eq!(digest.len(), 32);
                         func.instructions(bb)
                             .global_get(self.context_global.unwrap());
-                        for chunk in digest.chunks_exact(8) {
-                            func.instructions(bb)
-                                .i64_const(i64::from_le_bytes(<[u8; 8]>::try_from(chunk).unwrap()));
-                        }
+                        self.push_method_identity(func, bb, method);
                         func.instructions(bb)
                             .call(self.builtins.implements_method.unwrap());
                     }
@@ -3160,6 +3102,37 @@ impl Compiler {
         }
         func.instructions(bb).call(core_fn_idx);
         Ok(())
+    }
+
+    fn check_implements_abi(
+        &mut self,
+        func: &mut StFunction,
+        bb: &mut usize,
+        var: &Var,
+        abi: &AbiType,
+    ) {
+        func.instructions(bb).i32_const(1);
+        for method in &abi.methods {
+            var.load(func.instructions(bb), 1);
+            self.push_method_identity(func, bb, method);
+            func.instructions(bb)
+                .call(self.builtins.has_method.unwrap());
+            func.instructions(bb).i32_and();
+        }
+    }
+
+    fn push_method_identity(
+        &mut self,
+        func: &mut StFunction,
+        bb: &mut usize,
+        method: &TypedAbiMethodDecl,
+    ) {
+        let digest = sha2::Sha256::digest(method.identity());
+        assert_eq!(digest.len(), 32);
+        for chunk in digest.chunks_exact(8) {
+            func.instructions(bb)
+                .i64_const(i64::from_le_bytes(<[u8; 8]>::try_from(chunk).unwrap()));
+        }
     }
 
     fn enum_promote(

--- a/starstream-to-wasm/src/world_spec.rs
+++ b/starstream-to-wasm/src/world_spec.rs
@@ -35,7 +35,7 @@ impl Compiler {
         if self.world_type.has_imported(name) {
             return;
         }
-        let mut builtin = TypeBuilder::default();
+        let mut builtin = TypeBuilder::new_interface(&self.world_type);
 
         // `resource utxo`
         let utxo_resource = builtin.fresh_resource("utxo", "s-utxo");
@@ -86,7 +86,7 @@ impl Compiler {
             return;
         }
 
-        let mut utxo_context = TypeBuilder::default();
+        let mut utxo_context = TypeBuilder::new_interface(&self.world_type);
 
         let utxo_context_resource = utxo_context.fresh_resource("utxo-context", "s-utxo-context");
         self.builtins.utxo_context_resource = Some(utxo_context_resource.clone());

--- a/starstream-to-wasm/src/world_spec.rs
+++ b/starstream-to-wasm/src/world_spec.rs
@@ -227,7 +227,7 @@ impl Compiler {
 
         // Core import
         let func_idx = self.import_function(
-            &interface,
+            interface,
             &kebab,
             &FuncType::new(core_params.iter().copied(), core_results),
         );

--- a/starstream-to-wasm/src/world_spec.rs
+++ b/starstream-to-wasm/src/world_spec.rs
@@ -20,6 +20,8 @@ use crate::{
 /// Builtins imported from `starstream:std/builtins` and friends.
 #[derive(Default)]
 pub struct Builtins {
+    pub has_method: Option<u32>,
+
     pub utxo_context_resource: Option<Rc<Resource>>,
     pub utxo_context_drop: Option<u32>,
     pub resume: Option<u32>,
@@ -33,20 +35,47 @@ impl Compiler {
         if self.world_type.has_imported(name) {
             return;
         }
-
         let mut builtin = TypeBuilder::default();
-        self.star_to_component.insert(
-            Type::UtxoAny,
-            Rc::new(ComponentAbiType::Borrow {
-                resource: builtin.fresh_resource("utxo", "s-utxo"),
-            }),
+
+        // `resource utxo`
+        let utxo_resource = builtin.fresh_resource("utxo", "s-utxo");
+        let utxo_type = Rc::new(ComponentAbiType::Borrow {
+            resource: utxo_resource,
+        });
+        self.star_to_component
+            .insert(Type::UtxoAny, utxo_type.clone());
+        self.builtins.has_method = Some(self.import_function(
+            name,
+            "[method]utxo.has-method",
+            &FuncType::new(
+                [
+                    ValType::I32,
+                    ValType::I64,
+                    ValType::I64,
+                    ValType::I64,
+                    ValType::I64,
+                ],
+                [ValType::I32],
+            ),
+        ));
+        let u64_ty = Rc::new(ComponentAbiType::U64);
+        let tuple = Rc::new(ComponentAbiType::Tuple {
+            fields: vec![u64_ty; 4],
+        });
+        builtin.export_fn_2(
+            "[method]utxo.has-method",
+            [("self", utxo_type.clone()), ("hash", tuple)],
+            Some(&Rc::new(ComponentAbiType::Bool)),
         );
+
+        // `resource token`
         self.star_to_component.insert(
             Type::TokenAny,
             Rc::new(ComponentAbiType::Borrow {
                 resource: builtin.fresh_resource("token", "s-token"),
             }),
         );
+
         self.world_type.import_interface(name, &builtin);
     }
 

--- a/starstream-to-wasm/src/world_spec.rs
+++ b/starstream-to-wasm/src/world_spec.rs
@@ -7,7 +7,7 @@
 
 use std::{collections::BTreeMap, rc::Rc};
 
-use starstream_types::{Identifier, Type, TypedFunctionParam};
+use starstream_types::{AbiType, Identifier, Type, TypedFunctionParam};
 use wasm_encoder::{FuncType, InstanceType, ValType};
 
 use crate::{
@@ -34,7 +34,7 @@ impl Compiler {
             return;
         }
 
-        let mut builtin = TypeBuilder::new_interface();
+        let mut builtin = TypeBuilder::default();
         self.star_to_component.insert(
             Type::UtxoAny,
             Rc::new(ComponentAbiType::Borrow {
@@ -57,7 +57,7 @@ impl Compiler {
             return;
         }
 
-        let mut utxo_context = TypeBuilder::new_interface();
+        let mut utxo_context = TypeBuilder::default();
 
         let utxo_context_resource = utxo_context.fresh_resource("utxo-context", "s-utxo-context");
         self.builtins.utxo_context_resource = Some(utxo_context_resource.clone());
@@ -133,8 +133,10 @@ impl Compiler {
 
         // Component import
         let sig = self.star_to_component_signature(None, params, &Type::Unit);
-        let iface = imported_interfaces.entry(interface).or_default();
-        iface.export_fn(&kebab, &sig);
+        imported_interfaces
+            .entry(interface)
+            .or_insert_with(|| TypeBuilder::new_interface(&self.world_type))
+            .export_fn(&kebab, &sig);
 
         func_idx
     }
@@ -167,8 +169,46 @@ impl Compiler {
 
         // Component import
         let sig = self.star_to_component_signature(None, params, result);
-        let iface = imported_interfaces.entry(interface).or_default();
-        iface.export_fn(&kebab, &sig);
+        imported_interfaces
+            .entry(interface)
+            .or_insert_with(|| TypeBuilder::new_interface(&self.world_type))
+            .export_fn(&kebab, &sig);
+
+        func_idx
+    }
+
+    pub fn declare_dynamic_method(
+        &mut self,
+        imported_interfaces: &mut BTreeMap<String, TypeBuilder<InstanceType>>,
+        _abi_ty: &AbiType,
+        method_name: &Identifier,
+        params: &[TypedFunctionParam],
+        result: &Type,
+    ) -> u32 {
+        let mut core_params = Vec::with_capacity(16);
+        _ = self.star_to_core_types(method_name.span, &mut core_params, &Type::UtxoAny);
+        for p in params {
+            _ = self.star_to_core_types(p.ty_span, &mut core_params, &p.ty);
+        }
+        let mut core_results = Vec::new();
+        _ = self.star_to_core_types(method_name.span, &mut core_results, result);
+
+        let interface = "starstream:contract/dynamic-utxo";
+        let kebab = to_kebab_case(method_name.as_str());
+
+        // Core import
+        let func_idx = self.import_function(
+            &interface,
+            &kebab,
+            &FuncType::new(core_params.iter().copied(), core_results),
+        );
+
+        // Component import
+        let sig = self.star_to_component_signature(Some(&Type::UtxoAny), params, result);
+        imported_interfaces
+            .entry(interface.to_owned())
+            .or_insert_with(|| TypeBuilder::new_interface(&self.world_type))
+            .export_fn(&kebab, &sig);
 
         func_idx
     }

--- a/starstream-to-wasm/tests/inputs/if_abi.star
+++ b/starstream-to-wasm/tests/inputs/if_abi.star
@@ -4,7 +4,7 @@ abi MyAbi {
 
 script fn maybe_hello(u: Utxo) -> i32 {
     if u is MyAbi {
-        1
+        u.hello()
     } else {
         0
     }

--- a/starstream-to-wasm/tests/inputs/if_abi.star
+++ b/starstream-to-wasm/tests/inputs/if_abi.star
@@ -1,0 +1,11 @@
+abi MyAbi {
+    fn hello() -> i32;
+}
+
+script fn maybe_hello(u: Utxo) -> i32 {
+    if u is MyAbi {
+        1
+    } else {
+        0
+    }
+}

--- a/starstream-to-wasm/tests/overflow.rs
+++ b/starstream-to-wasm/tests/overflow.rs
@@ -33,7 +33,8 @@ fn execute_wasm(wasm: &[u8], func_name: &str, params: &[i64]) -> Result<Vec<i64>
     let engine = Engine::new(&config).unwrap();
     let module = Module::from_binary(&engine, wasm).unwrap();
 
-    let linker = Linker::new(&engine);
+    let mut linker = Linker::new(&engine);
+    linker.define_unknown_imports_as_traps(&module).unwrap();
     let mut store = Store::new(&engine, ());
 
     let instance = linker.instantiate(&mut store, &module).unwrap();

--- a/starstream-to-wasm/tests/snapshots/inputs@add.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@add.star.snap
@@ -217,9 +217,11 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i64 i64) (result i64)))
-  (export "add" (func 1))
-  (func (;0;) (type 0) (param i64 i64) (result i64)
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i64 i64) (result i64)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (export "add" (func 2))
+  (func (;1;) (type 1) (param i64 i64) (result i64)
     (local i64)
     (local.tee 2
       (i64.add
@@ -242,8 +244,8 @@ TypedProgram {
       (then
         (unreachable)))
   )
-  (func (;1;) (type 0) (param i64 i64) (result i64)
-    (call 0
+  (func (;2;) (type 1) (param i64 i64) (result i64)
+    (call 1
       (local.get 0)
       (local.get 1))
   )
@@ -259,9 +261,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -296,7 +301,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@blockheight.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@blockheight.star.snap
@@ -425,17 +425,19 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (result i64)))
-  (import "starstream:std/cardano" "block-height" (func (;0;) (type 0)))
-  (export "reexport" (func 1))
-  (export "second" (func 2))
-  (func (;1;) (type 0) (result i64)
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (result i64)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (import "starstream:std/cardano" "block-height" (func (;1;) (type 1)))
+  (export "reexport" (func 2))
+  (export "second" (func 3))
+  (func (;2;) (type 1) (result i64)
     (drop
-      (call 0))
-    (call 0)
-  )
-  (func (;2;) (type 0) (result i64)
+      (call 1))
     (call 1)
+  )
+  (func (;3;) (type 1) (result i64)
+    (call 2)
   )
   (@custom "component-type"
     (component
@@ -449,9 +451,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -497,7 +502,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@empty.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@empty.star.snap
@@ -72,9 +72,11 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func))
-  (export "main" (func 0))
-  (func (;0;) (type 0))
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (export "main" (func 1))
+  (func (;1;) (type 1))
   (@custom "component-type"
     (component
       (@custom "wit-component-encoding" "\04\00")
@@ -87,9 +89,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -124,7 +129,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@enum.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@enum.star.snap
@@ -881,22 +881,24 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32 i64)))
-  (type (;1;) (func))
-  (export "get-bar" (func 1))
-  (export "get-baz" (func 2))
-  (func (;0;) (type 0) (param i32 i64))
-  (func (;1;) (type 1)
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32 i64)))
+  (type (;2;) (func))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (export "get-bar" (func 2))
+  (export "get-baz" (func 3))
+  (func (;1;) (type 1) (param i32 i64))
+  (func (;2;) (type 2)
     (local i64)
-    (call 0
+    (call 1
       (i32.const 0)
       (local.set 0
         (i64.extend_i32_u
           (i32.const 1)))
       (local.get 0))
   )
-  (func (;2;) (type 1)
-    (call 0
+  (func (;3;) (type 2)
+    (call 1
       (i32.const 1)
       (i64.const 2))
   )
@@ -912,9 +914,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -961,7 +966,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@enum_simple.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@enum_simple.star.snap
@@ -93,6 +93,8 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
   (@custom "component-type"
     (component
       (@custom "wit-component-encoding" "\04\00")
@@ -105,9 +107,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -129,7 +134,8 @@ TypedProgram {
       )
       (export (;1;) "x" (type 0))
     )
-  ))
+  )
+)
 
 ==== WIT ====
 package root:component;
@@ -145,7 +151,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@events.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@events.star.snap
@@ -328,12 +328,14 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32 i32)))
-  (type (;1;) (func))
-  (import "starstream:events/foo" "hello" (func (;0;) (type 0)))
-  (export "main" (func 1))
-  (func (;1;) (type 1)
-    (call 0
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32 i32)))
+  (type (;2;) (func))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (import "starstream:events/foo" "hello" (func (;1;) (type 1)))
+  (export "main" (func 2))
+  (func (;2;) (type 2)
+    (call 1
       (i32.const 1)
       (i32.const 2))
   )
@@ -349,9 +351,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -394,7 +399,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@if_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@if_abi.star.snap
@@ -1,0 +1,429 @@
+---
+source: starstream-to-wasm/tests/snapshots.rs
+input_file: starstream-to-wasm/tests/inputs/if_abi.star
+---
+==== AST ====
+Program {
+    shebang: None,
+    definitions: [
+        Spanned {
+            node: Abi(
+                AbiDef {
+                    name: Identifier {
+                        name: "MyAbi",
+                        span: 4..9,
+                    },
+                    parts: [
+                        FnDecl(
+                            AbiMethodDecl {
+                                name: Identifier {
+                                    name: "hello",
+                                    span: 19..24,
+                                },
+                                params: [],
+                                return_type: Some(
+                                    Named {
+                                        name: [
+                                            Identifier {
+                                                name: "i32",
+                                                span: 30..33,
+                                            },
+                                        ],
+                                        generics: [],
+                                    },
+                                ),
+                                span: 16..35,
+                            },
+                        ),
+                    ],
+                },
+            ),
+            span: 0..38,
+        },
+        Spanned {
+            node: Function(
+                FunctionDef {
+                    export: Some(
+                        Script,
+                    ),
+                    name: Identifier {
+                        name: "maybe_hello",
+                        span: 48..59,
+                    },
+                    params: [
+                        FunctionParam {
+                            public: false,
+                            name: Identifier {
+                                name: "u",
+                                span: 60..61,
+                            },
+                            ty: Named {
+                                name: [
+                                    Identifier {
+                                        name: "Utxo",
+                                        span: 63..67,
+                                    },
+                                ],
+                                generics: [],
+                            },
+                        },
+                    ],
+                    return_type: Some(
+                        Named {
+                            name: [
+                                Identifier {
+                                    name: "i32",
+                                    span: 72..75,
+                                },
+                            ],
+                            generics: [],
+                        },
+                    ),
+                    body: Block {
+                        statements: [],
+                        tail_expression: Some(
+                            Spanned {
+                                node: If {
+                                    branches: [
+                                        (
+                                            Is {
+                                                name: Identifier {
+                                                    name: "u",
+                                                    span: 85..86,
+                                                },
+                                                abi_name: Identifier {
+                                                    name: "MyAbi",
+                                                    span: 90..95,
+                                                },
+                                            },
+                                            Block {
+                                                statements: [],
+                                                tail_expression: Some(
+                                                    Spanned {
+                                                        node: Literal(
+                                                            Integer(
+                                                                IntegerLiteral {
+                                                                    digits: "1",
+                                                                    radix: Decimal,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        span: 106..107,
+                                                    },
+                                                ),
+                                                span: 96..114,
+                                            },
+                                        ),
+                                    ],
+                                    else_branch: Some(
+                                        Block {
+                                            statements: [],
+                                            tail_expression: Some(
+                                                Spanned {
+                                                    node: Literal(
+                                                        Integer(
+                                                            IntegerLiteral {
+                                                                digits: "0",
+                                                                radix: Decimal,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    span: 129..130,
+                                                },
+                                            ),
+                                            span: 119..137,
+                                        },
+                                    ),
+                                },
+                                span: 82..137,
+                            },
+                        ),
+                        span: 76..139,
+                    },
+                },
+            ),
+            span: 38..139,
+        },
+    ],
+}
+
+==== Inference trace ====
+T-Fn: maybe_hello => i32
+  T-ReturnTail: if u is MyAbi {
+    1
+} else {
+    0
+} => i32
+    T-If: {maybe_hello: fn(u: Utxo) -> i32, u: Utxo} ⊢ if u is MyAbi {
+    1
+} else {
+    0
+} ⇒ ()
+      T-Tail: 1 => i64
+        T-Int: {maybe_hello: fn(u: Utxo) -> i32, u: MyAbi} ⊢ 1 ⇒ i64
+      T-Tail: 0 => i64
+        T-Int: {maybe_hello: fn(u: Utxo) -> i32, u: Utxo} ⊢ 0 ⇒ i64
+      Unify-Var: i64 ~ i64 => {i64/t3}
+    Unify-Var: i64 ~ i32 => {i32/t4}
+
+==== Typed AST ====
+TypedProgram {
+    definitions: [
+        Abi(
+            TypedAbiDef {
+                ty: AbiType {
+                    name: Identifier {
+                        name: "MyAbi",
+                        span: 4..9,
+                    },
+                    methods: [
+                        TypedAbiMethodDecl {
+                            name: Identifier {
+                                name: "hello",
+                                span: 19..24,
+                            },
+                            id: NameId(4),
+                            ty: FunctionType {
+                                kind: Normal,
+                                name_span: 19..24,
+                                params: [],
+                                result: Int(
+                                    I32,
+                                ),
+                                callee: Some(
+                                    Named(
+                                        NameId(4),
+                                    ),
+                                ),
+                            },
+                        },
+                    ],
+                },
+                functions: [
+                    TypedAbiMethodDecl {
+                        name: Identifier {
+                            name: "hello",
+                            span: 19..24,
+                        },
+                        id: NameId(4),
+                        ty: FunctionType {
+                            kind: Normal,
+                            name_span: 19..24,
+                            params: [],
+                            result: Int(
+                                I32,
+                            ),
+                            callee: Some(
+                                Named(
+                                    NameId(4),
+                                ),
+                            ),
+                        },
+                    },
+                ],
+            },
+        ),
+        Function(
+            TypedFunctionDef {
+                export: Some(
+                    Script,
+                ),
+                name: Identifier {
+                    name: "maybe_hello",
+                    span: 48..59,
+                },
+                id: NameId(5),
+                ty: FunctionType {
+                    kind: Normal,
+                    name_span: 48..59,
+                    params: [
+                        TypedFunctionParam {
+                            public: false,
+                            name: Identifier {
+                                name: "u",
+                                span: 60..61,
+                            },
+                            ty: UtxoAny,
+                            ty_span: 63..67,
+                        },
+                    ],
+                    result: Int(
+                        I32,
+                    ),
+                    callee: Some(
+                        Named(
+                            NameId(5),
+                        ),
+                    ),
+                },
+                body: TypedBlock {
+                    statements: [],
+                    tail_expression: Some(
+                        Spanned {
+                            node: TypedExpr {
+                                ty: Int(
+                                    I32,
+                                ),
+                                kind: If {
+                                    branches: [
+                                        (
+                                            Is {
+                                                name: Identifier {
+                                                    name: "u",
+                                                    span: 85..86,
+                                                },
+                                                original_type: UtxoAny,
+                                                abi: AbiType {
+                                                    name: Identifier {
+                                                        name: "MyAbi",
+                                                        span: 4..9,
+                                                    },
+                                                    methods: [
+                                                        TypedAbiMethodDecl {
+                                                            name: Identifier {
+                                                                name: "hello",
+                                                                span: 19..24,
+                                                            },
+                                                            id: NameId(4),
+                                                            ty: FunctionType {
+                                                                kind: Normal,
+                                                                name_span: 19..24,
+                                                                params: [],
+                                                                result: Int(
+                                                                    I32,
+                                                                ),
+                                                                callee: Some(
+                                                                    Named(
+                                                                        NameId(4),
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                abi_name_span: 90..95,
+                                            },
+                                            TypedBlock {
+                                                statements: [],
+                                                tail_expression: Some(
+                                                    Spanned {
+                                                        node: TypedExpr {
+                                                            ty: Int(
+                                                                I32,
+                                                            ),
+                                                            kind: Literal(
+                                                                Integer(
+                                                                    IntegerLiteral {
+                                                                        digits: "1",
+                                                                        radix: Decimal,
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                        span: 106..107,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    else_branch: Some(
+                                        TypedBlock {
+                                            statements: [],
+                                            tail_expression: Some(
+                                                Spanned {
+                                                    node: TypedExpr {
+                                                        ty: Int(
+                                                            I32,
+                                                        ),
+                                                        kind: Literal(
+                                                            Integer(
+                                                                IntegerLiteral {
+                                                                    digits: "0",
+                                                                    radix: Decimal,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    span: 129..130,
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            },
+                            span: 82..137,
+                        },
+                    ),
+                },
+            },
+        ),
+    ],
+}
+
+==== Core WebAssembly ====
+(module
+  (type (;0;) (func (param i32) (result i32)))
+  (export "maybe-hello" (func 0))
+  (func (;0;) (type 0) (param i32) (result i32)
+    (block (result i32) ;; label = @1
+      (block ;; label = @2
+        (br_if 0 (;@2;)
+          (local.get 0))
+        (br 1 (;@1;)
+          (i32.const 0)))
+      (i32.const 1))
+  )
+  (@custom "component-type"
+    (component
+      (@custom "wit-component-encoding" "\04\00")
+      (type (;0;)
+        (component
+          (type (;0;)
+            (component
+              (type (;0;)
+                (instance
+                  (export (;0;) "utxo" (type (sub resource)))
+                  (type (;1;) (borrow 0))
+                  (type (;2;) (own 0))
+                  (export (;3;) "token" (type (sub resource)))
+                  (type (;4;) (borrow 3))
+                  (type (;5;) (own 3))
+                )
+              )
+              (import "starstream:std/builtin" (instance (;0;) (type 0)))
+              (alias export 0 "utxo" (type (;1;)))
+              (import "s-utxo" (type (;2;) (eq 1)))
+              (type (;3;) (borrow 2))
+              (type (;4;) (own 2))
+              (alias export 0 "token" (type (;5;)))
+              (import "s-token" (type (;6;) (eq 5)))
+              (type (;7;) (borrow 6))
+              (type (;8;) (own 6))
+              (type (;9;) (func (param "u" 3) (result s32)))
+              (export (;0;) "maybe-hello" (func (type 9)))
+            )
+          )
+          (export (;0;) "my-namespace:my-package/my-world" (component (type 0)))
+        )
+      )
+      (export (;1;) "x" (type 0))
+    )
+  )
+)
+
+==== WIT ====
+package root:component;
+
+world root {
+  import starstream:std/builtin;
+  use starstream:std/builtin.{utxo as s-utxo, token as s-token};
+
+  export maybe-hello: func(u: borrow<s-utxo>) -> s32;
+}
+package starstream:std {
+  interface builtin {
+    resource utxo;
+
+    resource token;
+  }
+}

--- a/starstream-to-wasm/tests/snapshots/inputs@if_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@if_abi.star.snap
@@ -100,18 +100,33 @@ Program {
                                                 statements: [],
                                                 tail_expression: Some(
                                                     Spanned {
-                                                        node: Literal(
-                                                            Integer(
-                                                                IntegerLiteral {
-                                                                    digits: "1",
-                                                                    radix: Decimal,
+                                                        node: Call {
+                                                            callee: Spanned {
+                                                                node: FieldAccess {
+                                                                    target: Spanned {
+                                                                        node: ScopedName(
+                                                                            [
+                                                                                Identifier {
+                                                                                    name: "u",
+                                                                                    span: 106..107,
+                                                                                },
+                                                                            ],
+                                                                        ),
+                                                                        span: 106..107,
+                                                                    },
+                                                                    field: Identifier {
+                                                                        name: "hello",
+                                                                        span: 108..113,
+                                                                    },
                                                                 },
-                                                            ),
-                                                        ),
-                                                        span: 106..107,
+                                                                span: 106..113,
+                                                            },
+                                                            args: [],
+                                                        },
+                                                        span: 106..120,
                                                     },
                                                 ),
-                                                span: 96..114,
+                                                span: 96..122,
                                             },
                                         ),
                                     ],
@@ -128,21 +143,21 @@ Program {
                                                             },
                                                         ),
                                                     ),
-                                                    span: 129..130,
+                                                    span: 137..138,
                                                 },
                                             ),
-                                            span: 119..137,
+                                            span: 127..145,
                                         },
                                     ),
                                 },
-                                span: 82..137,
+                                span: 82..145,
                             },
                         ),
-                        span: 76..139,
+                        span: 76..147,
                     },
                 },
             ),
-            span: 38..139,
+            span: 38..147,
         },
     ],
 }
@@ -150,21 +165,23 @@ Program {
 ==== Inference trace ====
 T-Fn: maybe_hello => i32
   T-ReturnTail: if u is MyAbi {
-    1
+    u.hello()
 } else {
     0
 } => i32
     T-If: {maybe_hello: fn(u: Utxo) -> i32, u: Utxo} ⊢ if u is MyAbi {
-    1
+    u.hello()
 } else {
     0
 } ⇒ ()
-      T-Tail: 1 => i64
-        T-Int: {maybe_hello: fn(u: Utxo) -> i32, u: MyAbi} ⊢ 1 ⇒ i64
+      T-Tail: u.hello() => i32
+        T-Call: {maybe_hello: fn(u: Utxo) -> i32, u: MyAbi} ⊢ u.hello() ⇒ i32
+          T-FieldAccess: {maybe_hello: fn(u: Utxo) -> i32, u: MyAbi} ⊢ u.hello ⇒ fn() -> i32
+            T-Var: {maybe_hello: fn(u: Utxo) -> i32, u: MyAbi} ⊢ u ⇒ MyAbi
       T-Tail: 0 => i64
         T-Int: {maybe_hello: fn(u: Utxo) -> i32, u: Utxo} ⊢ 0 ⇒ i64
-      Unify-Var: i64 ~ i64 => {i64/t3}
-    Unify-Var: i64 ~ i32 => {i32/t4}
+      Unify-Var: i32 ~ i64 => {i32/t3}
+    Unify-Const: i32 ~ i32 => {}
 
 ==== Typed AST ====
 TypedProgram {
@@ -311,16 +328,81 @@ TypedProgram {
                                                             ty: Int(
                                                                 I32,
                                                             ),
-                                                            kind: Literal(
-                                                                Integer(
-                                                                    IntegerLiteral {
-                                                                        digits: "1",
-                                                                        radix: Decimal,
+                                                            kind: Call {
+                                                                callee: Spanned {
+                                                                    node: TypedExpr {
+                                                                        ty: Function(
+                                                                            FunctionType {
+                                                                                kind: Normal,
+                                                                                name_span: 19..24,
+                                                                                params: [],
+                                                                                result: Int(
+                                                                                    I32,
+                                                                                ),
+                                                                                callee: Some(
+                                                                                    Named(
+                                                                                        NameId(4),
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        kind: FieldAccess {
+                                                                            target: Spanned {
+                                                                                node: TypedExpr {
+                                                                                    ty: Abi(
+                                                                                        AbiType {
+                                                                                            name: Identifier {
+                                                                                                name: "MyAbi",
+                                                                                                span: 4..9,
+                                                                                            },
+                                                                                            methods: [
+                                                                                                TypedAbiMethodDecl {
+                                                                                                    name: Identifier {
+                                                                                                        name: "hello",
+                                                                                                        span: 19..24,
+                                                                                                    },
+                                                                                                    id: NameId(4),
+                                                                                                    ty: FunctionType {
+                                                                                                        kind: Normal,
+                                                                                                        name_span: 19..24,
+                                                                                                        params: [],
+                                                                                                        result: Int(
+                                                                                                            I32,
+                                                                                                        ),
+                                                                                                        callee: Some(
+                                                                                                            Named(
+                                                                                                                NameId(4),
+                                                                                                            ),
+                                                                                                        ),
+                                                                                                    },
+                                                                                                },
+                                                                                            ],
+                                                                                        },
+                                                                                    ),
+                                                                                    kind: ScopedName {
+                                                                                        name: [
+                                                                                            Identifier {
+                                                                                                name: "u",
+                                                                                                span: 106..107,
+                                                                                            },
+                                                                                        ],
+                                                                                        constant: None,
+                                                                                    },
+                                                                                },
+                                                                                span: 106..107,
+                                                                            },
+                                                                            field: Identifier {
+                                                                                name: "hello",
+                                                                                span: 108..113,
+                                                                            },
+                                                                        },
                                                                     },
-                                                                ),
-                                                            ),
+                                                                    span: 106..113,
+                                                                },
+                                                                args: [],
+                                                            },
                                                         },
-                                                        span: 106..107,
+                                                        span: 106..113,
                                                     },
                                                 ),
                                             },
@@ -344,14 +426,14 @@ TypedProgram {
                                                             ),
                                                         ),
                                                     },
-                                                    span: 129..130,
+                                                    span: 137..138,
                                                 },
                                             ),
                                         },
                                     ),
                                 },
                             },
-                            span: 82..137,
+                            span: 82..145,
                         },
                     ),
                 },
@@ -363,15 +445,17 @@ TypedProgram {
 ==== Core WebAssembly ====
 (module
   (type (;0;) (func (param i32) (result i32)))
-  (export "maybe-hello" (func 0))
-  (func (;0;) (type 0) (param i32) (result i32)
+  (import "starstream:contract/dynamic-utxo" "hello" (func (;0;) (type 0)))
+  (export "maybe-hello" (func 1))
+  (func (;1;) (type 0) (param i32) (result i32)
     (block (result i32) ;; label = @1
       (block ;; label = @2
         (br_if 0 (;@2;)
           (local.get 0))
         (br 1 (;@1;)
           (i32.const 0)))
-      (i32.const 1))
+      (call 0
+        (local.get 0)))
   )
   (@custom "component-type"
     (component
@@ -399,8 +483,19 @@ TypedProgram {
               (import "s-token" (type (;6;) (eq 5)))
               (type (;7;) (borrow 6))
               (type (;8;) (own 6))
-              (type (;9;) (func (param "u" 3) (result s32)))
-              (export (;0;) "maybe-hello" (func (type 9)))
+              (type (;9;)
+                (instance
+                  (alias outer 1 1 (type (;0;)))
+                  (export (;1;) "s-utxo" (type (eq 0)))
+                  (type (;2;) (borrow 1))
+                  (type (;3;) (own 1))
+                  (type (;4;) (func (param "self" 2) (result s32)))
+                  (export (;0;) "hello" (func (type 4)))
+                )
+              )
+              (import "starstream:contract/dynamic-utxo" (instance (;1;) (type 9)))
+              (type (;10;) (func (param "u" 3) (result s32)))
+              (export (;0;) "maybe-hello" (func (type 10)))
             )
           )
           (export (;0;) "my-namespace:my-package/my-world" (component (type 0)))
@@ -416,6 +511,7 @@ package root:component;
 
 world root {
   import starstream:std/builtin;
+  import starstream:contract/dynamic-utxo;
   use starstream:std/builtin.{utxo as s-utxo, token as s-token};
 
   export maybe-hello: func(u: borrow<s-utxo>) -> s32;
@@ -425,5 +521,14 @@ package starstream:std {
     resource utxo;
 
     resource token;
+  }
+}
+
+
+package starstream:contract {
+  interface dynamic-utxo {
+    use starstream:std/builtin.{utxo as s-utxo};
+
+    hello: func(self: borrow<s-utxo>) -> s32;
   }
 }

--- a/starstream-to-wasm/tests/snapshots/inputs@if_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@if_abi.star.snap
@@ -444,17 +444,19 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32) (result i32)))
-  (import "starstream:contract/dynamic-utxo" "hello" (func (;0;) (type 0)))
-  (export "maybe-hello" (func 1))
-  (func (;1;) (type 0) (param i32) (result i32)
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32) (result i32)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (import "starstream:contract/dynamic-utxo" "hello" (func (;1;) (type 1)))
+  (export "maybe-hello" (func 2))
+  (func (;2;) (type 1) (param i32) (result i32)
     (block (result i32) ;; label = @1
       (block ;; label = @2
         (br_if 0 (;@2;)
           (local.get 0))
         (br 1 (;@1;)
           (i32.const 0)))
-      (call 0
+      (call 1
         (local.get 0)))
   )
   (@custom "component-type"
@@ -469,9 +471,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -518,7 +523,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@if_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@if_abi.star.snap
@@ -453,7 +453,14 @@ TypedProgram {
     (block (result i32) ;; label = @1
       (block ;; label = @2
         (br_if 0 (;@2;)
-          (local.get 0))
+          (i32.and
+            (i32.const 1)
+            (call 0
+              (local.get 0)
+              (i64.const 1054880662928880172)
+              (i64.const -6997826614512064474)
+              (i64.const 6792174941159429659)
+              (i64.const 2637011046949389427))))
         (br 1 (;@1;)
           (i32.const 0)))
       (call 1

--- a/starstream-to-wasm/tests/snapshots/inputs@if_elseif_else.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@if_elseif_else.star.snap
@@ -307,9 +307,11 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func))
-  (export "main" (func 0))
-  (func (;0;) (type 0)
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (export "main" (func 1))
+  (func (;1;) (type 1)
     (block ;; label = @1
       (block ;; label = @2
         (br_if 0 (;@2;)
@@ -332,9 +334,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -369,7 +374,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@if_expression.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@if_expression.star.snap
@@ -300,9 +300,11 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (result i64)))
-  (export "main" (func 0))
-  (func (;0;) (type 0) (result i64)
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (result i64)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (export "main" (func 1))
+  (func (;1;) (type 1) (result i64)
     (block (result i64) ;; label = @1
       (block ;; label = @2
         (br_if 0 (;@2;)
@@ -328,9 +330,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -365,7 +370,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@integer_radix.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@integer_radix.star.snap
@@ -533,10 +533,12 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i64 i64) (result i64)))
-  (type (;1;) (func (result i64)))
-  (export "main" (func 1))
-  (func (;0;) (type 0) (param i64 i64) (result i64)
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i64 i64) (result i64)))
+  (type (;2;) (func (result i64)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (export "main" (func 2))
+  (func (;1;) (type 1) (param i64 i64) (result i64)
     (local i64)
     (local.tee 2
       (i64.add
@@ -559,7 +561,7 @@ TypedProgram {
       (then
         (unreachable)))
   )
-  (func (;1;) (type 1) (result i64)
+  (func (;2;) (type 2) (result i64)
     (local i64 i32 i32 i64)
     (local.set 0
       (i64.const 255))
@@ -568,14 +570,14 @@ TypedProgram {
     (local.set 2
       (i32.const 10))
     (local.set 3
-      (call 0
-        (call 0
-          (call 0
+      (call 1
+        (call 1
+          (call 1
             (i64.const 16)
             (i64.const 1))
           (i64.const 7))
         (i64.const 9)))
-    (call 0
+    (call 1
       (local.get 0)
       (local.get 3))
   )
@@ -591,9 +593,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -628,7 +633,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@match_expression.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@match_expression.star.snap
@@ -2873,12 +2873,14 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32 i64 i64) (result i64)))
-  (type (;1;) (func (param i64) (result i64)))
-  (type (;2;) (func (param i64 i64) (result i64)))
-  (type (;3;) (func))
-  (export "get-bar" (func 5))
-  (func (;0;) (type 0) (param i32 i64 i64) (result i64)
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32 i64 i64) (result i64)))
+  (type (;2;) (func (param i64) (result i64)))
+  (type (;3;) (func (param i64 i64) (result i64)))
+  (type (;4;) (func))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (export "get-bar" (func 6))
+  (func (;1;) (type 1) (param i32 i64 i64) (result i64)
     (local i32 i64 i64 i32 i64 i64 i32 i64)
     (block (result i64) ;; label = @1
       (block ;; label = @2
@@ -2928,7 +2930,7 @@ TypedProgram {
         (local.get 7))
       (local.get 8))
   )
-  (func (;1;) (type 0) (param i32 i64 i64) (result i64)
+  (func (;2;) (type 1) (param i32 i64 i64) (result i64)
     (local i32 i64 i64 i32)
     (block (result i64) ;; label = @1
       (block ;; label = @2
@@ -2949,7 +2951,7 @@ TypedProgram {
           (local.get 4)))
       (i64.const 1))
   )
-  (func (;2;) (type 1) (param i64) (result i64)
+  (func (;3;) (type 2) (param i64) (result i64)
     (local i64)
     (block (result i64) ;; label = @1
       (block ;; label = @2
@@ -2963,7 +2965,7 @@ TypedProgram {
           (i64.const 0)))
       (i64.const 1))
   )
-  (func (;3;) (type 2) (param i64 i64) (result i64)
+  (func (;4;) (type 3) (param i64 i64) (result i64)
     (local i64)
     (local.tee 2
       (i64.add
@@ -2986,7 +2988,7 @@ TypedProgram {
       (then
         (unreachable)))
   )
-  (func (;4;) (type 0) (param i32 i64 i64) (result i64)
+  (func (;5;) (type 1) (param i32 i64 i64) (result i64)
     (local i32 i64 i64 i64 i64)
     (block (result i64) ;; label = @1
       (block ;; label = @2
@@ -3006,14 +3008,14 @@ TypedProgram {
         (local.get 4))
       (local.set 7
         (local.get 5))
-      (call 3
+      (call 4
         (local.get 6)
         (local.get 7)))
   )
-  (func (;5;) (type 3)
+  (func (;6;) (type 4)
     (local i64)
     (drop
-      (call 0
+      (call 1
         (i32.const 0)
         (local.set 0
           (i64.extend_i32_u
@@ -3033,9 +3035,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -3103,7 +3108,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@multiple_functions.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@multiple_functions.star.snap
@@ -411,10 +411,12 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func))
-  (type (;1;) (func (param i64 i64) (result i64)))
-  (type (;2;) (func (result i64)))
-  (func (;0;) (type 0)
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func))
+  (type (;2;) (func (param i64 i64) (result i64)))
+  (type (;3;) (func (result i64)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (func (;1;) (type 1)
     (local i32)
     (block ;; label = @1
       (local.set 0
@@ -423,7 +425,7 @@ TypedProgram {
         (local.get 0))
       (return))
   )
-  (func (;1;) (type 1) (param i64 i64) (result i64)
+  (func (;2;) (type 2) (param i64 i64) (result i64)
     (local i64)
     (local.tee 2
       (i64.add
@@ -446,11 +448,11 @@ TypedProgram {
       (then
         (unreachable)))
   )
-  (func (;2;) (type 2) (result i64)
+  (func (;3;) (type 3) (result i64)
     (local i64)
     (local.set 0
       (i64.const 41))
-    (call 1
+    (call 2
       (local.get 0)
       (i64.const 1))
   )
@@ -466,9 +468,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -499,7 +504,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@option_result.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@option_result.star.snap
@@ -2665,19 +2665,21 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (result i32 i64)))
-  (type (;1;) (func (param i32 i64) (result i64)))
-  (type (;2;) (func (param i32 i64 i32 i64)))
-  (export "run" (func 6))
-  (func (;0;) (type 0) (result i32 i64)
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (result i32 i64)))
+  (type (;2;) (func (param i32 i64) (result i64)))
+  (type (;3;) (func (param i32 i64 i32 i64)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (export "run" (func 7))
+  (func (;1;) (type 1) (result i32 i64)
     (i32.const 1)
     (i64.const 42)
   )
-  (func (;1;) (type 0) (result i32 i64)
+  (func (;2;) (type 1) (result i32 i64)
     (i32.const 0)
     (i64.const 0)
   )
-  (func (;2;) (type 1) (param i32 i64) (result i64)
+  (func (;3;) (type 2) (param i32 i64) (result i64)
     (local i32 i64 i64)
     (block (result i64) ;; label = @1
       (block ;; label = @2
@@ -2701,11 +2703,11 @@ TypedProgram {
         (local.get 3))
       (local.get 4))
   )
-  (func (;3;) (type 0) (result i32 i64)
+  (func (;4;) (type 1) (result i32 i64)
     (i32.const 0)
     (i64.const 42)
   )
-  (func (;4;) (type 0) (result i32 i64)
+  (func (;5;) (type 1) (result i32 i64)
     (local i64)
     (i32.const 1)
     (local.set 0
@@ -2713,7 +2715,7 @@ TypedProgram {
         (i32.const 0)))
     (local.get 0)
   )
-  (func (;5;) (type 1) (param i32 i64) (result i64)
+  (func (;6;) (type 2) (param i32 i64) (result i64)
     (local i32 i64 i64 i32)
     (block (result i64) ;; label = @1
       (block ;; label = @2
@@ -2740,13 +2742,13 @@ TypedProgram {
         (local.get 3))
       (local.get 4))
   )
-  (func (;6;) (type 2) (param i32 i64 i32 i64)
+  (func (;7;) (type 3) (param i32 i64 i32 i64)
     (drop
-      (call 2
-        (call 0)))
+      (call 3
+        (call 1)))
     (drop
-      (call 5
-        (call 3)))
+      (call 6
+        (call 4)))
   )
   (@custom "component-type"
     (component
@@ -2760,9 +2762,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -2805,7 +2810,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
@@ -2785,31 +2785,33 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32)))
-  (type (;1;) (func (param i32 i64 i64 i64 i64)))
-  (type (;2;) (func (param i32 i64)))
-  (type (;3;) (func (param i64)))
-  (type (;4;) (func (param i32) (result i32)))
-  (type (;5;) (func (result i32)))
-  (type (;6;) (func))
-  (type (;7;) (func (param i64 i64) (result i64)))
-  (type (;8;) (func (param i32) (result i32 i64 i64 i32 i32)))
-  (type (;9;) (func (param i32 i64 i64 i32 i32) (result i32)))
-  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;0;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;1;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;2;) (type 1)))
-  (import "starstream:contract/dynamic-utxo" "plus-chips" (func (;3;) (type 2)))
-  (import "starstream:contract/dynamic-utxo" "plus-mult" (func (;4;) (type 2)))
-  (import "starstream:contract/dynamic-utxo" "mult-mult" (func (;5;) (type 2)))
-  (import "starstream:contract/dynamic-utxo" "finish" (func (;6;) (type 0)))
-  (import "starstream:events/score" "finish" (func (;7;) (type 3)))
-  (import "[export]score-progress" "[resource-new]utxo" (func (;8;) (type 4)))
-  (import "[export]score-progress" "[resource-drop]utxo" (func (;9;) (type 0)))
-  (import "starstream:self/score-progress" "[static]utxo.new" (func (;10;) (type 5)))
-  (import "starstream:self/score-progress" "[method]utxo.plus-chips" (func (;11;) (type 2)))
-  (import "starstream:self/score-progress" "[method]utxo.plus-mult" (func (;12;) (type 2)))
-  (import "starstream:self/score-progress" "[method]utxo.mult-mult" (func (;13;) (type 2)))
-  (import "starstream:self/score-progress" "[method]utxo.finish" (func (;14;) (type 0)))
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32)))
+  (type (;2;) (func (param i32 i64 i64 i64 i64)))
+  (type (;3;) (func (param i32 i64)))
+  (type (;4;) (func (param i64)))
+  (type (;5;) (func (param i32) (result i32)))
+  (type (;6;) (func (result i32)))
+  (type (;7;) (func))
+  (type (;8;) (func (param i64 i64) (result i64)))
+  (type (;9;) (func (param i32) (result i32 i64 i64 i32 i32)))
+  (type (;10;) (func (param i32 i64 i64 i32 i32) (result i32)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;3;) (type 2)))
+  (import "starstream:contract/dynamic-utxo" "plus-chips" (func (;4;) (type 3)))
+  (import "starstream:contract/dynamic-utxo" "plus-mult" (func (;5;) (type 3)))
+  (import "starstream:contract/dynamic-utxo" "mult-mult" (func (;6;) (type 3)))
+  (import "starstream:contract/dynamic-utxo" "finish" (func (;7;) (type 1)))
+  (import "starstream:events/score" "finish" (func (;8;) (type 4)))
+  (import "[export]score-progress" "[resource-new]utxo" (func (;9;) (type 5)))
+  (import "[export]score-progress" "[resource-drop]utxo" (func (;10;) (type 1)))
+  (import "starstream:self/score-progress" "[static]utxo.new" (func (;11;) (type 6)))
+  (import "starstream:self/score-progress" "[method]utxo.plus-chips" (func (;12;) (type 3)))
+  (import "starstream:self/score-progress" "[method]utxo.plus-mult" (func (;13;) (type 3)))
+  (import "starstream:self/score-progress" "[method]utxo.mult-mult" (func (;14;) (type 3)))
+  (import "starstream:self/score-progress" "[method]utxo.finish" (func (;15;) (type 1)))
   (memory (;0;) 1)
   (global (;0;) (mut i32) (i32.const 0))
   (global (;1;) (mut i32) (i32.const 0))
@@ -2817,27 +2819,27 @@ TypedProgram {
   (global (;3;) (mut i64) (i64.const 0))
   (global (;4;) (mut i32) (i32.const 0))
   (global (;5;) (mut i32) (i32.const 0))
-  (export "score-progress#[static]utxo.new" (func 17))
-  (export "score-progress#[method]utxo.plus-chips" (func 20))
-  (export "score-progress#[method]utxo.plus-mult" (func 21))
-  (export "score-progress#[method]utxo.mult-mult" (func 22))
-  (export "score-progress#[method]utxo.finish" (func 23))
-  (export "score-progress#get-storage" (func 25))
-  (export "score-progress#set-storage" (func 26))
-  (export "example" (func 27))
+  (export "score-progress#[static]utxo.new" (func 18))
+  (export "score-progress#[method]utxo.plus-chips" (func 21))
+  (export "score-progress#[method]utxo.plus-mult" (func 22))
+  (export "score-progress#[method]utxo.mult-mult" (func 23))
+  (export "score-progress#[method]utxo.finish" (func 24))
+  (export "score-progress#get-storage" (func 26))
+  (export "score-progress#set-storage" (func 27))
+  (export "example" (func 28))
   (export "memory" (memory 0))
-  (func (;15;) (type 6)
-    (call 1
+  (func (;16;) (type 7)
+    (call 2
       (global.get 1))
     (block ;; label = @1
       (br_if 0 (;@1;)
         (i32.ne
           (global.get 0)
           (i32.const 1)))
-      (return_call 18))
+      (return_call 19))
     (unreachable)
   )
-  (func (;16;) (type 7) (param i64 i64) (result i64)
+  (func (;17;) (type 8) (param i64 i64) (result i64)
     (local i64 i64 i64)
     (local.tee 2
       (i64.mul
@@ -2877,10 +2879,10 @@ TypedProgram {
           (then
             (unreachable)))))
   )
-  (func (;17;) (type 4) (param i32) (result i32)
+  (func (;18;) (type 5) (param i32) (result i32)
     (local i32)
     (local.set 1
-      (call 8
+      (call 9
         (i32.const 0)))
     (global.set 1
       (local.get 0))
@@ -2890,25 +2892,25 @@ TypedProgram {
       (local.get 0))
     (global.set 5
       (local.get 1))
-    (call 2
+    (call 3
       (global.get 1)
       (i64.const -8462002850237496965)
       (i64.const 3777191895585416912)
       (i64.const -7032313579976096834)
       (i64.const -593716351821793027))
-    (call 2
+    (call 3
       (global.get 1)
       (i64.const -8415072477063627739)
       (i64.const 5859691412821126436)
       (i64.const -3810519776703246304)
       (i64.const -46505724939742969))
-    (call 2
+    (call 3
       (global.get 1)
       (i64.const -7959776885903164596)
       (i64.const -5373630742727988565)
       (i64.const -4027567226927148146)
       (i64.const -2641969232007030050))
-    (call 2
+    (call 3
       (global.get 1)
       (i64.const 5384737671178596162)
       (i64.const 7822374597054249491)
@@ -2916,7 +2918,7 @@ TypedProgram {
       (i64.const -2683880554626369430))
     (local.get 1)
   )
-  (func (;18;) (type 6)
+  (func (;19;) (type 7)
     (local i32 i32)
     (local.set 0
       (global.get 4))
@@ -2926,14 +2928,14 @@ TypedProgram {
       (global.get 5))
     (global.set 5
       (i32.const 0))
-    (call 7
-      (call 16
+    (call 8
+      (call 17
         (global.get 2)
         (global.get 3)))
-    (call 0
+    (call 1
       (local.get 0))
   )
-  (func (;19;) (type 7) (param i64 i64) (result i64)
+  (func (;20;) (type 8) (param i64 i64) (result i64)
     (local i64)
     (local.tee 2
       (i64.add
@@ -2956,40 +2958,40 @@ TypedProgram {
       (then
         (unreachable)))
   )
-  (func (;20;) (type 2) (param i32 i64)
+  (func (;21;) (type 3) (param i32 i64)
     (global.set 2
-      (call 19
+      (call 20
         (global.get 2)
         (local.get 1)))
   )
-  (func (;21;) (type 2) (param i32 i64)
+  (func (;22;) (type 3) (param i32 i64)
     (global.set 3
-      (call 19
+      (call 20
         (global.get 3)
         (local.get 1)))
   )
-  (func (;22;) (type 2) (param i32 i64)
+  (func (;23;) (type 3) (param i32 i64)
     (global.set 3
       (i64.div_u
-        (call 16
+        (call 17
           (global.get 3)
           (local.get 1))
         (i64.const 100)))
   )
-  (func (;23;) (type 0) (param i32)
-    (return_call 15)
+  (func (;24;) (type 1) (param i32)
+    (return_call 16)
   )
-  (func (;24;) (type 8) (param i32) (result i32 i64 i64 i32 i32)
+  (func (;25;) (type 9) (param i32) (result i32 i64 i64 i32 i32)
     (global.get 0)
     (global.get 2)
     (global.get 3)
     (global.get 4)
     (global.get 5)
   )
-  (func (;25;) (type 4) (param i32) (result i32)
+  (func (;26;) (type 5) (param i32) (result i32)
     (local i32 i32 i64 i64 i32 i32)
     (i32.const 8)
-    (call 24
+    (call 25
       (local.get 0))
     (local.set 6)
     (local.set 5)
@@ -3014,7 +3016,7 @@ TypedProgram {
       (local.get 6))
     (i32.const 8)
   )
-  (func (;26;) (type 9) (param i32 i64 i64 i32 i32) (result i32)
+  (func (;27;) (type 10) (param i32 i64 i64 i32 i32) (result i32)
     (global.set 0
       (local.get 0))
     (global.set 2
@@ -3025,14 +3027,14 @@ TypedProgram {
       (local.get 3))
     (global.set 5
       (local.get 4))
-    (return_call 8
+    (return_call 9
       (i32.const 0))
   )
-  (func (;27;) (type 6)
+  (func (;28;) (type 7)
     (local i32)
     (local.set 0
-      (call 10))
-    (call 11
+      (call 11))
+    (call 12
       (local.get 0)
       (i64.const 10))
   )
@@ -3048,9 +3050,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -3205,7 +3210,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
@@ -2787,10 +2787,10 @@ TypedProgram {
 (module
   (type (;0;) (func (param i32)))
   (type (;1;) (func (param i32 i64 i64 i64 i64)))
-  (type (;2;) (func (param i64)))
-  (type (;3;) (func (param i32) (result i32)))
-  (type (;4;) (func (result i32)))
-  (type (;5;) (func (param i32 i64)))
+  (type (;2;) (func (param i32 i64)))
+  (type (;3;) (func (param i64)))
+  (type (;4;) (func (param i32) (result i32)))
+  (type (;5;) (func (result i32)))
   (type (;6;) (func))
   (type (;7;) (func (param i64 i64) (result i64)))
   (type (;8;) (func (param i32) (result i32 i64 i64 i32 i32)))
@@ -2798,14 +2798,18 @@ TypedProgram {
   (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;0;) (type 0)))
   (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;1;) (type 0)))
   (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;2;) (type 1)))
-  (import "starstream:events/score" "finish" (func (;3;) (type 2)))
-  (import "[export]score-progress" "[resource-new]utxo" (func (;4;) (type 3)))
-  (import "[export]score-progress" "[resource-drop]utxo" (func (;5;) (type 0)))
-  (import "starstream:self/score-progress" "[static]utxo.new" (func (;6;) (type 4)))
-  (import "starstream:self/score-progress" "[method]utxo.plus-chips" (func (;7;) (type 5)))
-  (import "starstream:self/score-progress" "[method]utxo.plus-mult" (func (;8;) (type 5)))
-  (import "starstream:self/score-progress" "[method]utxo.mult-mult" (func (;9;) (type 5)))
-  (import "starstream:self/score-progress" "[method]utxo.finish" (func (;10;) (type 0)))
+  (import "starstream:contract/dynamic-utxo" "plus-chips" (func (;3;) (type 2)))
+  (import "starstream:contract/dynamic-utxo" "plus-mult" (func (;4;) (type 2)))
+  (import "starstream:contract/dynamic-utxo" "mult-mult" (func (;5;) (type 2)))
+  (import "starstream:contract/dynamic-utxo" "finish" (func (;6;) (type 0)))
+  (import "starstream:events/score" "finish" (func (;7;) (type 3)))
+  (import "[export]score-progress" "[resource-new]utxo" (func (;8;) (type 4)))
+  (import "[export]score-progress" "[resource-drop]utxo" (func (;9;) (type 0)))
+  (import "starstream:self/score-progress" "[static]utxo.new" (func (;10;) (type 5)))
+  (import "starstream:self/score-progress" "[method]utxo.plus-chips" (func (;11;) (type 2)))
+  (import "starstream:self/score-progress" "[method]utxo.plus-mult" (func (;12;) (type 2)))
+  (import "starstream:self/score-progress" "[method]utxo.mult-mult" (func (;13;) (type 2)))
+  (import "starstream:self/score-progress" "[method]utxo.finish" (func (;14;) (type 0)))
   (memory (;0;) 1)
   (global (;0;) (mut i32) (i32.const 0))
   (global (;1;) (mut i32) (i32.const 0))
@@ -2813,16 +2817,16 @@ TypedProgram {
   (global (;3;) (mut i64) (i64.const 0))
   (global (;4;) (mut i32) (i32.const 0))
   (global (;5;) (mut i32) (i32.const 0))
-  (export "score-progress#[static]utxo.new" (func 13))
-  (export "score-progress#[method]utxo.plus-chips" (func 16))
-  (export "score-progress#[method]utxo.plus-mult" (func 17))
-  (export "score-progress#[method]utxo.mult-mult" (func 18))
-  (export "score-progress#[method]utxo.finish" (func 19))
-  (export "score-progress#get-storage" (func 21))
-  (export "score-progress#set-storage" (func 22))
-  (export "example" (func 23))
+  (export "score-progress#[static]utxo.new" (func 17))
+  (export "score-progress#[method]utxo.plus-chips" (func 20))
+  (export "score-progress#[method]utxo.plus-mult" (func 21))
+  (export "score-progress#[method]utxo.mult-mult" (func 22))
+  (export "score-progress#[method]utxo.finish" (func 23))
+  (export "score-progress#get-storage" (func 25))
+  (export "score-progress#set-storage" (func 26))
+  (export "example" (func 27))
   (export "memory" (memory 0))
-  (func (;11;) (type 6)
+  (func (;15;) (type 6)
     (call 1
       (global.get 1))
     (block ;; label = @1
@@ -2830,10 +2834,10 @@ TypedProgram {
         (i32.ne
           (global.get 0)
           (i32.const 1)))
-      (return_call 14))
+      (return_call 18))
     (unreachable)
   )
-  (func (;12;) (type 7) (param i64 i64) (result i64)
+  (func (;16;) (type 7) (param i64 i64) (result i64)
     (local i64 i64 i64)
     (local.tee 2
       (i64.mul
@@ -2873,10 +2877,10 @@ TypedProgram {
           (then
             (unreachable)))))
   )
-  (func (;13;) (type 3) (param i32) (result i32)
+  (func (;17;) (type 4) (param i32) (result i32)
     (local i32)
     (local.set 1
-      (call 4
+      (call 8
         (i32.const 0)))
     (global.set 1
       (local.get 0))
@@ -2912,7 +2916,7 @@ TypedProgram {
       (i64.const -2683880554626369430))
     (local.get 1)
   )
-  (func (;14;) (type 6)
+  (func (;18;) (type 6)
     (local i32 i32)
     (local.set 0
       (global.get 4))
@@ -2922,14 +2926,14 @@ TypedProgram {
       (global.get 5))
     (global.set 5
       (i32.const 0))
-    (call 3
-      (call 12
+    (call 7
+      (call 16
         (global.get 2)
         (global.get 3)))
     (call 0
       (local.get 0))
   )
-  (func (;15;) (type 7) (param i64 i64) (result i64)
+  (func (;19;) (type 7) (param i64 i64) (result i64)
     (local i64)
     (local.tee 2
       (i64.add
@@ -2952,40 +2956,40 @@ TypedProgram {
       (then
         (unreachable)))
   )
-  (func (;16;) (type 5) (param i32 i64)
+  (func (;20;) (type 2) (param i32 i64)
     (global.set 2
-      (call 15
+      (call 19
         (global.get 2)
         (local.get 1)))
   )
-  (func (;17;) (type 5) (param i32 i64)
+  (func (;21;) (type 2) (param i32 i64)
     (global.set 3
-      (call 15
+      (call 19
         (global.get 3)
         (local.get 1)))
   )
-  (func (;18;) (type 5) (param i32 i64)
+  (func (;22;) (type 2) (param i32 i64)
     (global.set 3
       (i64.div_u
-        (call 12
+        (call 16
           (global.get 3)
           (local.get 1))
         (i64.const 100)))
   )
-  (func (;19;) (type 0) (param i32)
-    (return_call 11)
+  (func (;23;) (type 0) (param i32)
+    (return_call 15)
   )
-  (func (;20;) (type 8) (param i32) (result i32 i64 i64 i32 i32)
+  (func (;24;) (type 8) (param i32) (result i32 i64 i64 i32 i32)
     (global.get 0)
     (global.get 2)
     (global.get 3)
     (global.get 4)
     (global.get 5)
   )
-  (func (;21;) (type 3) (param i32) (result i32)
+  (func (;25;) (type 4) (param i32) (result i32)
     (local i32 i32 i64 i64 i32 i32)
     (i32.const 8)
-    (call 20
+    (call 24
       (local.get 0))
     (local.set 6)
     (local.set 5)
@@ -3010,7 +3014,7 @@ TypedProgram {
       (local.get 6))
     (i32.const 8)
   )
-  (func (;22;) (type 9) (param i32 i64 i64 i32 i32) (result i32)
+  (func (;26;) (type 9) (param i32 i64 i64 i32 i32) (result i32)
     (global.set 0
       (local.get 0))
     (global.set 2
@@ -3021,14 +3025,14 @@ TypedProgram {
       (local.get 3))
     (global.set 5
       (local.get 4))
-    (return_call 4
+    (return_call 8
       (i32.const 0))
   )
-  (func (;23;) (type 6)
+  (func (;27;) (type 6)
     (local i32)
     (local.set 0
-      (call 6))
-    (call 7
+      (call 10))
+    (call 11
       (local.get 0)
       (i64.const 10))
   )
@@ -3077,12 +3081,29 @@ TypedProgram {
               (type (;13;) (own 11))
               (type (;14;)
                 (instance
+                  (alias outer 1 1 (type (;0;)))
+                  (export (;1;) "s-utxo" (type (eq 0)))
+                  (type (;2;) (borrow 1))
+                  (type (;3;) (own 1))
+                  (type (;4;) (func (param "self" 2) (param "chips" u64)))
+                  (export (;0;) "plus-chips" (func (type 4)))
+                  (type (;5;) (func (param "self" 2) (param "mult" u64)))
+                  (export (;1;) "plus-mult" (func (type 5)))
+                  (type (;6;) (func (param "self" 2) (param "mult-pct" u64)))
+                  (export (;2;) "mult-mult" (func (type 6)))
+                  (type (;7;) (func (param "self" 2)))
+                  (export (;3;) "finish" (func (type 7)))
+                )
+              )
+              (import "starstream:contract/dynamic-utxo" (instance (;2;) (type 14)))
+              (type (;15;)
+                (instance
                   (type (;0;) (func (param "total" u64)))
                   (export (;0;) "finish" (func (type 0)))
                 )
               )
-              (import "starstream:events/score" (instance (;2;) (type 14)))
-              (type (;15;)
+              (import "starstream:events/score" (instance (;3;) (type 15)))
+              (type (;16;)
                 (instance
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
@@ -3099,12 +3120,12 @@ TypedProgram {
                   (export (;4;) "[method]utxo.finish" (func (type 7)))
                 )
               )
-              (import "starstream:self/score-progress" (instance (;3;) (type 15)))
-              (alias export 3 "utxo" (type (;16;)))
-              (import "u-score-progress" (type (;17;) (eq 16)))
-              (type (;18;) (borrow 17))
-              (type (;19;) (own 17))
-              (type (;20;)
+              (import "starstream:self/score-progress" (instance (;4;) (type 16)))
+              (alias export 4 "utxo" (type (;17;)))
+              (import "u-score-progress" (type (;18;) (eq 17)))
+              (type (;19;) (borrow 18))
+              (type (;20;) (own 18))
+              (type (;21;)
                 (instance
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
@@ -3131,9 +3152,9 @@ TypedProgram {
                   (export (;6;) "set-storage" (func (type 15)))
                 )
               )
-              (export (;4;) "score-progress" (instance (type 20)))
-              (type (;21;) (func))
-              (export (;0;) "example" (func (type 21)))
+              (export (;5;) "score-progress" (instance (type 21)))
+              (type (;22;) (func))
+              (export (;0;) "example" (func (type 22)))
             )
           )
           (export (;0;) "my-namespace:my-package/my-world" (component (type 0)))
@@ -3150,6 +3171,7 @@ package root:component;
 world root {
   import starstream:std/builtin;
   import starstream:std/utxo-context;
+  import starstream:contract/dynamic-utxo;
   import starstream:events/score;
   import starstream:self/score-progress;
   use starstream:std/builtin.{utxo as s-utxo, token as s-token};
@@ -3192,6 +3214,21 @@ package starstream:std {
       resume: func();
       implements-method: func(hash: tuple<u64, u64, u64, u64>);
     }
+  }
+}
+
+
+package starstream:contract {
+  interface dynamic-utxo {
+    use starstream:std/builtin.{utxo as s-utxo};
+
+    plus-chips: func(self: borrow<s-utxo>, chips: u64);
+
+    plus-mult: func(self: borrow<s-utxo>, mult: u64);
+
+    mult-mult: func(self: borrow<s-utxo>, mult-pct: u64);
+
+    finish: func(self: borrow<s-utxo>);
   }
 }
 

--- a/starstream-to-wasm/tests/snapshots/inputs@struct_definition.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@struct_definition.star.snap
@@ -119,6 +119,8 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
   (@custom "component-type"
     (component
       (@custom "wit-component-encoding" "\04\00")
@@ -131,9 +133,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -154,7 +159,8 @@ TypedProgram {
       )
       (export (;1;) "x" (type 0))
     )
-  ))
+  )
+)
 
 ==== WIT ====
 package root:component;
@@ -171,7 +177,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@struct_param.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@struct_param.star.snap
@@ -388,9 +388,11 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i64 i64) (result i64)))
-  (export "total-value" (func 1))
-  (func (;0;) (type 0) (param i64 i64) (result i64)
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i64 i64) (result i64)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (export "total-value" (func 2))
+  (func (;1;) (type 1) (param i64 i64) (result i64)
     (local i64 i64 i64)
     (local.tee 2
       (i64.mul
@@ -430,9 +432,9 @@ TypedProgram {
           (then
             (unreachable)))))
   )
-  (func (;1;) (type 0) (param i64 i64) (result i64)
+  (func (;2;) (type 1) (param i64 i64) (result i64)
     (local i64)
-    (call 0
+    (call 1
       (local.get 0)
       (drop
         (local.get 1))
@@ -454,9 +456,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -498,7 +503,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint.star.snap
@@ -381,36 +381,38 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32) (result i32)))
-  (type (;1;) (func (param i32)))
-  (type (;2;) (func (result i32)))
-  (type (;3;) (func (param i32 i32)))
-  (import "[export]my-token" "[resource-new]token" (func (;0;) (type 0)))
-  (import "[export]my-token" "[resource-drop]token" (func (;1;) (type 1)))
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32) (result i32)))
+  (type (;2;) (func (param i32)))
+  (type (;3;) (func (result i32)))
+  (type (;4;) (func (param i32 i32)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (import "[export]my-token" "[resource-new]token" (func (;1;) (type 1)))
+  (import "[export]my-token" "[resource-drop]token" (func (;2;) (type 2)))
   (global (;0;) (mut i32) (i32.const 0))
-  (export "my-token#[static]token.mint" (func 2))
-  (export "my-token#[method]token.attach" (func 3))
-  (export "my-token#[method]token.detach" (func 4))
-  (export "my-token#get-storage" (func 5))
-  (export "my-token#set-storage" (func 6))
-  (func (;2;) (type 2) (result i32)
+  (export "my-token#[static]token.mint" (func 3))
+  (export "my-token#[method]token.attach" (func 4))
+  (export "my-token#[method]token.detach" (func 5))
+  (export "my-token#get-storage" (func 6))
+  (export "my-token#set-storage" (func 7))
+  (func (;3;) (type 3) (result i32)
     (local i32)
     (local.set 0
-      (call 0
+      (call 1
         (i32.const 0)))
     (global.set 0
       (i32.const 1))
     (local.get 0)
   )
-  (func (;3;) (type 3) (param i32 i32))
-  (func (;4;) (type 3) (param i32 i32))
-  (func (;5;) (type 0) (param i32) (result i32)
+  (func (;4;) (type 4) (param i32 i32))
+  (func (;5;) (type 4) (param i32 i32))
+  (func (;6;) (type 1) (param i32) (result i32)
     (global.get 0)
   )
-  (func (;6;) (type 0) (param i32) (result i32)
+  (func (;7;) (type 1) (param i32) (result i32)
     (global.set 0
       (local.get 0))
-    (return_call 0
+    (return_call 1
       (i32.const 0))
   )
   (@custom "component-type"
@@ -425,9 +427,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -514,7 +519,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
@@ -570,24 +570,26 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32) (result i32)))
-  (type (;1;) (func (param i32)))
-  (type (;2;) (func (param i64 i64) (result i64)))
-  (type (;3;) (func (result i32)))
-  (type (;4;) (func))
-  (type (;5;) (func (param i32 i32)))
-  (type (;6;) (func (param i32) (result i64)))
-  (type (;7;) (func (param i64) (result i32)))
-  (import "[export]my-token" "[resource-new]token" (func (;0;) (type 0)))
-  (import "[export]my-token" "[resource-drop]token" (func (;1;) (type 1)))
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32) (result i32)))
+  (type (;2;) (func (param i32)))
+  (type (;3;) (func (param i64 i64) (result i64)))
+  (type (;4;) (func (result i32)))
+  (type (;5;) (func))
+  (type (;6;) (func (param i32 i32)))
+  (type (;7;) (func (param i32) (result i64)))
+  (type (;8;) (func (param i64) (result i32)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (import "[export]my-token" "[resource-new]token" (func (;1;) (type 1)))
+  (import "[export]my-token" "[resource-drop]token" (func (;2;) (type 2)))
   (global (;0;) (mut i64) (i64.const 0))
-  (export "my-token#[static]token.mint" (func 3))
-  (export "my-token#[static]token.burn" (func 5))
-  (export "my-token#[method]token.attach" (func 6))
-  (export "my-token#[method]token.detach" (func 7))
-  (export "my-token#get-storage" (func 8))
-  (export "my-token#set-storage" (func 9))
-  (func (;2;) (type 2) (param i64 i64) (result i64)
+  (export "my-token#[static]token.mint" (func 4))
+  (export "my-token#[static]token.burn" (func 6))
+  (export "my-token#[method]token.attach" (func 7))
+  (export "my-token#[method]token.detach" (func 8))
+  (export "my-token#get-storage" (func 9))
+  (export "my-token#set-storage" (func 10))
+  (func (;3;) (type 3) (param i64 i64) (result i64)
     (local i64)
     (local.tee 2
       (i64.add
@@ -610,18 +612,18 @@ TypedProgram {
       (then
         (unreachable)))
   )
-  (func (;3;) (type 3) (result i32)
+  (func (;4;) (type 4) (result i32)
     (local i32)
     (local.set 0
-      (call 0
+      (call 1
         (i32.const 0)))
     (global.set 0
-      (call 2
+      (call 3
         (global.get 0)
         (i64.const 1)))
     (local.get 0)
   )
-  (func (;4;) (type 2) (param i64 i64) (result i64)
+  (func (;5;) (type 3) (param i64 i64) (result i64)
     (local i64)
     (local.tee 2
       (i64.sub
@@ -644,21 +646,21 @@ TypedProgram {
       (then
         (unreachable)))
   )
-  (func (;5;) (type 4)
+  (func (;6;) (type 5)
     (global.set 0
-      (call 4
+      (call 5
         (global.get 0)
         (i64.const 1)))
   )
-  (func (;6;) (type 5) (param i32 i32))
-  (func (;7;) (type 5) (param i32 i32))
-  (func (;8;) (type 6) (param i32) (result i64)
+  (func (;7;) (type 6) (param i32 i32))
+  (func (;8;) (type 6) (param i32 i32))
+  (func (;9;) (type 7) (param i32) (result i64)
     (global.get 0)
   )
-  (func (;9;) (type 7) (param i64) (result i32)
+  (func (;10;) (type 8) (param i64) (result i32)
     (global.set 0
       (local.get 0))
-    (return_call 0
+    (return_call 1
       (i32.const 0))
   )
   (@custom "component-type"
@@ -673,9 +675,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -765,7 +770,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@tuple.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@tuple.star.snap
@@ -1589,13 +1589,15 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i64 i32) (result i32 i64)))
-  (type (;1;) (func (param i64 i64) (result i64)))
-  (type (;2;) (func (param i64 i64 i32) (result i64)))
-  (type (;3;) (func (result i64)))
-  (type (;4;) (func))
-  (export "run-tuples" (func 4))
-  (func (;0;) (type 0) (param i64 i32) (result i32 i64)
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i64 i32) (result i32 i64)))
+  (type (;2;) (func (param i64 i64) (result i64)))
+  (type (;3;) (func (param i64 i64 i32) (result i64)))
+  (type (;4;) (func (result i64)))
+  (type (;5;) (func))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (export "run-tuples" (func 5))
+  (func (;1;) (type 1) (param i64 i32) (result i32 i64)
     (local i64 i32 i32 i64)
     (local.set 2
       (local.get 0)
@@ -1608,7 +1610,7 @@ TypedProgram {
     (local.get 4)
     (local.get 5)
   )
-  (func (;1;) (type 1) (param i64 i64) (result i64)
+  (func (;2;) (type 2) (param i64 i64) (result i64)
     (local i64)
     (local.tee 2
       (i64.add
@@ -1631,7 +1633,7 @@ TypedProgram {
       (then
         (unreachable)))
   )
-  (func (;2;) (type 2) (param i64 i64 i32) (result i64)
+  (func (;3;) (type 3) (param i64 i64 i32) (result i64)
     (local i64 i64 i32)
     (block (result i64) ;; label = @1
       (block ;; label = @2
@@ -1650,15 +1652,15 @@ TypedProgram {
           (unreachable))
         (br 1 (;@1;)
           (local.get 3)))
-      (call 1
+      (call 2
         (local.get 3)
         (local.get 4)))
   )
-  (func (;3;) (type 3) (result i64)
+  (func (;4;) (type 4) (result i64)
     (local i32 i64)
     (block (result i64) ;; label = @1
       (block ;; label = @2
-        (call 0
+        (call 1
           (i64.const 1)
           (i32.const 1))
         (local.set 1)
@@ -1674,11 +1676,11 @@ TypedProgram {
           (i64.const 0)))
       (local.get 1))
   )
-  (func (;4;) (type 4)
+  (func (;5;) (type 5)
     (drop
-      (call 3))
+      (call 4))
     (drop
-      (call 2
+      (call 3
         (i64.const 1)
         (i64.const 2)
         (i32.const 1)))
@@ -1695,9 +1697,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -1732,7 +1737,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
@@ -323,50 +323,52 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32)))
-  (type (;1;) (func (param i32 i64 i64 i64 i64)))
-  (type (;2;) (func))
-  (type (;3;) (func (param i32) (result i32)))
-  (type (;4;) (func (result i32)))
-  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;0;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;1;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;2;) (type 1)))
-  (import "starstream:events/foo-abi" "hello-event" (func (;3;) (type 2)))
-  (import "[export]my-utxo" "[resource-new]utxo" (func (;4;) (type 3)))
-  (import "[export]my-utxo" "[resource-drop]utxo" (func (;5;) (type 0)))
-  (import "starstream:self/my-utxo" "[static]utxo.hello-utxo" (func (;6;) (type 4)))
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32)))
+  (type (;2;) (func (param i32 i64 i64 i64 i64)))
+  (type (;3;) (func))
+  (type (;4;) (func (param i32) (result i32)))
+  (type (;5;) (func (result i32)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;3;) (type 2)))
+  (import "starstream:events/foo-abi" "hello-event" (func (;4;) (type 3)))
+  (import "[export]my-utxo" "[resource-new]utxo" (func (;5;) (type 4)))
+  (import "[export]my-utxo" "[resource-drop]utxo" (func (;6;) (type 1)))
+  (import "starstream:self/my-utxo" "[static]utxo.hello-utxo" (func (;7;) (type 5)))
   (global (;0;) (mut i32) (i32.const 0))
   (global (;1;) (mut i32) (i32.const 0))
-  (export "my-utxo#[static]utxo.hello-utxo" (func 9))
-  (export "my-utxo#get-storage" (func 10))
-  (export "my-utxo#set-storage" (func 11))
-  (func (;7;) (type 2)
-    (call 1
+  (export "my-utxo#[static]utxo.hello-utxo" (func 10))
+  (export "my-utxo#get-storage" (func 11))
+  (export "my-utxo#set-storage" (func 12))
+  (func (;8;) (type 3)
+    (call 2
       (global.get 1))
     (unreachable)
   )
-  (func (;8;) (type 2)
-    (call 3)
+  (func (;9;) (type 3)
+    (call 4)
   )
-  (func (;9;) (type 3) (param i32) (result i32)
+  (func (;10;) (type 4) (param i32) (result i32)
     (local i32)
     (local.set 1
-      (call 4
+      (call 5
         (i32.const 0)))
     (global.set 1
       (local.get 0))
-    (call 8)
-    (call 0
+    (call 9)
+    (call 1
       (local.get 0))
     (local.get 1)
   )
-  (func (;10;) (type 3) (param i32) (result i32)
+  (func (;11;) (type 4) (param i32) (result i32)
     (global.get 0)
   )
-  (func (;11;) (type 3) (param i32) (result i32)
+  (func (;12;) (type 4) (param i32) (result i32)
     (global.set 0
       (local.get 0))
-    (return_call 4
+    (return_call 5
       (i32.const 0))
   )
   (@custom "component-type"
@@ -381,9 +383,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -493,7 +498,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
@@ -296,28 +296,29 @@ TypedProgram {
   (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;0;) (type 0)))
   (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;1;) (type 0)))
   (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;2;) (type 1)))
-  (import "[export]my-utxo" "[resource-new]utxo" (func (;3;) (type 2)))
-  (import "[export]my-utxo" "[resource-drop]utxo" (func (;4;) (type 0)))
+  (import "starstream:contract/dynamic-utxo" "hello" (func (;3;) (type 2)))
+  (import "[export]my-utxo" "[resource-new]utxo" (func (;4;) (type 2)))
+  (import "[export]my-utxo" "[resource-drop]utxo" (func (;5;) (type 0)))
   (global (;0;) (mut i32) (i32.const 0))
   (global (;1;) (mut i32) (i32.const 0))
-  (export "my-utxo#[method]utxo.hello" (func 6))
-  (export "my-utxo#get-storage" (func 7))
-  (export "my-utxo#set-storage" (func 8))
-  (func (;5;) (type 3)
+  (export "my-utxo#[method]utxo.hello" (func 7))
+  (export "my-utxo#get-storage" (func 8))
+  (export "my-utxo#set-storage" (func 9))
+  (func (;6;) (type 3)
     (call 1
       (global.get 1))
     (unreachable)
   )
-  (func (;6;) (type 2) (param i32) (result i32)
+  (func (;7;) (type 2) (param i32) (result i32)
     (i32.const 17)
   )
-  (func (;7;) (type 2) (param i32) (result i32)
+  (func (;8;) (type 2) (param i32) (result i32)
     (global.get 0)
   )
-  (func (;8;) (type 2) (param i32) (result i32)
+  (func (;9;) (type 2) (param i32) (result i32)
     (global.set 0
       (local.get 0))
-    (return_call 3
+    (return_call 4
       (i32.const 0))
   )
   (@custom "component-type"
@@ -365,17 +366,28 @@ TypedProgram {
               (type (;13;) (own 11))
               (type (;14;)
                 (instance
+                  (alias outer 1 1 (type (;0;)))
+                  (export (;1;) "s-utxo" (type (eq 0)))
+                  (type (;2;) (borrow 1))
+                  (type (;3;) (own 1))
+                  (type (;4;) (func (param "self" 2) (result s32)))
+                  (export (;0;) "hello" (func (type 4)))
+                )
+              )
+              (import "starstream:contract/dynamic-utxo" (instance (;2;) (type 14)))
+              (type (;15;)
+                (instance
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
                 )
               )
-              (import "starstream:self/my-utxo" (instance (;2;) (type 14)))
-              (alias export 2 "utxo" (type (;15;)))
-              (import "u-my-utxo" (type (;16;) (eq 15)))
-              (type (;17;) (borrow 16))
-              (type (;18;) (own 16))
-              (type (;19;)
+              (import "starstream:self/my-utxo" (instance (;3;) (type 15)))
+              (alias export 3 "utxo" (type (;16;)))
+              (import "u-my-utxo" (type (;17;) (eq 16)))
+              (type (;18;) (borrow 17))
+              (type (;19;) (own 17))
+              (type (;20;)
                 (instance
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
@@ -390,7 +402,7 @@ TypedProgram {
                   (export (;2;) "set-storage" (func (type 7)))
                 )
               )
-              (export (;3;) "my-utxo" (instance (type 19)))
+              (export (;4;) "my-utxo" (instance (type 20)))
             )
           )
           (export (;0;) "my-namespace:my-package/my-world" (component (type 0)))
@@ -407,6 +419,7 @@ package root:component;
 world root {
   import starstream:std/builtin;
   import starstream:std/utxo-context;
+  import starstream:contract/dynamic-utxo;
   import starstream:self/my-utxo;
   use starstream:std/builtin.{utxo as s-utxo, token as s-token};
   use starstream:std/utxo-context.{utxo-context as s-utxo-context};
@@ -437,6 +450,15 @@ package starstream:std {
       resume: func();
       implements-method: func(hash: tuple<u64, u64, u64, u64>);
     }
+  }
+}
+
+
+package starstream:contract {
+  interface dynamic-utxo {
+    use starstream:std/builtin.{utxo as s-utxo};
+
+    hello: func(self: borrow<s-utxo>) -> s32;
   }
 }
 

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
@@ -289,36 +289,38 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32)))
-  (type (;1;) (func (param i32 i64 i64 i64 i64)))
-  (type (;2;) (func (param i32) (result i32)))
-  (type (;3;) (func))
-  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;0;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;1;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;2;) (type 1)))
-  (import "starstream:contract/dynamic-utxo" "hello" (func (;3;) (type 2)))
-  (import "[export]my-utxo" "[resource-new]utxo" (func (;4;) (type 2)))
-  (import "[export]my-utxo" "[resource-drop]utxo" (func (;5;) (type 0)))
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32)))
+  (type (;2;) (func (param i32 i64 i64 i64 i64)))
+  (type (;3;) (func (param i32) (result i32)))
+  (type (;4;) (func))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;3;) (type 2)))
+  (import "starstream:contract/dynamic-utxo" "hello" (func (;4;) (type 3)))
+  (import "[export]my-utxo" "[resource-new]utxo" (func (;5;) (type 3)))
+  (import "[export]my-utxo" "[resource-drop]utxo" (func (;6;) (type 1)))
   (global (;0;) (mut i32) (i32.const 0))
   (global (;1;) (mut i32) (i32.const 0))
-  (export "my-utxo#[method]utxo.hello" (func 7))
-  (export "my-utxo#get-storage" (func 8))
-  (export "my-utxo#set-storage" (func 9))
-  (func (;6;) (type 3)
-    (call 1
+  (export "my-utxo#[method]utxo.hello" (func 8))
+  (export "my-utxo#get-storage" (func 9))
+  (export "my-utxo#set-storage" (func 10))
+  (func (;7;) (type 4)
+    (call 2
       (global.get 1))
     (unreachable)
   )
-  (func (;7;) (type 2) (param i32) (result i32)
+  (func (;8;) (type 3) (param i32) (result i32)
     (i32.const 17)
   )
-  (func (;8;) (type 2) (param i32) (result i32)
+  (func (;9;) (type 3) (param i32) (result i32)
     (global.get 0)
   )
-  (func (;9;) (type 2) (param i32) (result i32)
+  (func (;10;) (type 3) (param i32) (result i32)
     (global.set 0
       (local.get 0))
-    (return_call 4
+    (return_call 5
       (i32.const 0))
   )
   (@custom "component-type"
@@ -333,9 +335,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -441,7 +446,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
@@ -216,47 +216,49 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32)))
-  (type (;1;) (func (param i32 i64 i64 i64 i64)))
-  (type (;2;) (func))
-  (type (;3;) (func (param i32) (result i32)))
-  (type (;4;) (func (result i32)))
-  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;0;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;1;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;2;) (type 1)))
-  (import "starstream:events/foo-abi" "hello-event" (func (;3;) (type 2)))
-  (import "[export]my-utxo" "[resource-new]utxo" (func (;4;) (type 3)))
-  (import "[export]my-utxo" "[resource-drop]utxo" (func (;5;) (type 0)))
-  (import "starstream:self/my-utxo" "[static]utxo.hello-utxo" (func (;6;) (type 4)))
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32)))
+  (type (;2;) (func (param i32 i64 i64 i64 i64)))
+  (type (;3;) (func))
+  (type (;4;) (func (param i32) (result i32)))
+  (type (;5;) (func (result i32)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;3;) (type 2)))
+  (import "starstream:events/foo-abi" "hello-event" (func (;4;) (type 3)))
+  (import "[export]my-utxo" "[resource-new]utxo" (func (;5;) (type 4)))
+  (import "[export]my-utxo" "[resource-drop]utxo" (func (;6;) (type 1)))
+  (import "starstream:self/my-utxo" "[static]utxo.hello-utxo" (func (;7;) (type 5)))
   (global (;0;) (mut i32) (i32.const 0))
   (global (;1;) (mut i32) (i32.const 0))
-  (export "my-utxo#[static]utxo.hello-utxo" (func 8))
-  (export "my-utxo#get-storage" (func 9))
-  (export "my-utxo#set-storage" (func 10))
-  (func (;7;) (type 2)
-    (call 1
+  (export "my-utxo#[static]utxo.hello-utxo" (func 9))
+  (export "my-utxo#get-storage" (func 10))
+  (export "my-utxo#set-storage" (func 11))
+  (func (;8;) (type 3)
+    (call 2
       (global.get 1))
     (unreachable)
   )
-  (func (;8;) (type 3) (param i32) (result i32)
+  (func (;9;) (type 4) (param i32) (result i32)
     (local i32)
     (local.set 1
-      (call 4
+      (call 5
         (i32.const 0)))
     (global.set 1
       (local.get 0))
-    (call 3)
-    (call 0
+    (call 4)
+    (call 1
       (local.get 0))
     (local.get 1)
   )
-  (func (;9;) (type 3) (param i32) (result i32)
+  (func (;10;) (type 4) (param i32) (result i32)
     (global.get 0)
   )
-  (func (;10;) (type 3) (param i32) (result i32)
+  (func (;11;) (type 4) (param i32) (result i32)
     (global.set 0
       (local.get 0))
-    (return_call 4
+    (return_call 5
       (i32.const 0))
   )
   (@custom "component-type"
@@ -271,9 +273,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -383,7 +388,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_nothing.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_nothing.star.snap
@@ -47,31 +47,33 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32)))
-  (type (;1;) (func (param i32 i64 i64 i64 i64)))
-  (type (;2;) (func (param i32) (result i32)))
-  (type (;3;) (func))
-  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;0;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;1;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;2;) (type 1)))
-  (import "[export]my-utxo" "[resource-new]utxo" (func (;3;) (type 2)))
-  (import "[export]my-utxo" "[resource-drop]utxo" (func (;4;) (type 0)))
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32)))
+  (type (;2;) (func (param i32 i64 i64 i64 i64)))
+  (type (;3;) (func (param i32) (result i32)))
+  (type (;4;) (func))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;3;) (type 2)))
+  (import "[export]my-utxo" "[resource-new]utxo" (func (;4;) (type 3)))
+  (import "[export]my-utxo" "[resource-drop]utxo" (func (;5;) (type 1)))
   (global (;0;) (mut i32) (i32.const 0))
   (global (;1;) (mut i32) (i32.const 0))
-  (export "my-utxo#get-storage" (func 6))
-  (export "my-utxo#set-storage" (func 7))
-  (func (;5;) (type 3)
-    (call 1
+  (export "my-utxo#get-storage" (func 7))
+  (export "my-utxo#set-storage" (func 8))
+  (func (;6;) (type 4)
+    (call 2
       (global.get 1))
     (unreachable)
   )
-  (func (;6;) (type 2) (param i32) (result i32)
+  (func (;7;) (type 3) (param i32) (result i32)
     (global.get 0)
   )
-  (func (;7;) (type 2) (param i32) (result i32)
+  (func (;8;) (type 3) (param i32) (result i32)
     (global.set 0
       (local.get 0))
-    (return_call 3
+    (return_call 4
       (i32.const 0))
   )
   (@custom "component-type"
@@ -86,9 +88,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -178,7 +183,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
@@ -387,37 +387,39 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32)))
-  (type (;1;) (func (param i32 i64 i64 i64 i64)))
-  (type (;2;) (func (param i32) (result i32)))
-  (type (;3;) (func (result i32)))
-  (type (;4;) (func))
-  (type (;5;) (func (param i64 i64) (result i64)))
-  (type (;6;) (func (param i32) (result i32 i64 i64)))
-  (type (;7;) (func (param i32 i64 i64) (result i32)))
-  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;0;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;1;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;2;) (type 1)))
-  (import "[export]my-utxo" "[resource-new]utxo" (func (;3;) (type 2)))
-  (import "[export]my-utxo" "[resource-drop]utxo" (func (;4;) (type 0)))
-  (import "starstream:self/my-utxo" "[static]utxo.increment" (func (;5;) (type 3)))
-  (import "starstream:self/my-utxo" "[static]utxo.increment-mult" (func (;6;) (type 3)))
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32)))
+  (type (;2;) (func (param i32 i64 i64 i64 i64)))
+  (type (;3;) (func (param i32) (result i32)))
+  (type (;4;) (func (result i32)))
+  (type (;5;) (func))
+  (type (;6;) (func (param i64 i64) (result i64)))
+  (type (;7;) (func (param i32) (result i32 i64 i64)))
+  (type (;8;) (func (param i32 i64 i64) (result i32)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;3;) (type 2)))
+  (import "[export]my-utxo" "[resource-new]utxo" (func (;4;) (type 3)))
+  (import "[export]my-utxo" "[resource-drop]utxo" (func (;5;) (type 1)))
+  (import "starstream:self/my-utxo" "[static]utxo.increment" (func (;6;) (type 4)))
+  (import "starstream:self/my-utxo" "[static]utxo.increment-mult" (func (;7;) (type 4)))
   (memory (;0;) 1)
   (global (;0;) (mut i32) (i32.const 0))
   (global (;1;) (mut i32) (i32.const 0))
   (global (;2;) (mut i64) (i64.const 0))
   (global (;3;) (mut i64) (i64.const 0))
-  (export "my-utxo#[static]utxo.increment" (func 9))
-  (export "my-utxo#[static]utxo.increment-mult" (func 10))
-  (export "my-utxo#get-storage" (func 12))
-  (export "my-utxo#set-storage" (func 13))
+  (export "my-utxo#[static]utxo.increment" (func 10))
+  (export "my-utxo#[static]utxo.increment-mult" (func 11))
+  (export "my-utxo#get-storage" (func 13))
+  (export "my-utxo#set-storage" (func 14))
   (export "memory" (memory 0))
-  (func (;7;) (type 4)
-    (call 1
+  (func (;8;) (type 5)
+    (call 2
       (global.get 1))
     (unreachable)
   )
-  (func (;8;) (type 5) (param i64 i64) (result i64)
+  (func (;9;) (type 6) (param i64 i64) (result i64)
     (local i64)
     (local.tee 2
       (i64.add
@@ -440,45 +442,45 @@ TypedProgram {
       (then
         (unreachable)))
   )
-  (func (;9;) (type 2) (param i32) (result i32)
+  (func (;10;) (type 3) (param i32) (result i32)
     (local i32)
     (local.set 1
-      (call 3
+      (call 4
         (i32.const 0)))
     (global.set 1
       (local.get 0))
     (global.set 2
-      (call 8
+      (call 9
         (global.get 2)
         (i64.const 1)))
-    (call 0
+    (call 1
       (local.get 0))
     (local.get 1)
   )
-  (func (;10;) (type 2) (param i32) (result i32)
+  (func (;11;) (type 3) (param i32) (result i32)
     (local i32)
     (local.set 1
-      (call 3
+      (call 4
         (i32.const 0)))
     (global.set 1
       (local.get 0))
     (global.set 3
-      (call 8
+      (call 9
         (global.get 3)
         (i64.const 1)))
-    (call 0
+    (call 1
       (local.get 0))
     (local.get 1)
   )
-  (func (;11;) (type 6) (param i32) (result i32 i64 i64)
+  (func (;12;) (type 7) (param i32) (result i32 i64 i64)
     (global.get 0)
     (global.get 2)
     (global.get 3)
   )
-  (func (;12;) (type 2) (param i32) (result i32)
+  (func (;13;) (type 3) (param i32) (result i32)
     (local i32 i32 i64 i64)
     (i32.const 8)
-    (call 11
+    (call 12
       (local.get 0))
     (local.set 4)
     (local.set 3)
@@ -495,14 +497,14 @@ TypedProgram {
       (local.get 4))
     (i32.const 8)
   )
-  (func (;13;) (type 7) (param i32 i64 i64) (result i32)
+  (func (;14;) (type 8) (param i32 i64 i64) (result i32)
     (global.set 0
       (local.get 0))
     (global.set 2
       (local.get 1))
     (global.set 3
       (local.get 2))
-    (return_call 3
+    (return_call 4
       (i32.const 0))
   )
   (@custom "component-type"
@@ -517,9 +519,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -628,7 +633,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
@@ -156,36 +156,38 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32)))
-  (type (;1;) (func (param i32 i64 i64 i64 i64)))
-  (type (;2;) (func (param i32) (result i32)))
-  (type (;3;) (func))
-  (type (;4;) (func (param i32 i32)))
-  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;0;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;1;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;2;) (type 1)))
-  (import "[export]my-utxo" "[resource-new]utxo" (func (;3;) (type 2)))
-  (import "[export]my-utxo" "[resource-drop]utxo" (func (;4;) (type 0)))
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32)))
+  (type (;2;) (func (param i32 i64 i64 i64 i64)))
+  (type (;3;) (func (param i32) (result i32)))
+  (type (;4;) (func))
+  (type (;5;) (func (param i32 i32)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;3;) (type 2)))
+  (import "[export]my-utxo" "[resource-new]utxo" (func (;4;) (type 3)))
+  (import "[export]my-utxo" "[resource-drop]utxo" (func (;5;) (type 1)))
   (global (;0;) (mut i32) (i32.const 0))
   (global (;1;) (mut i32) (i32.const 0))
-  (export "my-utxo#get-storage" (func 6))
-  (export "my-utxo#set-storage" (func 7))
-  (export "script-accepts-utxos" (func 8))
-  (func (;5;) (type 3)
-    (call 1
+  (export "my-utxo#get-storage" (func 7))
+  (export "my-utxo#set-storage" (func 8))
+  (export "script-accepts-utxos" (func 9))
+  (func (;6;) (type 4)
+    (call 2
       (global.get 1))
     (unreachable)
   )
-  (func (;6;) (type 2) (param i32) (result i32)
+  (func (;7;) (type 3) (param i32) (result i32)
     (global.get 0)
   )
-  (func (;7;) (type 2) (param i32) (result i32)
+  (func (;8;) (type 3) (param i32) (result i32)
     (global.set 0
       (local.get 0))
-    (return_call 3
+    (return_call 4
       (i32.const 0))
   )
-  (func (;8;) (type 4) (param i32 i32))
+  (func (;9;) (type 5) (param i32 i32))
   (@custom "component-type"
     (component
       (@custom "wit-component-encoding" "\04\00")
@@ -198,9 +200,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -293,7 +298,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@while_simple.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@while_simple.star.snap
@@ -309,10 +309,12 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i64 i64) (result i64)))
-  (type (;1;) (func))
-  (export "main" (func 1))
-  (func (;0;) (type 0) (param i64 i64) (result i64)
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i64 i64) (result i64)))
+  (type (;2;) (func))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (export "main" (func 2))
+  (func (;1;) (type 1) (param i64 i64) (result i64)
     (local i64)
     (local.tee 2
       (i64.add
@@ -335,7 +337,7 @@ TypedProgram {
       (then
         (unreachable)))
   )
-  (func (;1;) (type 1)
+  (func (;2;) (type 2)
     (local i64)
     (local.set 0
       (i64.const 0))
@@ -347,7 +349,7 @@ TypedProgram {
               (local.get 0)
               (i64.const 10))))
         (local.set 0
-          (call 0
+          (call 1
             (local.get 0)
             (i64.const 1)))
         (br 0 (;@2;))))
@@ -364,9 +366,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -401,7 +406,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
@@ -405,22 +405,23 @@ TypedProgram {
   (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;0;) (type 0)))
   (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;1;) (type 0)))
   (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;2;) (type 1)))
-  (import "[export]my-utxo" "[resource-new]utxo" (func (;3;) (type 2)))
-  (import "[export]my-utxo" "[resource-drop]utxo" (func (;4;) (type 0)))
-  (import "starstream:self/my-utxo" "[static]utxo.hello-utxo" (func (;5;) (type 2)))
-  (import "starstream:self/my-utxo" "[method]utxo.foo" (func (;6;) (type 0)))
+  (import "starstream:contract/dynamic-utxo" "foo" (func (;3;) (type 0)))
+  (import "[export]my-utxo" "[resource-new]utxo" (func (;4;) (type 2)))
+  (import "[export]my-utxo" "[resource-drop]utxo" (func (;5;) (type 0)))
+  (import "starstream:self/my-utxo" "[static]utxo.hello-utxo" (func (;6;) (type 2)))
+  (import "starstream:self/my-utxo" "[method]utxo.foo" (func (;7;) (type 0)))
   (memory (;0;) 1)
   (global (;0;) (mut i32) (i32.const 0))
   (global (;1;) (mut i32) (i32.const 0))
   (global (;2;) (mut i32) (i32.const 0))
   (global (;3;) (mut i32) (i32.const 0))
   (global (;4;) (mut i32) (i32.const 0))
-  (export "my-utxo#[static]utxo.hello-utxo" (func 8))
-  (export "my-utxo#[method]utxo.foo" (func 10))
-  (export "my-utxo#get-storage" (func 12))
-  (export "my-utxo#set-storage" (func 13))
+  (export "my-utxo#[static]utxo.hello-utxo" (func 9))
+  (export "my-utxo#[method]utxo.foo" (func 11))
+  (export "my-utxo#get-storage" (func 13))
+  (export "my-utxo#set-storage" (func 14))
   (export "memory" (memory 0))
-  (func (;7;) (type 3)
+  (func (;8;) (type 3)
     (call 1
       (global.get 1))
     (block ;; label = @1
@@ -428,13 +429,13 @@ TypedProgram {
         (i32.ne
           (global.get 0)
           (i32.const 1)))
-      (return_call 9))
+      (return_call 10))
     (unreachable)
   )
-  (func (;8;) (type 4) (param i32 i32) (result i32)
+  (func (;9;) (type 4) (param i32 i32) (result i32)
     (local i32)
     (local.set 2
-      (call 3
+      (call 4
         (i32.const 0)))
     (global.set 1
       (local.get 0))
@@ -454,7 +455,7 @@ TypedProgram {
       (i64.const -5843589418109203719))
     (local.get 2)
   )
-  (func (;9;) (type 3)
+  (func (;10;) (type 3)
     (local i32 i32 i32)
     (local.set 0
       (global.get 2))
@@ -471,19 +472,19 @@ TypedProgram {
     (call 0
       (local.get 0))
   )
-  (func (;10;) (type 0) (param i32)
-    (return_call 7)
+  (func (;11;) (type 0) (param i32)
+    (return_call 8)
   )
-  (func (;11;) (type 5) (param i32) (result i32 i32 i32 i32)
+  (func (;12;) (type 5) (param i32) (result i32 i32 i32 i32)
     (global.get 0)
     (global.get 2)
     (global.get 3)
     (global.get 4)
   )
-  (func (;12;) (type 2) (param i32) (result i32)
+  (func (;13;) (type 2) (param i32) (result i32)
     (local i32 i32 i32 i32 i32)
     (i32.const 4)
-    (call 11
+    (call 12
       (local.get 0))
     (local.set 5)
     (local.set 4)
@@ -504,7 +505,7 @@ TypedProgram {
       (local.get 5))
     (i32.const 4)
   )
-  (func (;13;) (type 6) (param i32 i32 i32 i32) (result i32)
+  (func (;14;) (type 6) (param i32 i32 i32 i32) (result i32)
     (global.set 0
       (local.get 0))
     (global.set 2
@@ -513,7 +514,7 @@ TypedProgram {
       (local.get 2))
     (global.set 4
       (local.get 3))
-    (return_call 3
+    (return_call 4
       (i32.const 0))
   )
   (@custom "component-type"
@@ -561,6 +562,17 @@ TypedProgram {
               (type (;13;) (own 11))
               (type (;14;)
                 (instance
+                  (alias outer 1 1 (type (;0;)))
+                  (export (;1;) "s-utxo" (type (eq 0)))
+                  (type (;2;) (borrow 1))
+                  (type (;3;) (own 1))
+                  (type (;4;) (func (param "self" 2)))
+                  (export (;0;) "foo" (func (type 4)))
+                )
+              )
+              (import "starstream:contract/dynamic-utxo" (instance (;2;) (type 14)))
+              (type (;15;)
+                (instance
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
@@ -570,12 +582,12 @@ TypedProgram {
                   (export (;1;) "[method]utxo.foo" (func (type 4)))
                 )
               )
-              (import "starstream:self/my-utxo" (instance (;2;) (type 14)))
-              (alias export 2 "utxo" (type (;15;)))
-              (import "u-my-utxo" (type (;16;) (eq 15)))
-              (type (;17;) (borrow 16))
-              (type (;18;) (own 16))
-              (type (;19;)
+              (import "starstream:self/my-utxo" (instance (;3;) (type 15)))
+              (alias export 3 "utxo" (type (;16;)))
+              (import "u-my-utxo" (type (;17;) (eq 16)))
+              (type (;18;) (borrow 17))
+              (type (;19;) (own 17))
+              (type (;20;)
                 (instance
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
@@ -596,7 +608,7 @@ TypedProgram {
                   (export (;3;) "set-storage" (func (type 12)))
                 )
               )
-              (export (;3;) "my-utxo" (instance (type 19)))
+              (export (;4;) "my-utxo" (instance (type 20)))
             )
           )
           (export (;0;) "my-namespace:my-package/my-world" (component (type 0)))
@@ -613,6 +625,7 @@ package root:component;
 world root {
   import starstream:std/builtin;
   import starstream:std/utxo-context;
+  import starstream:contract/dynamic-utxo;
   import starstream:self/my-utxo;
   use starstream:std/builtin.{utxo as s-utxo, token as s-token};
   use starstream:std/utxo-context.{utxo-context as s-utxo-context};
@@ -649,6 +662,15 @@ package starstream:std {
       resume: func();
       implements-method: func(hash: tuple<u64, u64, u64, u64>);
     }
+  }
+}
+
+
+package starstream:contract {
+  interface dynamic-utxo {
+    use starstream:std/builtin.{utxo as s-utxo};
+
+    foo: func(self: borrow<s-utxo>);
   }
 }
 

--- a/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
@@ -395,47 +395,49 @@ TypedProgram {
 
 ==== Core WebAssembly ====
 (module
-  (type (;0;) (func (param i32)))
-  (type (;1;) (func (param i32 i64 i64 i64 i64)))
-  (type (;2;) (func (param i32) (result i32)))
-  (type (;3;) (func))
-  (type (;4;) (func (param i32 i32) (result i32)))
-  (type (;5;) (func (param i32) (result i32 i32 i32 i32)))
-  (type (;6;) (func (param i32 i32 i32 i32) (result i32)))
-  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;0;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;1;) (type 0)))
-  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;2;) (type 1)))
-  (import "starstream:contract/dynamic-utxo" "foo" (func (;3;) (type 0)))
-  (import "[export]my-utxo" "[resource-new]utxo" (func (;4;) (type 2)))
-  (import "[export]my-utxo" "[resource-drop]utxo" (func (;5;) (type 0)))
-  (import "starstream:self/my-utxo" "[static]utxo.hello-utxo" (func (;6;) (type 2)))
-  (import "starstream:self/my-utxo" "[method]utxo.foo" (func (;7;) (type 0)))
+  (type (;0;) (func (param i32 i64 i64 i64 i64) (result i32)))
+  (type (;1;) (func (param i32)))
+  (type (;2;) (func (param i32 i64 i64 i64 i64)))
+  (type (;3;) (func (param i32) (result i32)))
+  (type (;4;) (func))
+  (type (;5;) (func (param i32 i32) (result i32)))
+  (type (;6;) (func (param i32) (result i32 i32 i32 i32)))
+  (type (;7;) (func (param i32 i32 i32 i32) (result i32)))
+  (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
+  (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
+  (import "starstream:std/utxo-context" "[method]utxo-context.implements-method" (func (;3;) (type 2)))
+  (import "starstream:contract/dynamic-utxo" "foo" (func (;4;) (type 1)))
+  (import "[export]my-utxo" "[resource-new]utxo" (func (;5;) (type 3)))
+  (import "[export]my-utxo" "[resource-drop]utxo" (func (;6;) (type 1)))
+  (import "starstream:self/my-utxo" "[static]utxo.hello-utxo" (func (;7;) (type 3)))
+  (import "starstream:self/my-utxo" "[method]utxo.foo" (func (;8;) (type 1)))
   (memory (;0;) 1)
   (global (;0;) (mut i32) (i32.const 0))
   (global (;1;) (mut i32) (i32.const 0))
   (global (;2;) (mut i32) (i32.const 0))
   (global (;3;) (mut i32) (i32.const 0))
   (global (;4;) (mut i32) (i32.const 0))
-  (export "my-utxo#[static]utxo.hello-utxo" (func 9))
-  (export "my-utxo#[method]utxo.foo" (func 11))
-  (export "my-utxo#get-storage" (func 13))
-  (export "my-utxo#set-storage" (func 14))
+  (export "my-utxo#[static]utxo.hello-utxo" (func 10))
+  (export "my-utxo#[method]utxo.foo" (func 12))
+  (export "my-utxo#get-storage" (func 14))
+  (export "my-utxo#set-storage" (func 15))
   (export "memory" (memory 0))
-  (func (;8;) (type 3)
-    (call 1
+  (func (;9;) (type 4)
+    (call 2
       (global.get 1))
     (block ;; label = @1
       (br_if 0 (;@1;)
         (i32.ne
           (global.get 0)
           (i32.const 1)))
-      (return_call 10))
+      (return_call 11))
     (unreachable)
   )
-  (func (;9;) (type 4) (param i32 i32) (result i32)
+  (func (;10;) (type 5) (param i32 i32) (result i32)
     (local i32)
     (local.set 2
-      (call 4
+      (call 5
         (i32.const 0)))
     (global.set 1
       (local.get 0))
@@ -447,7 +449,7 @@ TypedProgram {
       (local.get 1))
     (global.set 4
       (local.get 2))
-    (call 2
+    (call 3
       (global.get 1)
       (i64.const -8086495256948496852)
       (i64.const 3765343665581825017)
@@ -455,7 +457,7 @@ TypedProgram {
       (i64.const -5843589418109203719))
     (local.get 2)
   )
-  (func (;10;) (type 3)
+  (func (;11;) (type 4)
     (local i32 i32 i32)
     (local.set 0
       (global.get 2))
@@ -469,22 +471,22 @@ TypedProgram {
       (global.get 4))
     (global.set 4
       (i32.const 0))
-    (call 0
+    (call 1
       (local.get 0))
   )
-  (func (;11;) (type 0) (param i32)
-    (return_call 8)
+  (func (;12;) (type 1) (param i32)
+    (return_call 9)
   )
-  (func (;12;) (type 5) (param i32) (result i32 i32 i32 i32)
+  (func (;13;) (type 6) (param i32) (result i32 i32 i32 i32)
     (global.get 0)
     (global.get 2)
     (global.get 3)
     (global.get 4)
   )
-  (func (;13;) (type 2) (param i32) (result i32)
+  (func (;14;) (type 3) (param i32) (result i32)
     (local i32 i32 i32 i32 i32)
     (i32.const 4)
-    (call 12
+    (call 13
       (local.get 0))
     (local.set 5)
     (local.set 4)
@@ -505,7 +507,7 @@ TypedProgram {
       (local.get 5))
     (i32.const 4)
   )
-  (func (;14;) (type 6) (param i32 i32 i32 i32) (result i32)
+  (func (;15;) (type 7) (param i32 i32 i32 i32) (result i32)
     (global.set 0
       (local.get 0))
     (global.set 2
@@ -514,7 +516,7 @@ TypedProgram {
       (local.get 2))
     (global.set 4
       (local.get 3))
-    (return_call 4
+    (return_call 5
       (i32.const 0))
   )
   (@custom "component-type"
@@ -529,9 +531,12 @@ TypedProgram {
                   (export (;0;) "utxo" (type (sub resource)))
                   (type (;1;) (borrow 0))
                   (type (;2;) (own 0))
-                  (export (;3;) "token" (type (sub resource)))
-                  (type (;4;) (borrow 3))
-                  (type (;5;) (own 3))
+                  (type (;3;) (tuple u64 u64 u64 u64))
+                  (type (;4;) (func (param "self" 1) (param "hash" 3) (result bool)))
+                  (export (;0;) "[method]utxo.has-method" (func (type 4)))
+                  (export (;5;) "token" (type (sub resource)))
+                  (type (;6;) (borrow 5))
+                  (type (;7;) (own 5))
                 )
               )
               (import "starstream:std/builtin" (instance (;0;) (type 0)))
@@ -653,7 +658,9 @@ world root {
 }
 package starstream:std {
   interface builtin {
-    resource utxo;
+    resource utxo {
+      has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     resource token;
   }

--- a/starstream-to-wasm/wit/builtin.wit
+++ b/starstream-to-wasm/wit/builtin.wit
@@ -4,7 +4,9 @@ package starstream:std;
 /// Starstream programs require.
 interface builtin {
     /// A generic handle to any Utxo.
-    resource utxo {}
+    resource utxo {
+        has-method: func(hash: tuple<u64, u64, u64, u64>) -> bool;
+    }
 
     /// A generic handle to any Token.
     resource token {}


### PR DESCRIPTION
- Import and call `starstream:std/builtin`::`[method]utxo.has-method` to perform the actual `is` check
- Import and call `starstream:contract/dynamic-utxo`::$NAME to call methods on the narrowed `MyAbi`-typed value