### PR TITLE
rt-next: contract imports, `has-method`

### DIFF
--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -99,6 +99,28 @@ fn load_component(engine: &Engine, wasm: impl AsRef<[u8]>) -> wasmtime::Result<C
     }
 }
 
+enum ContractImportTarget<'a, T: 'static> {
+    Component(&'a Component),
+    Contract(Contract<T>),
+}
+
+impl<T> ContractImportTarget<'_, T> {
+    fn component(&self) -> &Component {
+        match self {
+            Self::Component(component) => component,
+            Self::Contract(contract) => contract.pre.component(),
+        }
+    }
+
+    fn contract(&self) -> Option<&Contract<T>> {
+        if let Self::Contract(contract) = self {
+            Some(contract)
+        } else {
+            None
+        }
+    }
+}
+
 /// Link ABI event [`types::ComponentFunc`] in a [`LinkerInstance`]
 #[instrument(level = "trace", skip_all)]
 fn link_event_function<T: Host>(
@@ -149,16 +171,16 @@ fn link_event_instance<T: Host>(
 }
 
 /// Link typed UTXO [`types::ComponentFunc`] in a [`LinkerInstance`]
-#[instrument(level = "trace", skip(component, contract, linker, ty, instance))]
+#[instrument(level = "trace", skip(target, linker, ty, instance))]
 fn link_typed_utxo_function<T: Host>(
-    contract: Option<Contract<T>>,
-    component: &Component,
+    target: &ContractImportTarget<'_, T>,
     linker: &mut LinkerInstance<T>,
     ty: types::ComponentFunc,
     instance: &ComponentExportIndex,
     name: &str,
 ) -> wasmtime::Result<()> {
-    let idx = component
+    let idx = target
+        .component()
         .get_export_index(Some(instance), name)
         .with_context(|| format!("`{name}` export was not found"))?;
     match name.split_once(']') {
@@ -170,6 +192,7 @@ fn link_typed_utxo_function<T: Host>(
                 bail!("function does not return a single resource value")
             };
             let instance_idx = *instance;
+            let contract = target.contract().cloned();
             linker.func_new_async(name, move |mut store, _ty, params, results| {
                 let contract = contract.clone();
                 Box::new(async move {
@@ -238,12 +261,12 @@ fn link_typed_utxo_function<T: Host>(
 /// Link typed UTXO instance in a [`LinkerInstance`].
 #[instrument(level = "trace", skip_all)]
 fn link_typed_utxo_instance<T: Host>(
-    contract: Option<Contract<T>>,
-    component: &Component,
+    target: &ContractImportTarget<'_, T>,
     linker: &mut LinkerInstance<T>,
     ty: &types::ComponentInstance,
     name: &str,
 ) -> wasmtime::Result<()> {
+    let component = target.component();
     let idx = component
         .get_export_index(None, name)
         .with_context(|| format!("`{name}` export was not found"))?;
@@ -251,7 +274,7 @@ fn link_typed_utxo_instance<T: Host>(
         debug!(name, "linking typed UTXO instance item");
         match ty {
             types::ComponentItem::ComponentFunc(ty) => {
-                link_typed_utxo_function(contract.clone(), component, linker, ty, &idx, name)?;
+                link_typed_utxo_function(target, linker, ty, &idx, name)?;
             }
             types::ComponentItem::CoreFunc(..) => {
                 bail!("typed UTXO instance core function imports unsupported")
@@ -358,24 +381,30 @@ fn link_dynamic_utxo_instance<T: Host>(
 }
 
 /// Link dynamic instance in a [`LinkerInstance`].
-#[instrument(level = "trace", skip(component, linker, ty))]
+#[instrument(level = "trace", skip(component, linker, contracts, ty))]
 fn link_instance<T: Host>(
     component: &Component,
     linker: &mut LinkerInstance<T>,
+    contracts: &impl ContractLookup<T>,
     ty: &types::ComponentInstance,
-    instance: &str,
+    name: &str,
+    external_id: Option<&str>,
 ) -> wasmtime::Result<()> {
-    debug_assert!(!instance.starts_with("starstream:std"));
+    debug_assert!(!name.starts_with("starstream:std"));
 
     let engine = component.engine();
     match (
-        instance.split_once('/'),
+        name.split_once('/'),
         ty.get_export(engine, "utxo"),
         ty.get_export(engine, "token"),
     ) {
-        (Some(("starstream:utxo", _name)), ..) => {
-            // TODO: Use external-id to lookup the contract
-            bail!("cross-contract UTXO imports unsupported")
+        (Some(("starstream:utxo", name)), ..) => {
+            let external_id = external_id
+                .with_context(|| format!("`external-id` missing for typed UTXO import `{name}`"))?;
+            let contract = contracts.get_contract(external_id).with_context(|| {
+                format!("failed to get contract for typed UTXO import `{name}`")
+            })?;
+            link_typed_utxo_instance(&ContractImportTarget::Contract(contract), linker, ty, name)
         }
 
         (
@@ -385,7 +414,12 @@ fn link_instance<T: Host>(
                 ..
             }),
             None,
-        ) => link_typed_utxo_instance(None, component, linker, ty, name),
+        ) => link_typed_utxo_instance(
+            &ContractImportTarget::Component(component),
+            linker,
+            ty,
+            name,
+        ),
 
         (
             Some(("starstream:self", ..)),
@@ -406,7 +440,7 @@ fn link_instance<T: Host>(
                 ty: types::ComponentItem::Resource(..),
                 ..
             }),
-        ) => bail!("both `utxo` and `token` resources exported by instance `{instance}` import"),
+        ) => bail!("both `utxo` and `token` resources exported by instance `{name}` import"),
 
         (Some(("starstream:self", ..)), ..) => {
             bail!("failed to classify `starstream:self` instance import")
@@ -426,15 +460,23 @@ fn link_instance<T: Host>(
             bail!("coordination script imports unsupported")
         }
 
-        _ => bail!("unexpected instance import `{instance}`"),
+        _ => bail!("unexpected instance import `{name}`"),
     }
 }
 
 /// Link imports of the contract.
 #[instrument(level = "trace", skip_all)]
-fn link_imports<T: Host>(component: &Component, linker: &mut Linker<T>) -> wasmtime::Result<()> {
-    for (name, types::ComponentExtern { ty, .. }) in
-        component.component_type().imports(component.engine())
+fn link_imports<T: Host>(
+    component: &Component,
+    linker: &mut Linker<T>,
+    contracts: &impl ContractLookup<T>,
+) -> wasmtime::Result<()> {
+    for (
+        name,
+        types::ComponentExtern {
+            ty, external_id, ..
+        },
+    ) in component.component_type().imports(component.engine())
     {
         match ty {
             types::ComponentItem::ComponentFunc(..) => {
@@ -454,7 +496,7 @@ fn link_imports<T: Host>(component: &Component, linker: &mut Linker<T>) -> wasmt
                     .instance(name)
                     .with_context(|| format!("failed to instantiate `{name}` in the linker"))?;
                 debug!(?name, "linking root instance");
-                link_instance(component, &mut linker, &ty, name)?;
+                link_instance(component, &mut linker, contracts, &ty, name, external_id)?;
             }
             types::ComponentItem::Type(..) => {}
             types::ComponentItem::Resource(..) => {
@@ -500,10 +542,19 @@ fn link_utxo_context<T: Host>(linker: &mut Linker<T>) -> wasmtime::Result<()> {
     Ok(())
 }
 
+pub trait ContractLookup<T> {
+    /// Lookup a contract by `external_id`
+    fn get_contract(&self, external_id: &str) -> wasmtime::Result<Contract<T>>;
+}
+
 impl<T: Host> Contract<T> {
     /// Compile and pre-instantiate a Starstream [Contract]
     #[instrument(level = "trace", skip_all)]
-    pub fn new(engine: &Engine, wasm: impl AsRef<[u8]>) -> wasmtime::Result<Self> {
+    pub fn new(
+        engine: &Engine,
+        contracts: impl ContractLookup<T>,
+        wasm: impl AsRef<[u8]>,
+    ) -> wasmtime::Result<Self> {
         let wasm = wasm.as_ref();
 
         debug!("loading component");
@@ -515,7 +566,7 @@ impl<T: Host> Contract<T> {
         bindings::Host_::add_to_linker::<_, HasSelf<_>>(&mut linker, |cx| cx)
             .context("failed to link builtins")?;
         link_utxo_context(&mut linker).context("failed to link `utxo-context`")?;
-        link_imports(&component, &mut linker)?;
+        link_imports(&component, &mut linker, &contracts)?;
 
         let ty = linker
             .substituted_component_type(&component)

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -10,34 +10,25 @@ use wasmtime::error::Context as _;
 use wasmtime::{AsContextMut, Engine, StoreContextMut, bail, ensure};
 
 pub mod bindings {
-    // NOTE: `starstream:std/utxo-context` bindings are hand-written
+    // NOTE: `starstream:std/{builtin,utxo-context}` bindings are hand-written
     wasmtime::component::bindgen!({
         path: "../starstream-to-wasm/wit",
         inline: "
             package starstream:host;
 
             world host {
-                import starstream:std/builtin;
                 import starstream:std/cardano;
             }
         ",
-        with: {
-            "starstream:std/builtin.utxo": crate::Utxo,
-        },
         imports: {
             default: tracing | trappable,
         }
     });
 }
 
-pub trait Host:
-    bindings::starstream::std::builtin::Host
-    + bindings::starstream::std::cardano::Host
-    + Send
-    + Sized
-    + 'static
-{
-    type UtxoContext: Send;
+pub trait Host: bindings::starstream::std::cardano::Host + Send + Sized + 'static {
+    type UtxoContext: Clone + Send;
+    type Token;
 
     fn table(&mut self) -> &mut ResourceTable;
 
@@ -48,10 +39,21 @@ pub trait Host:
         f: impl for<'a> FnOnce(
             StoreContextMut<'a, Self>,
             Self::UtxoContext,
-        )
-            -> Pin<Box<dyn Future<Output = wasmtime::Result<Utxo>> + Send + 'a>>
-        + Send,
-    ) -> impl Future<Output = wasmtime::Result<Utxo>> + Send;
+        ) -> Pin<
+            Box<dyn Future<Output = wasmtime::Result<Utxo<Self::UtxoContext>>> + Send + 'a>,
+        > + Send,
+    ) -> impl Future<Output = wasmtime::Result<Utxo<Self::UtxoContext>>> + Send;
+
+    fn has_method(
+        store: StoreContextMut<Self>,
+        cx: Resource<Utxo<Self::UtxoContext>>,
+        hash: (u64, u64, u64, u64),
+    ) -> wasmtime::Result<bool>;
+
+    fn drop_utxo(
+        store: StoreContextMut<Self>,
+        cx: Resource<Utxo<Self::UtxoContext>>,
+    ) -> wasmtime::Result<()>;
 
     fn implements_method(
         store: StoreContextMut<Self>,
@@ -68,6 +70,8 @@ pub trait Host:
         store: StoreContextMut<Self>,
         cx: Resource<Self::UtxoContext>,
     ) -> wasmtime::Result<()>;
+
+    fn drop_token(store: StoreContextMut<Self>, cx: Resource<Self::Token>) -> wasmtime::Result<()>;
 
     fn emit_event(
         store: StoreContextMut<Self>,
@@ -209,11 +213,11 @@ fn link_typed_utxo_function<T: Host>(
                     };
                     let utxo = T::call_utxo_main(store.as_context_mut(), move |mut store, cx| {
                         Box::pin(async move {
-                            let cx = store.data_mut().table().push(cx)?;
-                            let cx = cx.try_into_resource_any(&mut store)?;
-                            params[0] = Val::Resource(cx);
+                            let cx_res = store.data_mut().table().push(cx.clone())?;
+                            let cx_res = cx_res.try_into_resource_any(&mut store)?;
+                            params[0] = Val::Resource(cx_res);
                             instance
-                                .construct_utxo(&mut store, instance_idx, idx, params)
+                                .construct_utxo(&mut store, instance_idx, idx, params, cx)
                                 .await
                         })
                     })
@@ -234,10 +238,10 @@ fn link_typed_utxo_function<T: Host>(
                     let Some(Val::Resource(utxo)) = params.first() else {
                         bail!("first parameter is not a resource")
                     };
-                    let utxo = utxo.try_into_resource::<Utxo>(&mut store)?;
-                    let Utxo {
+                    let utxo = utxo.try_into_resource::<Utxo<T::UtxoContext>>(&mut store)?;
+                    let &Utxo {
                         instance, resource, ..
-                    } = store.data_mut().table().get(&utxo).copied()?;
+                    } = store.data_mut().table().get(&utxo)?;
                     let f = instance
                         .get_func(&mut store, idx)
                         .context("method export not found")?;
@@ -290,13 +294,17 @@ fn link_typed_utxo_instance<T: Host>(
             }
             types::ComponentItem::Type(..) => {}
             types::ComponentItem::Resource(..) if name == "utxo" => {
-                linker.resource("utxo", ResourceType::host::<Utxo>(), |mut store, rep| {
-                    store
-                        .data_mut()
-                        .table()
-                        .delete::<Utxo>(Resource::new_own(rep))?;
-                    Ok(())
-                })?;
+                linker.resource(
+                    "utxo",
+                    ResourceType::host::<Utxo<T::UtxoContext>>(),
+                    |mut store, rep| {
+                        store
+                            .data_mut()
+                            .table()
+                            .delete::<Utxo<T::UtxoContext>>(Resource::new_own(rep))?;
+                        Ok(())
+                    },
+                )?;
             }
             types::ComponentItem::Resource(..) => {
                 bail!("typed UTXO instance resource imports unsupported")
@@ -323,12 +331,13 @@ fn link_dynamic_utxo_function<T: Host>(
             let Some(Val::Resource(utxo)) = params.first() else {
                 bail!("first parameter is not a resource")
             };
-            let utxo = utxo.try_into_resource::<Utxo>(&mut store)?;
-            let Utxo {
+            let utxo = utxo.try_into_resource::<Utxo<T::UtxoContext>>(&mut store)?;
+            let &Utxo {
                 instance,
                 instance_idx,
                 resource,
-            } = store.data_mut().table().get(&utxo).copied()?;
+                ..
+            } = store.data_mut().table().get(&utxo)?;
             let idx = instance
                 .get_export_index(&mut store, Some(&instance_idx), &export_name)
                 .context("method export index not found")?;
@@ -443,7 +452,7 @@ fn link_instance<T: Host>(
         ) => bail!("both `utxo` and `token` resources exported by instance `{name}` import"),
 
         (Some(("starstream:self", ..)), ..) => {
-            bail!("failed to classify `starstream:self` instance import")
+            bail!("failed to classify `{name}` instance import")
         }
 
         (Some(("starstream:events", name)), ..) => link_event_instance(engine, linker, ty, name),
@@ -522,10 +531,31 @@ impl<T: 'static> Clone for Contract<T> {
     }
 }
 
+fn link_builtin<T: Host>(linker: &mut Linker<T>) -> wasmtime::Result<()> {
+    let mut linker = linker
+        .instance("starstream:std/builtin")
+        .context("failed to instantiate `starstream:std/builtin` in the linker")?;
+
+    linker.resource(
+        "utxo",
+        ResourceType::host::<Utxo<T::UtxoContext>>(),
+        |store, cx| T::drop_utxo(store, Resource::new_own(cx)),
+    )?;
+    linker.func_wrap("[method]utxo.has-method", |store, (cx, hash)| {
+        let ret = T::has_method(store, cx, hash)?;
+        Ok((ret,))
+    })?;
+
+    linker.resource("token", ResourceType::host::<T::Token>(), |store, cx| {
+        T::drop_token(store, Resource::new_own(cx))
+    })?;
+    Ok(())
+}
+
 fn link_utxo_context<T: Host>(linker: &mut Linker<T>) -> wasmtime::Result<()> {
     let mut linker = linker
         .instance("starstream:std/utxo-context")
-        .context("failed to instantiate `utxo-context` in the linker")?;
+        .context("failed to instantiate `starstream:std/utxo-context` in the linker")?;
 
     linker.resource(
         "utxo-context",
@@ -564,8 +594,9 @@ impl<T: Host> Contract<T> {
 
         debug!("linking component imports");
         bindings::Host_::add_to_linker::<_, HasSelf<_>>(&mut linker, |cx| cx)
-            .context("failed to link builtins")?;
-        link_utxo_context(&mut linker).context("failed to link `utxo-context`")?;
+            .context("failed to link generated bindings")?;
+        link_builtin(&mut linker).context("failed to link `starstream:std/builtin`")?;
+        link_utxo_context(&mut linker).context("failed to link `starstream:std/utxo-context`")?;
         link_imports(&component, &mut linker, &contracts)?;
 
         let ty = linker
@@ -868,10 +899,7 @@ impl<T: Host> Contract<T> {
     pub async fn instantiate(
         &self,
         store: impl AsContextMut<Data = T>,
-    ) -> wasmtime::Result<ContractInstance>
-    where
-        T: Send,
-    {
+    ) -> wasmtime::Result<ContractInstance> {
         debug!("instantiating component");
         let instance = self
             .pre
@@ -895,14 +923,12 @@ impl ContractInstance {
     #[instrument(level = "trace", skip_all)]
     async fn construct_utxo<T>(
         &self,
-        mut store: impl AsContextMut<Data = T>,
+        mut store: impl AsContextMut<Data: Send>,
         instance_idx: ComponentExportIndex,
         name: impl ExportLookup,
         params: impl AsRef<[Val]>,
-    ) -> wasmtime::Result<Utxo>
-    where
-        T: Send + 'static,
-    {
+        cx: T,
+    ) -> wasmtime::Result<Utxo<T>> {
         let f = self
             .0
             .get_func(store.as_context_mut(), name)
@@ -919,49 +945,44 @@ impl ContractInstance {
             instance: self.0,
             instance_idx,
             resource,
+            cx,
         })
     }
 
     #[instrument(level = "trace", skip_all)]
     pub async fn call_utxo_main<T>(
         &self,
-        store: impl AsContextMut<Data = T>,
+        store: impl AsContextMut<Data: Send>,
         UtxoExport { instance_idx, .. }: &UtxoExport,
         UtxoMainExport { idx, .. }: &UtxoMainExport,
+        cx: T,
         params: impl AsRef<[Val]>,
-    ) -> wasmtime::Result<Utxo>
-    where
-        T: Send + 'static,
-    {
-        self.construct_utxo(store, *instance_idx, idx, params).await
+    ) -> wasmtime::Result<Utxo<T>> {
+        self.construct_utxo(store, *instance_idx, idx, params, cx)
+            .await
     }
 
     #[instrument(level = "trace", skip_all)]
     pub async fn load_utxo<T>(
         &self,
-        store: impl AsContextMut<Data = T>,
+        store: impl AsContextMut<Data: Send>,
         UtxoExport { instance_idx, .. }: &UtxoExport,
         UtxoStorageExport { set, .. }: &UtxoStorageExport,
+        cx: T,
         fields: impl Into<Vec<(String, Val)>>,
-    ) -> wasmtime::Result<Utxo>
-    where
-        T: Send + 'static,
-    {
-        self.construct_utxo(store, *instance_idx, set, [Val::Record(fields.into())])
+    ) -> wasmtime::Result<Utxo<T>> {
+        self.construct_utxo(store, *instance_idx, set, [Val::Record(fields.into())], cx)
             .await
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub async fn call_coordination_script<T>(
+    pub async fn call_coordination_script(
         &self,
-        mut store: impl AsContextMut<Data = T>,
+        mut store: impl AsContextMut<Data: Send>,
         CoordinationScriptExport { idx, .. }: &CoordinationScriptExport,
         params: impl AsRef<[Val]>,
         mut results: impl AsMut<[Val]>,
-    ) -> wasmtime::Result<()>
-    where
-        T: Send + 'static,
-    {
+    ) -> wasmtime::Result<()> {
         let f = self
             .0
             .get_func(store.as_context_mut(), idx)
@@ -1043,13 +1064,14 @@ impl CoordinationScriptExport {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct Utxo {
+pub struct Utxo<T> {
     instance: Instance,
     instance_idx: ComponentExportIndex,
     resource: ResourceAny,
+    cx: T,
 }
 
-impl Utxo {
+impl<T> Utxo<T> {
     #[must_use]
     pub fn instance(&self) -> Instance {
         self.instance
@@ -1060,7 +1082,12 @@ impl Utxo {
         self.resource
     }
 
-    pub fn storage(&self, export: &UtxoStorageExport) -> UtxoStorage<'_> {
+    #[must_use]
+    pub fn context(&self) -> &T {
+        &self.cx
+    }
+
+    pub fn storage(&self, export: &UtxoStorageExport) -> UtxoStorage<'_, T> {
         UtxoStorage {
             utxo: self,
             get: export.get,
@@ -1068,9 +1095,9 @@ impl Utxo {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub async fn call<T: Send>(
+    pub async fn call(
         &self,
-        mut store: impl AsContextMut<Data = T>,
+        mut store: impl AsContextMut<Data: Send>,
         MethodExport { idx, .. }: &MethodExport,
         params: impl AsRef<[Val]>,
         mut results: impl AsMut<[Val]>,
@@ -1086,25 +1113,22 @@ impl Utxo {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub async fn drop<T: Send>(
-        self,
-        mut store: impl AsContextMut<Data = T>,
-    ) -> wasmtime::Result<()> {
+    pub async fn drop(self, mut store: impl AsContextMut<Data: Send>) -> wasmtime::Result<()> {
         self.resource.resource_drop_async(&mut store).await?;
         Ok(())
     }
 }
 
-pub struct UtxoStorage<'a> {
-    utxo: &'a Utxo,
+pub struct UtxoStorage<'a, T> {
+    utxo: &'a Utxo<T>,
     get: ComponentExportIndex,
 }
 
-impl UtxoStorage<'_> {
+impl<T> UtxoStorage<'_, T> {
     #[instrument(level = "trace", skip_all)]
-    pub async fn get<T: Send>(
+    pub async fn get(
         &self,
-        mut store: impl AsContextMut<Data = T>,
+        mut store: impl AsContextMut<Data: Send>,
     ) -> wasmtime::Result<Vec<(String, Val)>> {
         let f = self
             .utxo

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -59,39 +59,13 @@ struct Ctx {
     table: ResourceTable,
     events: Vec<Event>,
 
-    outputs: Vec<(Utxo, Arc<Mutex<UtxoCtx>>)>,
+    outputs: Vec<Utxo<Arc<Mutex<UtxoCtx>>>>,
 }
 
 #[derive(Debug, Default)]
 pub struct UtxoCtx {
     methods: Vec<(u64, u64, u64, u64)>,
     dropped: bool,
-}
-
-impl bindings::starstream::std::builtin::Host for Ctx {}
-
-impl bindings::starstream::std::builtin::HostUtxo for Ctx {
-    fn drop(&mut self, _utxo: Resource<Utxo>) -> wasmtime::Result<()> {
-        Ok(())
-    }
-
-    fn has_method(
-        &mut self,
-        _utxo: Resource<Utxo>,
-        _hash: (u64, u64, u64, u64),
-    ) -> wasmtime::Result<bool> {
-        // TODO
-        Ok(false)
-    }
-}
-
-impl bindings::starstream::std::builtin::HostToken for Ctx {
-    fn drop(
-        &mut self,
-        _token: Resource<bindings::starstream::std::builtin::Token>,
-    ) -> wasmtime::Result<()> {
-        Ok(())
-    }
 }
 
 impl bindings::starstream::std::cardano::Host for Ctx {
@@ -106,6 +80,7 @@ impl bindings::starstream::std::cardano::Host for Ctx {
 
 impl Host for Ctx {
     type UtxoContext = Arc<Mutex<UtxoCtx>>;
+    type Token = (); // TODO: add token support
 
     fn table(&mut self) -> &mut ResourceTable {
         &mut self.table
@@ -120,14 +95,35 @@ impl Host for Ctx {
         f: impl for<'a> FnOnce(
             StoreContextMut<'a, Self>,
             Self::UtxoContext,
-        )
-            -> Pin<Box<dyn Future<Output = wasmtime::Result<Utxo>> + Send + 'a>>
-        + Send,
-    ) -> wasmtime::Result<Utxo> {
+        ) -> Pin<
+            Box<dyn Future<Output = wasmtime::Result<Utxo<Self::UtxoContext>>> + Send + 'a>,
+        > + Send,
+    ) -> wasmtime::Result<Utxo<Self::UtxoContext>> {
         let cx = Self::UtxoContext::default();
         let utxo = f(store.as_context_mut(), Arc::clone(&cx)).await?;
-        store.data_mut().outputs.push((utxo, cx));
+        store.data_mut().outputs.push(utxo.clone());
         Ok(utxo)
+    }
+
+    #[instrument(skip(store, utxo), ret)]
+    fn has_method(
+        store: StoreContextMut<Self>,
+        utxo: Resource<Utxo<Self::UtxoContext>>,
+        hash: (u64, u64, u64, u64),
+    ) -> wasmtime::Result<bool> {
+        let Ctx { table, .. } = store.data();
+        let utxo = table.get(&utxo)?;
+        Ok(utxo.context().lock().unwrap().methods.contains(&hash))
+    }
+
+    #[instrument(skip(store, utxo), ret)]
+    fn drop_utxo(
+        mut store: StoreContextMut<Self>,
+        utxo: Resource<Utxo<Self::UtxoContext>>,
+    ) -> wasmtime::Result<()> {
+        let Ctx { table, .. } = store.data_mut();
+        let _utxo = table.delete(utxo)?;
+        Ok(())
     }
 
     #[instrument(skip(store, cx), ret)]
@@ -136,7 +132,8 @@ impl Host for Ctx {
         cx: Resource<Self::UtxoContext>,
         hash: (u64, u64, u64, u64),
     ) -> wasmtime::Result<()> {
-        let cx = store.data_mut().table.get_mut(&cx)?;
+        let Ctx { table, .. } = store.data_mut();
+        let cx = table.get_mut(&cx)?;
         cx.lock().unwrap().methods.push(hash);
         Ok(())
     }
@@ -146,7 +143,8 @@ impl Host for Ctx {
         mut store: StoreContextMut<Self>,
         cx: Resource<Self::UtxoContext>,
     ) -> wasmtime::Result<()> {
-        let cx = store.data_mut().table.get_mut(&cx)?;
+        let Ctx { table, .. } = store.data_mut();
+        let cx = table.get_mut(&cx)?;
         cx.lock().unwrap().methods.clear();
         Ok(())
     }
@@ -162,6 +160,16 @@ impl Host for Ctx {
         Ok(())
     }
 
+    #[instrument(skip(store, token), ret)]
+    fn drop_token(
+        mut store: StoreContextMut<Self>,
+        token: Resource<Self::Token>,
+    ) -> wasmtime::Result<()> {
+        let Ctx { table, .. } = store.data_mut();
+        () = table.delete(token)?;
+        Ok(())
+    }
+
     #[instrument(skip(store), ret)]
     fn emit_event(
         mut store: StoreContextMut<Self>,
@@ -169,7 +177,8 @@ impl Host for Ctx {
         name: &Arc<str>,
         params: &[Val],
     ) -> wasmtime::Result<()> {
-        store.data_mut().events.push(Event {
+        let Ctx { events, .. } = store.data_mut();
+        events.push(Event {
             abi_name: Arc::clone(abi_name),
             name: Arc::clone(name),
             params: params.into(),
@@ -318,9 +327,9 @@ impl<'a> FromIterator<&'a (String, Val)> for ProgressStorage {
     }
 }
 
-async fn get_progress_storage<T: Send + 'static>(
-    store: &mut Store<T>,
-    utxo: &Utxo,
+async fn get_progress_storage<T>(
+    store: &mut Store<impl Send + 'static>,
+    utxo: &Utxo<T>,
     storage: &UtxoStorageExport,
 ) -> wasmtime::Result<ProgressStorage> {
     let storage = utxo
@@ -353,7 +362,13 @@ async fn score_main_new() -> wasmtime::Result<()> {
     let utxo_cx_res = utxo_cx_res.try_into_resource_any(&mut store)?;
     let instance = contract.instantiate(&mut store).await?;
     let utxo = instance
-        .call_utxo_main(&mut store, &ty.utxo, &ty.new, [Val::Resource(utxo_cx_res)])
+        .call_utxo_main(
+            &mut store,
+            &ty.utxo,
+            &ty.new,
+            Arc::clone(&utxo_cx),
+            [Val::Resource(utxo_cx_res)],
+        )
         .instrument(info_span!("new"))
         .await
         .context("failed to construct UTXO")?;
@@ -480,12 +495,12 @@ async fn score_script_example() -> wasmtime::Result<()> {
         events, outputs, ..
     } = store.data();
     let mut outputs = outputs.iter();
-    let (utxo, utxo_cx) = match (outputs.next(), outputs.next()) {
-        (Some((utxo, utxo_cx)), None) => (*utxo, utxo_cx),
+    let utxo = match (outputs.next(), outputs.next()) {
+        (Some(utxo), None) => utxo.clone(),
         _ => bail!("unexpected outputs created: {outputs:?}"),
     };
     {
-        let utxo_cx = utxo_cx.lock().unwrap();
+        let utxo_cx = utxo.context().lock().unwrap();
         assert_eq!(utxo_cx.methods, *METHODS);
         assert!(!utxo_cx.dropped);
     }

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -5,8 +5,8 @@ use std::sync::{Arc, LazyLock, Mutex};
 use sha2::{Digest as _, Sha256};
 use starstream_compiler::{TypecheckOptions, parse_program, typecheck_program};
 use starstream_runtime_next::{
-    Contract, CoordinationScriptExport, Host, MethodExport, Utxo, UtxoExport, UtxoMainExport,
-    UtxoStorageExport, bindings,
+    Contract, ContractLookup, CoordinationScriptExport, Host, MethodExport, Utxo, UtxoExport,
+    UtxoMainExport, UtxoStorageExport, bindings,
 };
 use starstream_to_wasm::compile;
 use tracing::{Instrument as _, info_span, instrument};
@@ -37,6 +37,14 @@ fn compile_contract(source: &str) -> Vec<u8> {
 
 static EXAMPLE_SCORE: LazyLock<Vec<u8>> =
     LazyLock::new(|| compile_contract(include_str!("../../examples/score.star")));
+
+struct NoopContractLookup;
+
+impl<T> ContractLookup<T> for NoopContractLookup {
+    fn get_contract(&self, external_id: &str) -> wasmtime::Result<Contract<T>> {
+        bail!("contract with external_id `{external_id}` unknown")
+    }
+}
 
 #[derive(Debug, Eq, PartialEq)]
 struct Event {
@@ -326,8 +334,8 @@ async fn get_progress_storage<T: Send + 'static>(
 #[test_log::test(tokio::test)]
 async fn score_main_new() -> wasmtime::Result<()> {
     let engine = wasmtime::Engine::default();
-    let contract =
-        Contract::new(&engine, EXAMPLE_SCORE.as_slice()).context("failed to create contract")?;
+    let contract = Contract::new(&engine, NoopContractLookup, EXAMPLE_SCORE.as_slice())
+        .context("failed to create contract")?;
     let ty = assert_progress_utxo(&contract)?;
 
     let mut table = ResourceTable::default();
@@ -445,8 +453,8 @@ async fn score_main_new() -> wasmtime::Result<()> {
 #[test_log::test(tokio::test)]
 async fn score_script_example() -> wasmtime::Result<()> {
     let engine = wasmtime::Engine::default();
-    let contract =
-        Contract::new(&engine, EXAMPLE_SCORE.as_slice()).context("failed to create contract")?;
+    let contract = Contract::new(&engine, NoopContractLookup, EXAMPLE_SCORE.as_slice())
+        .context("failed to create contract")?;
     let ty = assert_progress_utxo(&contract)?;
 
     let mut store = wasmtime::Store::new(


### PR DESCRIPTION
First commit:

Add support for importing typed UTXOs from contracts other than self.
For now this uses `external_id` string verbatim, but as spec evolves that will likely change.

Second commit:

Implement `has-method` in the test and handle all the necessary plumbing to make it possible. A reference-counted UTXO context is now stored in the UTXO object itself