### PR TITLE
cli: add `run` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bellpepper"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2224,6 +2230,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.8.8",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lsp-types"
 version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3595,15 +3634,20 @@ dependencies = [
  "ignore",
  "miette",
  "serde_json",
+ "sha2",
  "similar",
  "starstream-compiler",
  "starstream-language-server",
+ "starstream-runtime-next",
  "starstream-to-wasm",
  "starstream-types",
  "thiserror 2.0.17",
  "tokio",
  "tower-lsp-server",
+ "tracing",
+ "tracing-subscriber",
  "walkdir",
+ "wasmtime 49.0.0-dev",
  "wit-component 0.254.0",
 ]
 
@@ -4457,6 +4501,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-wave"
+version = "0.258.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1d8cbc89bc22dac012f5fd56fca419330cb88d8d2c8f6ccb313f08ec4a6836"
+dependencies = [
+ "anyhow",
+ "logos",
+ "thiserror 2.0.17",
+ "wit-parser 0.258.0",
+]
+
+[[package]]
 name = "wasm_runtime_layer"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4626,6 +4682,7 @@ dependencies = [
  "tempfile",
  "wasm-compose",
  "wasm-encoder 0.258.0",
+ "wasm-wave",
  "wasmparser 0.258.0",
  "wasmtime-environ 49.0.0-dev",
  "wasmtime-internal-cache",

--- a/starstream-cli/Cargo.toml
+++ b/starstream-cli/Cargo.toml
@@ -18,13 +18,22 @@ console = "0.16.0"
 ignore = "0.4.24"
 miette = { workspace = true, features = ["fancy"] }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 similar = "2.7.0"
 starstream-compiler = { workspace = true }
 starstream-language-server = { workspace = true }
+starstream-runtime-next = { workspace = true }
 starstream-to-wasm = { workspace = true }
 starstream-types = { workspace = true }
 thiserror = { workspace = true }
 tokio = { version = "1.47.1", features = ["full"] }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3.20", default-features = false, features = [
+    "ansi",
+    "env-filter",
+    "fmt",
+] }
 tower-lsp-server = { workspace = true }
 walkdir = "2.5.0"
+wasmtime = { workspace = true, features = ["wave"] }
 wit-component.workspace = true

--- a/starstream-cli/src/lib.rs
+++ b/starstream-cli/src/lib.rs
@@ -11,6 +11,7 @@ mod explain;
 mod format;
 mod lsp;
 mod project;
+mod run;
 mod style;
 mod wasm;
 
@@ -20,6 +21,7 @@ pub use docs::Docs;
 pub use explain::Explain;
 pub use format::Format;
 pub use lsp::Lsp;
+pub use run::Run;
 pub use wasm::Wasm;
 
 /// The Starstream language and toolchain CLI.
@@ -34,6 +36,7 @@ pub enum Command {
     Explain(Explain),
     #[clap(hide = true)]
     Lsp(Lsp),
+    Run(Run),
 }
 
 #[derive(Parser, Debug)]
@@ -55,6 +58,7 @@ impl Cli {
             Command::Check(c) => c.exec(),
             Command::Explain(e) => e.exec(),
             Command::Lsp(l) => l.exec(),
+            Command::Run(r) => r.exec(),
         }
     }
 }

--- a/starstream-cli/src/main.rs
+++ b/starstream-cli/src/main.rs
@@ -7,5 +7,14 @@ use starstream_cli::Cli;
 fn main() -> miette::Result<()> {
     miette::set_panic_hook();
 
+    tracing_subscriber::fmt()
+        .without_time()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_env("STARSTREAM_LOG")
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
     Cli::parse().exec()
 }

