### PR TITLE
Fix some component ABI bugs

### DIFF
--- a/docs/wit-worlds.mdx
+++ b/docs/wit-worlds.mdx
@@ -59,7 +59,7 @@ world root {
         }
 
         get-storage: func(self: borrow<utxo>) -> storage;
-        set-storage: func(storage: storage) -> utxo;
+        set-storage: func(ctx: own<utxo-context>, storage: storage) -> utxo;
     }
 }
 ```

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -578,8 +578,10 @@ impl<T: Host> Contract<T> {
                 bail!("`set-storage` export is not a function")
             };
             let mut params = ty.params();
-            let (Some((_, Type::Record(record_ty))), None) = (params.next(), params.next()) else {
-                bail!("`set-storage` does not take a storage record as the only parameter");
+            let (Some((_, Type::Own(_))), Some((_, Type::Record(record_ty))), None) =
+                (params.next(), params.next(), params.next())
+            else {
+                bail!("`set-storage` parameter list does not match (own<utxo-context>, storage)");
             };
             if record_ty != *storage_ty {
                 bail!("`set-storage` record type does not match storage type");

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -1691,6 +1691,9 @@ impl Compiler {
                 resource: resource.clone(),
             }),
         );
+        let owned = Rc::new(ComponentAbiType::Own {
+            resource: resource.clone(),
+        });
 
         let (resource_new_fn, _resource_drop_fn) = *self.resource_abi_fns.get(&this_ty).unwrap();
 
@@ -1719,25 +1722,23 @@ impl Compiler {
                     }
                 }
                 TypedTokenPart::Function(function) => {
-                    let core = self.visit_function(
-                        None,
-                        None, // TODO: token context type
-                        function,
-                        &(&() as &dyn Locals, &token_storage),
-                    );
                     match function.export {
                         // A `mint fn` is a constructor: it returns an owned
                         // handle to the freshly minted token (see the resource
                         // spawn in `visit_function`).
                         Some(FunctionExport::TokenMint) => {
+                            let core = self.visit_function(
+                                None,
+                                None, // TODO: token context type
+                                function,
+                                &(&() as &dyn Locals, &token_storage),
+                            );
                             let mut sig = self.star_to_component_signature(
                                 None,
                                 &function.ty.params,
                                 &function.ty.result,
                             );
-                            sig.result = Some(Rc::new(ComponentAbiType::Own {
-                                resource: resource.clone(),
-                            }));
+                            sig.result = Some(owned.clone());
                             let wit_name = format!(
                                 "[static]{resource_name}.{}",
                                 to_kebab_case(function.name.as_str())
@@ -1755,16 +1756,21 @@ impl Compiler {
                                 iface.export_fn(&wit_name, &sig);
                             }
                         }
-                        // `burn fn` carries no special wasm semantics — what
-                        // burning actually does is a runtime concern. It is
-                        // exported as a plain static function on the token,
-                        // distinguished only by its export name.
+                        // `burn fn`s are like a named destructors. They accept
+                        // an `own<>` handle to a token and destroy it if possible.
                         Some(FunctionExport::TokenBurn) => {
-                            let sig = self.star_to_component_signature(
+                            let core = self.visit_function(
+                                Some(&this_ty),
+                                None, // TODO: token context type
+                                function,
+                                &(&() as &dyn Locals, &token_storage),
+                            );
+                            let mut sig = self.star_to_component_signature(
                                 None,
                                 &function.ty.params,
                                 &function.ty.result,
                             );
+                            sig.params.insert(0, ("this".to_owned(), owned.clone()));
                             let wit_name = format!(
                                 "[static]{resource_name}.{}",
                                 to_kebab_case(function.name.as_str())
@@ -1784,7 +1790,14 @@ impl Compiler {
                         }
                         // Plain helper functions are compiled but not exported,
                         // matching `utxo` non-`main` functions.
-                        _ => {}
+                        _ => {
+                            self.visit_function(
+                                None,
+                                None,
+                                function,
+                                &(&() as &dyn Locals, &token_storage),
+                            );
+                        }
                     }
                 }
                 TypedTokenPart::AbiImpl {

--- a/starstream-to-wasm/src/lib.rs
+++ b/starstream-to-wasm/src/lib.rs
@@ -452,8 +452,41 @@ impl Compiler {
             }
         }
 
-        // set-storage(storage: storage) -> utxo
-        {
+        if let Some(context_global) = self.context_global {
+            // set-storage(ctx: own<utxo-context>, storage: storage) -> utxo
+            let utxo_context_own = Rc::new(ComponentAbiType::Own {
+                resource: self.builtins.utxo_context_resource.clone().unwrap(),
+            });
+            let sig = ComponentAbiFunctionSignature {
+                params: vec![
+                    ("ctx".to_owned(), utxo_context_own),
+                    ("storage".to_owned(), storage_record.clone()),
+                ],
+                result: Some(utxo_own.clone()),
+            };
+            let ty = FuncType::new(
+                std::iter::once(ValType::I32).chain(storage_flat.iter().copied()),
+                [ValType::I32],
+            );
+            let mut code = Function::new([]);
+            code.instructions().local_get(0).global_set(context_global);
+            for (l, g) in fields.clone().enumerate() {
+                code.instructions()
+                    .local_get(u32::try_from(1 + l).unwrap())
+                    .global_set(g);
+            }
+            code.instructions()
+                .i32_const(0)
+                .return_call(self.current_resource.as_ref().unwrap().resource_new_fn)
+                .end();
+            let func = self.add_function(&ty, code.into_raw_body());
+            if let Some(func_idx) =
+                self.make_component_export_wrapper_fn(name.span, &sig, func, &ty)
+            {
+                self.export_core_fn(&format!("{interface_name}#set-storage"), func_idx);
+                iface.export_fn("set-storage", &sig);
+            }
+        } else {
             let sig = ComponentAbiFunctionSignature {
                 params: vec![("storage".to_owned(), storage_record.clone())],
                 result: Some(utxo_own.clone()),

--- a/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@score.star.snap
@@ -2795,7 +2795,7 @@ TypedProgram {
   (type (;7;) (func))
   (type (;8;) (func (param i64 i64) (result i64)))
   (type (;9;) (func (param i32) (result i32 i64 i64 i32 i32)))
-  (type (;10;) (func (param i32 i64 i64 i32 i32) (result i32)))
+  (type (;10;) (func (param i32 i32 i64 i64 i32 i32) (result i32)))
   (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
   (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
   (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
@@ -3016,17 +3016,19 @@ TypedProgram {
       (local.get 6))
     (i32.const 8)
   )
-  (func (;27;) (type 10) (param i32 i64 i64 i32 i32) (result i32)
-    (global.set 0
+  (func (;27;) (type 10) (param i32 i32 i64 i64 i32 i32) (result i32)
+    (global.set 1
       (local.get 0))
-    (global.set 2
+    (global.set 0
       (local.get 1))
-    (global.set 3
+    (global.set 2
       (local.get 2))
-    (global.set 4
+    (global.set 3
       (local.get 3))
-    (global.set 5
+    (global.set 4
       (local.get 4))
+    (global.set 5
+      (local.get 5))
     (return_call 9
       (i32.const 0))
   )
@@ -3153,7 +3155,7 @@ TypedProgram {
                   (export (;13;) "storage" (type (eq 12)))
                   (type (;14;) (func (param "self" 1) (result 13)))
                   (export (;5;) "get-storage" (func (type 14)))
-                  (type (;15;) (func (param "storage" 13) (result 2)))
+                  (type (;15;) (func (param "ctx" 6) (param "storage" 13) (result 2)))
                   (export (;6;) "set-storage" (func (type 15)))
                 )
               )
@@ -3205,7 +3207,7 @@ world root {
 
     get-storage: func(self: borrow<utxo>) -> storage;
 
-    set-storage: func(storage: storage) -> utxo;
+    set-storage: func(ctx: s-utxo-context, storage: storage) -> utxo;
   }
 }
 package starstream:std {

--- a/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@token_mint_burn.star.snap
@@ -575,10 +575,9 @@ TypedProgram {
   (type (;2;) (func (param i32)))
   (type (;3;) (func (param i64 i64) (result i64)))
   (type (;4;) (func (result i32)))
-  (type (;5;) (func))
-  (type (;6;) (func (param i32 i32)))
-  (type (;7;) (func (param i32) (result i64)))
-  (type (;8;) (func (param i64) (result i32)))
+  (type (;5;) (func (param i32 i32)))
+  (type (;6;) (func (param i32) (result i64)))
+  (type (;7;) (func (param i64) (result i32)))
   (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
   (import "[export]my-token" "[resource-new]token" (func (;1;) (type 1)))
   (import "[export]my-token" "[resource-drop]token" (func (;2;) (type 2)))
@@ -646,18 +645,18 @@ TypedProgram {
       (then
         (unreachable)))
   )
-  (func (;6;) (type 5)
+  (func (;6;) (type 2) (param i32)
     (global.set 0
       (call 5
         (global.get 0)
         (i64.const 1)))
   )
-  (func (;7;) (type 6) (param i32 i32))
-  (func (;8;) (type 6) (param i32 i32))
-  (func (;9;) (type 7) (param i32) (result i64)
+  (func (;7;) (type 5) (param i32 i32))
+  (func (;8;) (type 5) (param i32 i32))
+  (func (;9;) (type 6) (param i32) (result i64)
     (global.get 0)
   )
-  (func (;10;) (type 8) (param i64) (result i32)
+  (func (;10;) (type 7) (param i64) (result i32)
     (global.set 0
       (local.get 0))
     (return_call 1
@@ -711,7 +710,7 @@ TypedProgram {
                   (type (;2;) (own 0))
                   (type (;3;) (func (result 2)))
                   (export (;0;) "[static]token.mint" (func (type 3)))
-                  (type (;4;) (func))
+                  (type (;4;) (func (param "this" 2)))
                   (export (;1;) "[static]token.burn" (func (type 4)))
                   (alias outer 1 1 (type (;5;)))
                   (export (;6;) "s-utxo" (type (eq 5)))
@@ -754,7 +753,7 @@ world root {
 
     resource token {
       mint: static func() -> token;
-      burn: static func();
+      burn: static func(this: token);
       attach: func(to: borrow<s-utxo>);
       detach: func(source: borrow<s-utxo>);
     }

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_fn.star.snap
@@ -329,6 +329,7 @@ TypedProgram {
   (type (;3;) (func))
   (type (;4;) (func (param i32) (result i32)))
   (type (;5;) (func (result i32)))
+  (type (;6;) (func (param i32 i32) (result i32)))
   (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
   (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
   (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
@@ -365,9 +366,11 @@ TypedProgram {
   (func (;11;) (type 4) (param i32) (result i32)
     (global.get 0)
   )
-  (func (;12;) (type 4) (param i32) (result i32)
-    (global.set 0
+  (func (;12;) (type 6) (param i32 i32) (result i32)
+    (global.set 1
       (local.get 0))
+    (global.set 0
+      (local.get 1))
     (return_call 5
       (i32.const 0))
   )
@@ -453,7 +456,7 @@ TypedProgram {
                   (export (;9;) "storage" (type (eq 8)))
                   (type (;10;) (func (param "self" 1) (result 9)))
                   (export (;1;) "get-storage" (func (type 10)))
-                  (type (;11;) (func (param "storage" 9) (result 2)))
+                  (type (;11;) (func (param "ctx" 6) (param "storage" 9) (result 2)))
                   (export (;2;) "set-storage" (func (type 11)))
                 )
               )
@@ -493,7 +496,7 @@ world root {
 
     get-storage: func(self: borrow<utxo>) -> storage;
 
-    set-storage: func(storage: storage) -> utxo;
+    set-storage: func(ctx: s-utxo-context, storage: storage) -> utxo;
   }
 }
 package starstream:std {

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_impl_abi.star.snap
@@ -294,6 +294,7 @@ TypedProgram {
   (type (;2;) (func (param i32 i64 i64 i64 i64)))
   (type (;3;) (func (param i32) (result i32)))
   (type (;4;) (func))
+  (type (;5;) (func (param i32 i32) (result i32)))
   (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
   (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
   (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
@@ -317,9 +318,11 @@ TypedProgram {
   (func (;9;) (type 3) (param i32) (result i32)
     (global.get 0)
   )
-  (func (;10;) (type 3) (param i32) (result i32)
-    (global.set 0
+  (func (;10;) (type 5) (param i32 i32) (result i32)
+    (global.set 1
       (local.get 0))
+    (global.set 0
+      (local.get 1))
     (return_call 5
       (i32.const 0))
   )
@@ -403,8 +406,12 @@ TypedProgram {
                   (export (;5;) "storage" (type (eq 4)))
                   (type (;6;) (func (param "self" 1) (result 5)))
                   (export (;1;) "get-storage" (func (type 6)))
-                  (type (;7;) (func (param "storage" 5) (result 2)))
-                  (export (;2;) "set-storage" (func (type 7)))
+                  (alias outer 1 10 (type (;7;)))
+                  (export (;8;) "s-utxo-context" (type (eq 7)))
+                  (type (;9;) (borrow 8))
+                  (type (;10;) (own 8))
+                  (type (;11;) (func (param "ctx" 10) (param "storage" 5) (result 2)))
+                  (export (;2;) "set-storage" (func (type 11)))
                 )
               )
               (export (;4;) "my-utxo" (instance (type 20)))
@@ -431,6 +438,8 @@ world root {
   use starstream:self/my-utxo.{utxo as u-my-utxo};
 
   export my-utxo: interface {
+    use starstream:std/utxo-context.{utxo-context as s-utxo-context};
+
     resource utxo {
       hello: func() -> s32;
     }
@@ -441,7 +450,7 @@ world root {
 
     get-storage: func(self: borrow<utxo>) -> storage;
 
-    set-storage: func(storage: storage) -> utxo;
+    set-storage: func(ctx: s-utxo-context, storage: storage) -> utxo;
   }
 }
 package starstream:std {

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_main_fn.star.snap
@@ -222,6 +222,7 @@ TypedProgram {
   (type (;3;) (func))
   (type (;4;) (func (param i32) (result i32)))
   (type (;5;) (func (result i32)))
+  (type (;6;) (func (param i32 i32) (result i32)))
   (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
   (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
   (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
@@ -255,9 +256,11 @@ TypedProgram {
   (func (;10;) (type 4) (param i32) (result i32)
     (global.get 0)
   )
-  (func (;11;) (type 4) (param i32) (result i32)
-    (global.set 0
+  (func (;11;) (type 6) (param i32 i32) (result i32)
+    (global.set 1
       (local.get 0))
+    (global.set 0
+      (local.get 1))
     (return_call 5
       (i32.const 0))
   )
@@ -343,7 +346,7 @@ TypedProgram {
                   (export (;9;) "storage" (type (eq 8)))
                   (type (;10;) (func (param "self" 1) (result 9)))
                   (export (;1;) "get-storage" (func (type 10)))
-                  (type (;11;) (func (param "storage" 9) (result 2)))
+                  (type (;11;) (func (param "ctx" 6) (param "storage" 9) (result 2)))
                   (export (;2;) "set-storage" (func (type 11)))
                 )
               )
@@ -383,7 +386,7 @@ world root {
 
     get-storage: func(self: borrow<utxo>) -> storage;
 
-    set-storage: func(storage: storage) -> utxo;
+    set-storage: func(ctx: s-utxo-context, storage: storage) -> utxo;
   }
 }
 package starstream:std {

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_nothing.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_nothing.star.snap
@@ -52,6 +52,7 @@ TypedProgram {
   (type (;2;) (func (param i32 i64 i64 i64 i64)))
   (type (;3;) (func (param i32) (result i32)))
   (type (;4;) (func))
+  (type (;5;) (func (param i32 i32) (result i32)))
   (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
   (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
   (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
@@ -70,9 +71,11 @@ TypedProgram {
   (func (;7;) (type 3) (param i32) (result i32)
     (global.get 0)
   )
-  (func (;8;) (type 3) (param i32) (result i32)
-    (global.set 0
+  (func (;8;) (type 5) (param i32 i32) (result i32)
+    (global.set 1
       (local.get 0))
+    (global.set 0
+      (local.get 1))
     (return_call 4
       (i32.const 0))
   )
@@ -143,8 +146,12 @@ TypedProgram {
                   (export (;4;) "storage" (type (eq 3)))
                   (type (;5;) (func (param "self" 1) (result 4)))
                   (export (;0;) "get-storage" (func (type 5)))
-                  (type (;6;) (func (param "storage" 4) (result 2)))
-                  (export (;1;) "set-storage" (func (type 6)))
+                  (alias outer 1 10 (type (;6;)))
+                  (export (;7;) "s-utxo-context" (type (eq 6)))
+                  (type (;8;) (borrow 7))
+                  (type (;9;) (own 7))
+                  (type (;10;) (func (param "ctx" 9) (param "storage" 4) (result 2)))
+                  (export (;1;) "set-storage" (func (type 10)))
                 )
               )
               (export (;3;) "my-utxo" (instance (type 19)))
@@ -170,6 +177,8 @@ world root {
   use starstream:self/my-utxo.{utxo as u-my-utxo};
 
   export my-utxo: interface {
+    use starstream:std/utxo-context.{utxo-context as s-utxo-context};
+
     resource utxo;
 
     record storage {
@@ -178,7 +187,7 @@ world root {
 
     get-storage: func(self: borrow<utxo>) -> storage;
 
-    set-storage: func(storage: storage) -> utxo;
+    set-storage: func(ctx: s-utxo-context, storage: storage) -> utxo;
   }
 }
 package starstream:std {

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_storage.star.snap
@@ -395,7 +395,7 @@ TypedProgram {
   (type (;5;) (func))
   (type (;6;) (func (param i64 i64) (result i64)))
   (type (;7;) (func (param i32) (result i32 i64 i64)))
-  (type (;8;) (func (param i32 i64 i64) (result i32)))
+  (type (;8;) (func (param i32 i32 i64 i64) (result i32)))
   (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
   (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
   (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
@@ -497,13 +497,15 @@ TypedProgram {
       (local.get 4))
     (i32.const 8)
   )
-  (func (;14;) (type 8) (param i32 i64 i64) (result i32)
-    (global.set 0
+  (func (;14;) (type 8) (param i32 i32 i64 i64) (result i32)
+    (global.set 1
       (local.get 0))
-    (global.set 2
+    (global.set 0
       (local.get 1))
-    (global.set 3
+    (global.set 2
       (local.get 2))
+    (global.set 3
+      (local.get 3))
     (return_call 4
       (i32.const 0))
   )
@@ -586,7 +588,7 @@ TypedProgram {
                   (export (;10;) "storage" (type (eq 9)))
                   (type (;11;) (func (param "self" 1) (result 10)))
                   (export (;2;) "get-storage" (func (type 11)))
-                  (type (;12;) (func (param "storage" 10) (result 2)))
+                  (type (;12;) (func (param "ctx" 6) (param "storage" 10) (result 2)))
                   (export (;3;) "set-storage" (func (type 12)))
                 )
               )
@@ -628,7 +630,7 @@ world root {
 
     get-storage: func(self: borrow<utxo>) -> storage;
 
-    set-storage: func(storage: storage) -> utxo;
+    set-storage: func(ctx: s-utxo-context, storage: storage) -> utxo;
   }
 }
 package starstream:std {

--- a/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@utxo_types.star.snap
@@ -161,7 +161,8 @@ TypedProgram {
   (type (;2;) (func (param i32 i64 i64 i64 i64)))
   (type (;3;) (func (param i32) (result i32)))
   (type (;4;) (func))
-  (type (;5;) (func (param i32 i32)))
+  (type (;5;) (func (param i32 i32) (result i32)))
+  (type (;6;) (func (param i32 i32)))
   (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
   (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
   (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
@@ -181,13 +182,15 @@ TypedProgram {
   (func (;7;) (type 3) (param i32) (result i32)
     (global.get 0)
   )
-  (func (;8;) (type 3) (param i32) (result i32)
-    (global.set 0
+  (func (;8;) (type 5) (param i32 i32) (result i32)
+    (global.set 1
       (local.get 0))
+    (global.set 0
+      (local.get 1))
     (return_call 4
       (i32.const 0))
   )
-  (func (;9;) (type 5) (param i32 i32))
+  (func (;9;) (type 6) (param i32 i32))
   (@custom "component-type"
     (component
       (@custom "wit-component-encoding" "\04\00")
@@ -255,8 +258,12 @@ TypedProgram {
                   (export (;4;) "storage" (type (eq 3)))
                   (type (;5;) (func (param "self" 1) (result 4)))
                   (export (;0;) "get-storage" (func (type 5)))
-                  (type (;6;) (func (param "storage" 4) (result 2)))
-                  (export (;1;) "set-storage" (func (type 6)))
+                  (alias outer 1 10 (type (;6;)))
+                  (export (;7;) "s-utxo-context" (type (eq 6)))
+                  (type (;8;) (borrow 7))
+                  (type (;9;) (own 7))
+                  (type (;10;) (func (param "ctx" 9) (param "storage" 4) (result 2)))
+                  (export (;1;) "set-storage" (func (type 10)))
                 )
               )
               (export (;3;) "my-utxo" (instance (type 19)))
@@ -285,6 +292,8 @@ world root {
 
   export script-accepts-utxos: func(utxo: borrow<s-utxo>, my-utxo: borrow<u-my-utxo>);
   export my-utxo: interface {
+    use starstream:std/utxo-context.{utxo-context as s-utxo-context};
+
     resource utxo;
 
     record storage {
@@ -293,7 +302,7 @@ world root {
 
     get-storage: func(self: borrow<utxo>) -> storage;
 
-    set-storage: func(storage: storage) -> utxo;
+    set-storage: func(ctx: s-utxo-context, storage: storage) -> utxo;
   }
 }
 package starstream:std {

--- a/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
+++ b/starstream-to-wasm/tests/snapshots/inputs@yield.star.snap
@@ -402,7 +402,7 @@ TypedProgram {
   (type (;4;) (func))
   (type (;5;) (func (param i32 i32) (result i32)))
   (type (;6;) (func (param i32) (result i32 i32 i32 i32)))
-  (type (;7;) (func (param i32 i32 i32 i32) (result i32)))
+  (type (;7;) (func (param i32 i32 i32 i32 i32) (result i32)))
   (import "starstream:std/builtin" "[method]utxo.has-method" (func (;0;) (type 0)))
   (import "starstream:std/utxo-context" "[resource-drop]utxo-context" (func (;1;) (type 1)))
   (import "starstream:std/utxo-context" "[method]utxo-context.resume" (func (;2;) (type 1)))
@@ -507,15 +507,17 @@ TypedProgram {
       (local.get 5))
     (i32.const 4)
   )
-  (func (;15;) (type 7) (param i32 i32 i32 i32) (result i32)
-    (global.set 0
+  (func (;15;) (type 7) (param i32 i32 i32 i32 i32) (result i32)
+    (global.set 1
       (local.get 0))
-    (global.set 2
+    (global.set 0
       (local.get 1))
-    (global.set 3
+    (global.set 2
       (local.get 2))
-    (global.set 4
+    (global.set 3
       (local.get 3))
+    (global.set 4
+      (local.get 4))
     (return_call 5
       (i32.const 0))
   )
@@ -609,7 +611,7 @@ TypedProgram {
                   (export (;10;) "storage" (type (eq 9)))
                   (type (;11;) (func (param "self" 1) (result 10)))
                   (export (;2;) "get-storage" (func (type 11)))
-                  (type (;12;) (func (param "storage" 10) (result 2)))
+                  (type (;12;) (func (param "ctx" 6) (param "storage" 10) (result 2)))
                   (export (;3;) "set-storage" (func (type 12)))
                 )
               )
@@ -653,7 +655,7 @@ world root {
 
     get-storage: func(self: borrow<utxo>) -> storage;
 
-    set-storage: func(storage: storage) -> utxo;
+    set-storage: func(ctx: s-utxo-context, storage: storage) -> utxo;
   }
 }
 package starstream:std {


### PR DESCRIPTION
1. Accept `own<utxo-context>` in `set-storage`
2. Accept `own<token>` in `burn fn`s

Future work:
* Drop borrowed resource handles passed to `attach`/`detach`, and other functions that accept borrowed resource handles.

Fixes #209.