--- a/starstream-cli/src/run.rs
+++ b/starstream-cli/src/run.rs
@@ -1,0 +1,247 @@
+use core::iter::zip;
+use core::pin::Pin;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use clap::Args;
+use miette::IntoDiagnostic as _;
+use sha2::{Digest as _, Sha256};
+use starstream_runtime_next::{Contract, ContractLookup, Host, Utxo, bindings};
+use tokio::fs;
+use tracing::{debug, info, instrument};
+use wasmtime::component::{Resource, ResourceTable, Val};
+use wasmtime::error::Context as _;
+use wasmtime::{AsContextMut as _, Store, StoreContextMut, ensure};
+
+/// Run a coordination script exported by a Wasm component
+#[derive(Args, Debug)]
+pub struct Run {
+    /// Path to Wasm component
+    wasm: PathBuf,
+
+    /// Script to run
+    script: String,
+
+    /// Script arguments
+    args: Vec<String>,
+
+    /// Contracts to import
+    #[arg(long = "import", value_name = "PATH")]
+    imports: Vec<PathBuf>,
+}
+
+struct Ctx {
+    contract: Contract<Self>,
+    table: ResourceTable,
+    outputs: Vec<Utxo<Arc<Mutex<UtxoCtx>>>>,
+}
+
+#[derive(Debug, Default)]
+struct UtxoCtx {
+    methods: Vec<(u64, u64, u64, u64)>,
+}
+
+#[derive(Default)]
+struct Imports(HashMap<String, Contract<Ctx>>);
+
+impl ContractLookup<Ctx> for &Imports {
+    fn get_contract(&self, external_id: &str) -> wasmtime::Result<Contract<Ctx>> {
+        let contract = self
+            .0
+            .get(external_id)
+            .with_context(|| format!("contract `{external_id}` not found"))?;
+        Ok(contract.clone())
+    }
+}
+
+impl bindings::starstream::std::cardano::Host for Ctx {
+    fn block_height(&mut self) -> wasmtime::Result<i64> {
+        Ok(0)
+    }
+
+    fn current_slot(&mut self) -> wasmtime::Result<i64> {
+        Ok(0)
+    }
+}
+
+impl Host for Ctx {
+    type UtxoContext = Arc<Mutex<UtxoCtx>>;
+    type Token = ();
+
+    fn table(&mut self) -> &mut ResourceTable {
+        &mut self.table
+    }
+
+    fn contract(store: StoreContextMut<Self>) -> Contract<Self> {
+        store.data().contract.clone()
+    }
+
+    #[instrument(level = "trace", skip_all, ret)]
+    async fn call_utxo_main(
+        mut store: StoreContextMut<'_, Self>,
+        f: impl for<'a> FnOnce(
+            StoreContextMut<'a, Self>,
+            Self::UtxoContext,
+        ) -> Pin<
+            Box<dyn Future<Output = wasmtime::Result<Utxo<Self::UtxoContext>>> + Send + 'a>,
+        > + Send,
+    ) -> wasmtime::Result<Utxo<Self::UtxoContext>> {
+        let cx = Self::UtxoContext::default();
+        let utxo = f(store.as_context_mut(), Arc::clone(&cx)).await?;
+        let Ctx { outputs, .. } = store.data_mut();
+        info!(i = outputs.len(), "constructed UTXO");
+        store.data_mut().outputs.push(utxo.clone());
+        Ok(utxo)
+    }
+
+    #[instrument(level = "debug", skip(store, utxo), ret)]
+    fn has_method(
+        store: StoreContextMut<Self>,
+        utxo: Resource<Utxo<Self::UtxoContext>>,
+        hash: (u64, u64, u64, u64),
+    ) -> wasmtime::Result<bool> {
+        let Ctx { table, .. } = store.data();
+        let utxo = table.get(&utxo)?;
+        Ok(utxo.context().lock().unwrap().methods.contains(&hash))
+    }
+
+    #[instrument(level = "debug", skip_all, ret)]
+    fn drop_utxo(
+        mut store: StoreContextMut<Self>,
+        utxo: Resource<Utxo<Self::UtxoContext>>,
+    ) -> wasmtime::Result<()> {
+        let Ctx { table, .. } = store.data_mut();
+        let _utxo = table.delete(utxo)?;
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(store, cx), ret)]
+    fn implements_method(
+        mut store: StoreContextMut<Self>,
+        cx: Resource<Self::UtxoContext>,
+        hash: (u64, u64, u64, u64),
+    ) -> wasmtime::Result<()> {
+        let Ctx { table, .. } = store.data_mut();
+        let cx = table.get_mut(&cx)?;
+        cx.lock().unwrap().methods.push(hash);
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip_all, ret)]
+    fn resume(
+        mut store: StoreContextMut<Self>,
+        cx: Resource<Self::UtxoContext>,
+    ) -> wasmtime::Result<()> {
+        let Ctx { table, .. } = store.data_mut();
+        let cx = table.get_mut(&cx)?;
+        cx.lock().unwrap().methods.clear();
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip_all, ret)]
+    fn drop_utxo_context(
+        mut store: StoreContextMut<Self>,
+        cx: Resource<Self::UtxoContext>,
+    ) -> wasmtime::Result<()> {
+        let Ctx { table, .. } = store.data_mut();
+        let _cx = table.delete(cx)?;
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip_all, ret)]
+    fn drop_token(
+        mut store: StoreContextMut<Self>,
+        token: Resource<Self::Token>,
+    ) -> wasmtime::Result<()> {
+        let Ctx { table, .. } = store.data_mut();
+        () = table.delete(token)?;
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(_store), ret)]
+    fn emit_event(
+        _store: StoreContextMut<Self>,
+        abi_name: &Arc<str>,
+        name: &Arc<str>,
+        params: &[Val],
+    ) -> wasmtime::Result<()> {
+        let params = Val::Tuple(params.to_vec())
+            .to_wave()
+            .context("failed to encode parameters")?;
+        info!(abi = ?abi_name, event = ?name, params);
+        Ok(())
+    }
+}
+
+async fn exec(
+    Run {
+        wasm,
+        script,
+        args,
+        imports,
+    }: Run,
+) -> wasmtime::Result<()> {
+    let mut config = wasmtime::Config::new();
+    config.wasm_component_model_implements(true);
+    let engine = wasmtime::Engine::new(&config)?;
+
+    let mut lookup = Imports::default();
+    for import in imports {
+        let wasm = fs::read(&import)
+            .await
+            .with_context(|| format!("failed to read import contract `{}`", import.display()))?;
+        let contract = Contract::new(&engine, &lookup, &wasm)
+            .with_context(|| format!("failed to load import contract `{}`", import.display()))?;
+        let digest = Sha256::digest(&wasm);
+        let digest = format!("{digest:02x}");
+        debug!(?digest, path = %import.display(), "imported contract");
+        lookup.0.insert(digest, contract);
+    }
+
+    let wasm = fs::read(&wasm).await.context("failed to read contract")?;
+    let contract = Contract::new(&engine, &lookup, wasm).context("failed to load contract")?;
+    let mut store = Store::new(
+        &engine,
+        Ctx {
+            contract: contract.clone(),
+            table: ResourceTable::default(),
+            outputs: Vec::default(),
+        },
+    );
+    let script = contract.get_coordination_script(&script)?;
+    let contract = contract.instantiate(&mut store).await?;
+    let params_ty = script.ty().params();
+    ensure!(
+        params_ty.len() == args.len(),
+        "expected {} arguments, got {}",
+        params_ty.len(),
+        args.len(),
+    );
+    let params = zip(params_ty, args)
+        .map(|((name, ty), arg)| {
+            Val::from_wave(&ty, &arg).with_context(|| format!("failed to parse argument `{name}`"))
+        })
+        .collect::<wasmtime::Result<Vec<_>>>()?;
+    let mut results = vec![Val::Bool(false); script.ty().results().len()];
+    contract
+        .call_coordination_script(&mut store, &script, &params, &mut results)
+        .await?;
+    debug!(outputs = store.data().outputs.len(), "script returned");
+    let results = Val::Tuple(results)
+        .to_wave()
+        .context("failed to encode results")?;
+    println!("{results}");
+    Ok(())
+}
+
+impl Run {
+    pub fn exec(self) -> miette::Result<()> {
+        let rt = tokio::runtime::Runtime::new().into_diagnostic()?;
+        match rt.block_on(exec(self)) {
+            Ok(()) => Ok(()),
+            Err(err) => Err(miette::miette!("{err:?}")),
+        }
+    }
+}


### PR DESCRIPTION
closes #213 

usage:

```
$ ./starstream wasm -c examples/score.star --output-component score.wasm
$ ./starstream run ./score.wasm example
   Compiling starstream-cli v0.0.0 (/Users/rvolosatovs/src/github.com/LFDT-Nightstream/Starstream/starstream-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.80s
     Running `target/debug/starstream run ./score.wasm example`
 INFO starstream_cli::run: constructed UTXO i=0
 INFO starstream_cli::run: abi="score" event="finish" params="(168)"
()
```

with:

```diff
diff --git a/examples/score.star b/examples/score.star
index b97fea0..51bc230 100644
--- a/examples/score.star
+++ b/examples/score.star
@@ -38,4 +38,5 @@ script fn example() {
     prog.plus_chips(42);
     prog.plus_mult(2);
     prog.mult_mult(200);
+    prog.finish();
 }
```

or in debug mode:
```
STARSTREAM_LOG=debug ./starstream run ./score.wasm example  
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/starstream run ./score.wasm example`
DEBUG starstream_runtime_next: loading component
DEBUG starstream_runtime_next: linking component imports
DEBUG starstream_runtime_next: skipping `starstream:std` import name="starstream:std/builtin"
DEBUG starstream_runtime_next: skipping `starstream:std` import name="starstream:std/utxo-context"
DEBUG starstream_runtime_next: linking root instance name="starstream:contract/dynamic-utxo"
DEBUG starstream_runtime_next: linking dynamic UTXO instance item name="s-utxo"
DEBUG starstream_runtime_next: linking dynamic UTXO instance item name="plus-chips"
DEBUG starstream_runtime_next: linking dynamic UTXO instance item name="plus-mult"
DEBUG starstream_runtime_next: linking dynamic UTXO instance item name="mult-mult"
DEBUG starstream_runtime_next: linking dynamic UTXO instance item name="finish"
DEBUG starstream_runtime_next: linking root instance name="starstream:events/score"
DEBUG starstream_runtime_next: linking event instance item name="finish"
DEBUG starstream_runtime_next: linking root instance name="starstream:self/score-progress"
DEBUG starstream_runtime_next: linking typed UTXO instance item name="utxo"
DEBUG starstream_runtime_next: linking typed UTXO instance item name="[static]utxo.new"
DEBUG starstream_runtime_next: linking typed UTXO instance item name="[method]utxo.plus-chips"
DEBUG starstream_runtime_next: linking typed UTXO instance item name="[method]utxo.plus-mult"
DEBUG starstream_runtime_next: linking typed UTXO instance item name="[method]utxo.mult-mult"
DEBUG starstream_runtime_next: linking typed UTXO instance item name="[method]utxo.finish"
DEBUG starstream_runtime_next: skip root instance resource import name="s-utxo"
DEBUG starstream_runtime_next: skip root instance resource import name="s-token"
DEBUG starstream_runtime_next: skip root instance resource import name="s-utxo-context"
DEBUG starstream_runtime_next: skip root instance resource import name="u-score-progress"
DEBUG starstream_runtime_next: pre-instantiating component
DEBUG starstream_runtime_next: instantiating component
DEBUG starstream_runtime_next: calling coordination script
DEBUG starstream_runtime_next: instantiating component
DEBUG starstream_runtime_next: calling constructor function
DEBUG implements_method{hash=(9984741223472054651, 3777191895585416912, 11414430493733454782, 17853027721887758589)}: starstream_cli::run: return=Ok(())
DEBUG implements_method{hash=(10031671596645923877, 5859691412821126436, 14636224297006305312, 18400238348769808647)}: starstream_cli::run: return=Ok(())
DEBUG implements_method{hash=(10486967187806387020, 13073113330981563051, 14419176846782403470, 15804774841702521566)}: starstream_cli::run: return=Ok(())
DEBUG implements_method{hash=(5384737671178596162, 7822374597054249491, 11449494298339117153, 15762863519083182186)}: starstream_cli::run: return=Ok(())
 INFO starstream_cli::run: constructed UTXO i=0
DEBUG resume: starstream_cli::run: return=Ok(())
 INFO emit_event{abi_name="score" name="finish" params=[U64(168)]}: starstream_cli::run: abi="score" event="finish" params="(168)"
DEBUG emit_event{abi_name="score" name="finish" params=[U64(168)]}: starstream_cli::run: return=Ok(())
DEBUG drop_utxo_context: starstream_cli::run: return=Ok(())
DEBUG starstream_cli::run: script returned outputs=1
()
```

This CLI supports cross-contract imports as well. Referenced contracts must be specified via `--import` flag (which can be repeated). In case there are dependencies between imported contracts, the assumption is that the contracts being dependent upon are specified *first*, i.e. ordering of `--import` flags matters.