### PR TITLE
rt-next: `upcast` and `downcast`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,11 +950,10 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.135.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9903e767cc0a95a59950de099a6b1d61e1476f774be1cdfa06d7ccdc9bfae56f"
+version = "0.136.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
- "cranelift-assembler-x64-meta 0.135.1",
+ "cranelift-assembler-x64-meta 0.136.0-dev",
 ]
 
 [[package]]
@@ -968,11 +967,10 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.135.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e777252ea3ec9daffa71408fbfe0793ab0a7b7bc3b2cf0f417dd0fa33964b8ef"
+version = "0.136.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
- "cranelift-srcgen 0.135.1",
+ "cranelift-srcgen 0.136.0-dev",
 ]
 
 [[package]]
@@ -987,12 +985,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.135.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7828208a36e6627481cea61bd24c6234e31411d5c58b48e80ca094a1d593b944"
+version = "0.136.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
- "cranelift-entity 0.135.1",
- "wasmtime-internal-core 48.0.1",
+ "cranelift-entity 0.136.0-dev",
+ "wasmtime-internal-core 49.0.0-dev",
 ]
 
 [[package]]
@@ -1008,13 +1005,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.135.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58c8447cc59ef98c49096679f81392ad0acec2224cea2bef52011f5169f9d02"
+version = "0.136.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "serde",
  "serde_derive",
- "wasmtime-internal-core 48.0.1",
+ "wasmtime-internal-core 49.0.0-dev",
 ]
 
 [[package]]
@@ -1047,25 +1043,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.135.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce520e899df1de583e7b564eafd66760fbc147d72894d2278ddac57a1489fcc0"
+version = "0.136.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64 0.135.1",
- "cranelift-bforest 0.135.1",
- "cranelift-bitset 0.135.1",
- "cranelift-codegen-meta 0.135.1",
- "cranelift-codegen-shared 0.135.1",
- "cranelift-control 0.135.1",
- "cranelift-entity 0.135.1",
- "cranelift-isle 0.135.1",
+ "cranelift-assembler-x64 0.136.0-dev",
+ "cranelift-bforest 0.136.0-dev",
+ "cranelift-bitset 0.136.0-dev",
+ "cranelift-codegen-meta 0.136.0-dev",
+ "cranelift-codegen-shared 0.136.0-dev",
+ "cranelift-control 0.136.0-dev",
+ "cranelift-entity 0.136.0-dev",
+ "cranelift-isle 0.136.0-dev",
  "gimli 0.33.0",
  "hashbrown 0.17.1",
  "libm",
  "log",
  "postcard",
- "pulley-interpreter 48.0.1",
+ "pulley-interpreter 49.0.0-dev",
  "regalloc2",
  "rustc-hash",
  "serde",
@@ -1073,7 +1068,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-core 48.0.1",
+ "wasmtime-internal-core 49.0.0-dev",
 ]
 
 [[package]]
@@ -1091,15 +1086,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.135.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8ab23e63d78ea6bbda18ae1ed9c958bc1cb88d90fb5e95f5ba62e9c019474b"
+version = "0.136.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
- "cranelift-assembler-x64-meta 0.135.1",
- "cranelift-codegen-shared 0.135.1",
- "cranelift-srcgen 0.135.1",
+ "cranelift-assembler-x64-meta 0.136.0-dev",
+ "cranelift-codegen-shared 0.136.0-dev",
+ "cranelift-srcgen 0.136.0-dev",
  "heck",
- "pulley-interpreter 48.0.1",
+ "pulley-interpreter 49.0.0-dev",
 ]
 
 [[package]]
@@ -1110,9 +1104,8 @@ checksum = "78fdb83ab012d0ee6a44ced7ca8788a444f17cf821c62f95d6ef87c9f0262518"
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.135.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24319a996b1ef40ebf8af69b39c868c790b35a42cfe38edacfd8c9deb75ea712"
+version = "0.136.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 
 [[package]]
 name = "cranelift-control"
@@ -1125,9 +1118,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-control"
-version = "0.135.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9856d68cc2cefb83229cb2c55b620dd38427555c2fe87d73f8a4421616f628"
+version = "0.136.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "arbitrary",
 ]
@@ -1146,14 +1138,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.135.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec225d6b79c5d61358cb5ea081a1384ec541dbf8c1a8c618d187875af326ad"
+version = "0.136.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
- "cranelift-bitset 0.135.1",
+ "cranelift-bitset 0.136.0-dev",
  "serde",
  "serde_derive",
- "wasmtime-internal-core 48.0.1",
+ "wasmtime-internal-core 49.0.0-dev",
 ]
 
 [[package]]
@@ -1170,11 +1161,10 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.135.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3a96a09bd9bd3cf6df2de2ea15d7418f493e946a8eaa1acfe39297a67ed3f3"
+version = "0.136.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
- "cranelift-codegen 0.135.1",
+ "cranelift-codegen 0.136.0-dev",
  "hashbrown 0.17.1",
  "log",
  "smallvec",
@@ -1189,9 +1179,8 @@ checksum = "94eaf429c32a12715429c7c6ddfdd43c170f4cdd7e97bfa507bd68a652091087"
 
 [[package]]
 name = "cranelift-isle"
-version = "0.135.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd28f593c36afbdc9aa17305c0bb66c39ce0530e1caffcf389fbec053950083e"
+version = "0.136.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 
 [[package]]
 name = "cranelift-native"
@@ -1206,11 +1195,10 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.135.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2987ca47affc261aa31ac643fb80dd7f8274cebf878003ba9f50cd6ff2c1055f"
+version = "0.136.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
- "cranelift-codegen 0.135.1",
+ "cranelift-codegen 0.136.0-dev",
  "libc",
  "target-lexicon",
 ]
@@ -1223,9 +1211,8 @@ checksum = "cba7c0ff5941842c36653da155580ce41e675c204a67ac1b4e1c478a9347bbb7"
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.135.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7431dd8c9def94aca43b27915dee0d42103d9b13922cfb044febcd975547d68"
+version = "0.136.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 
 [[package]]
 name = "crc32fast"
@@ -2555,6 +2542,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd229a0361b9d0d4396176e02d65897f487eebeab7caa6d443855ee152ca0b9c"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,14 +2956,13 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f755d75e0809a4738a3e4880eeeb852fadbe1de5a437505b84f09c381657012a"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
- "cranelift-bitset 0.135.1",
+ "cranelift-bitset 0.136.0-dev",
  "log",
- "pulley-macros 48.0.1",
- "wasmtime-internal-core 48.0.1",
+ "pulley-macros 49.0.0-dev",
+ "wasmtime-internal-core 49.0.0-dev",
 ]
 
 [[package]]
@@ -2980,9 +2978,8 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e69fa1c4a555946f82e7894a7df88b0e9ee03b4266829b4811467c616ce51d"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3406,9 +3403,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3607,7 +3604,7 @@ dependencies = [
  "tokio",
  "tower-lsp-server",
  "walkdir",
- "wit-component",
+ "wit-component 0.254.0",
 ]
 
 [[package]]
@@ -3636,10 +3633,10 @@ dependencies = [
  "thiserror 2.0.17",
  "wasm_runtime_layer 0.6.0",
  "wasmprinter 0.254.0",
- "wasmtime 48.0.1",
+ "wasmtime 49.0.0-dev",
  "wasmtime_runtime_layer",
  "wat",
- "wit-component",
+ "wit-component 0.254.0",
 ]
 
 [[package]]
@@ -3724,10 +3721,10 @@ dependencies = [
  "wasm-encoder 0.254.0",
  "wasmparser 0.254.0",
  "wasmprinter 0.254.0",
- "wasmtime 48.0.1",
+ "wasmtime 49.0.0-dev",
  "wat",
- "wit-component",
- "wit-parser",
+ "wit-component 0.254.0",
+ "wit-parser 0.254.0",
 ]
 
 [[package]]
@@ -3742,8 +3739,8 @@ dependencies = [
  "tokio",
  "tracing",
  "wasmparser 0.254.0",
- "wasmtime 48.0.1",
- "wit-component",
+ "wasmtime 49.0.0-dev",
+ "wit-component 0.254.0",
 ]
 
 [[package]]
@@ -3758,7 +3755,7 @@ dependencies = [
  "starstream-to-wasm",
  "termcolor",
  "wasmprinter 0.254.0",
- "wit-component",
+ "wit-component 0.254.0",
 ]
 
 [[package]]
@@ -3774,8 +3771,8 @@ dependencies = [
  "wasm-encoder 0.254.0",
  "wasmparser 0.254.0",
  "wasmprinter 0.254.0",
- "wasmtime 48.0.1",
- "wit-component",
+ "wasmtime 49.0.0-dev",
+ "wit-component 0.254.0",
 ]
 
 [[package]]
@@ -4074,9 +4071,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -4089,27 +4086,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -4390,9 +4387,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.254.0"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd717357bff09b5f1ea49aea8ed1cd149b0c521823a1cc70bc2ac16b90b651a"
+checksum = "7dd08e5283f98238f2f16f5f978188a33af9901b81186bb549faad306a7b5388"
 dependencies = [
  "anyhow",
  "heck",
@@ -4400,8 +4397,8 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec",
- "wasm-encoder 0.254.0",
- "wasmparser 0.254.0",
+ "wasm-encoder 0.258.0",
+ "wasmparser 0.258.0",
  "wat",
 ]
 
@@ -4445,6 +4442,18 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder 0.254.0",
  "wasmparser 0.254.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.258.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a11585adb92fe9b55ad1d760e8d8fb5d87e0d2e303cb8eed57f078d54293a2"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder 0.258.0",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]
@@ -4506,8 +4515,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9a61719f93a87b16d325921e251800c4833f8fab50fa21c7de73aed50086313"
 dependencies = [
  "bitflags 2.9.4",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "semver",
+ "serde",
 ]
 
 [[package]]
@@ -4530,6 +4541,17 @@ dependencies = [
  "anyhow",
  "termcolor",
  "wasmparser 0.254.0",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.258.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a65e30fb2cd3cc5cb7761a6064787b2abf017e6566d8d0dedf2bb7f55ad5383"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]
@@ -4572,9 +4594,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd39f78fe9bc82cee4025ec9d52118269e9a1498016cc60119b14f2e1d86a8d"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
@@ -4590,10 +4611,10 @@ dependencies = [
  "log",
  "mach2 0.6.0",
  "memfd",
- "object 0.39.1",
+ "object 0.40.0",
  "once_cell",
  "postcard",
- "pulley-interpreter 48.0.1",
+ "pulley-interpreter 49.0.0-dev",
  "rayon",
  "rustix",
  "semver",
@@ -4604,22 +4625,22 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.254.0",
- "wasmparser 0.254.0",
- "wasmtime-environ 48.0.1",
+ "wasm-encoder 0.258.0",
+ "wasmparser 0.258.0",
+ "wasmtime-environ 49.0.0-dev",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
  "wasmtime-internal-component-util",
- "wasmtime-internal-core 48.0.1",
- "wasmtime-internal-cranelift 48.0.1",
- "wasmtime-internal-fiber 48.0.1",
- "wasmtime-internal-jit-debug 48.0.1",
- "wasmtime-internal-jit-icache-coherence 48.0.1",
- "wasmtime-internal-unwinder 48.0.1",
- "wasmtime-internal-versioned-export-macros 48.0.1",
+ "wasmtime-internal-core 49.0.0-dev",
+ "wasmtime-internal-cranelift 49.0.0-dev",
+ "wasmtime-internal-fiber 49.0.0-dev",
+ "wasmtime-internal-jit-debug 49.0.0-dev",
+ "wasmtime-internal-jit-icache-coherence 49.0.0-dev",
+ "wasmtime-internal-unwinder 49.0.0-dev",
+ "wasmtime-internal-versioned-export-macros 49.0.0-dev",
  "wat",
  "windows-sys 0.61.2",
- "wit-parser",
+ "wit-parser 0.258.0",
 ]
 
 [[package]]
@@ -4653,20 +4674,19 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c1070d95484d048994ec109cd42c4932ac07e6ee3cc1886fb90c7a18ec29da"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "anyhow",
  "cpp_demangle 0.5.1",
- "cranelift-bforest 0.135.1",
- "cranelift-bitset 0.135.1",
- "cranelift-entity 0.135.1",
+ "cranelift-bforest 0.136.0-dev",
+ "cranelift-bitset 0.136.0-dev",
+ "cranelift-entity 0.136.0-dev",
  "gimli 0.33.0",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "log",
- "object 0.39.1",
+ "object 0.40.0",
  "postcard",
  "rustc-demangle",
  "semver",
@@ -4675,18 +4695,17 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.254.0",
- "wasmparser 0.254.0",
- "wasmprinter 0.254.0",
+ "wasm-encoder 0.258.0",
+ "wasmparser 0.258.0",
+ "wasmprinter 0.258.0",
  "wasmtime-internal-component-util",
- "wasmtime-internal-core 48.0.1",
+ "wasmtime-internal-core 49.0.0-dev",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d447fd40f3e149cda8c0cd808660a1d1de438f3ff28627abb9bcda90dfb4895"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "base64",
  "directories-next",
@@ -4697,16 +4716,15 @@ dependencies = [
  "serde_derive",
  "sha2",
  "toml",
- "wasmtime-environ 48.0.1",
+ "wasmtime-environ 49.0.0-dev",
  "windows-sys 0.61.2",
  "zstd",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d2b2f9f89a65bb2277d82fbdd49263d27d8233bc717d750c4b13a23d57721c"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4714,14 +4732,13 @@ dependencies = [
  "syn 2.0.106",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.258.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fe8292115fda08875f29064ae9f7f0b2c1ffbb323146eae538ae34b8a613f"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 
 [[package]]
 name = "wasmtime-internal-core"
@@ -4737,9 +4754,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821385794cf44baf2967fd2515368429ed2bff9b9b256f62d09a0f1301474fd8"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -4776,28 +4792,27 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0238b4a52773457ad1b8a1a26be90486e0ca0108cf46b9be16cc1d8d8cabdfa1"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
- "cranelift-codegen 0.135.1",
- "cranelift-control 0.135.1",
- "cranelift-entity 0.135.1",
- "cranelift-frontend 0.135.1",
- "cranelift-native 0.135.1",
+ "cranelift-codegen 0.136.0-dev",
+ "cranelift-control 0.136.0-dev",
+ "cranelift-entity 0.136.0-dev",
+ "cranelift-frontend 0.136.0-dev",
+ "cranelift-native 0.136.0-dev",
  "gimli 0.33.0",
  "itertools 0.14.0",
  "log",
- "object 0.39.1",
- "pulley-interpreter 48.0.1",
+ "object 0.40.0",
+ "pulley-interpreter 49.0.0-dev",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.17",
- "wasmparser 0.254.0",
- "wasmtime-environ 48.0.1",
- "wasmtime-internal-core 48.0.1",
- "wasmtime-internal-unwinder 48.0.1",
- "wasmtime-internal-versioned-export-macros 48.0.1",
+ "wasmparser 0.258.0",
+ "wasmtime-environ 49.0.0-dev",
+ "wasmtime-internal-core 49.0.0-dev",
+ "wasmtime-internal-unwinder 49.0.0-dev",
+ "wasmtime-internal-versioned-export-macros 49.0.0-dev",
 ]
 
 [[package]]
@@ -4817,15 +4832,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "596f1d85e06cbf9c9add9c78ea135171c5753264ffe94a83dcc082a1ff49fc9b"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "cc",
  "libc",
  "rustix",
- "wasmtime-environ 48.0.1",
- "wasmtime-internal-versioned-export-macros 48.0.1",
+ "wasmtime-environ 49.0.0-dev",
+ "wasmtime-internal-versioned-export-macros 49.0.0-dev",
  "windows-sys 0.61.2",
 ]
 
@@ -4841,14 +4855,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365faed74827bb0116785bab5872372df1baaec9ec0003c83bc99ccdc595f689"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "cc",
- "object 0.39.1",
+ "object 0.40.0",
  "rustix",
- "wasmtime-internal-versioned-export-macros 48.0.1",
+ "wasmtime-internal-versioned-export-macros 49.0.0-dev",
 ]
 
 [[package]]
@@ -4865,12 +4878,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cce25afd9e7ac4957292a5c6a219951dd0f140b8417e7378a97f50b67c3b96f"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "libc",
- "wasmtime-internal-core 48.0.1",
+ "wasmtime-internal-core 49.0.0-dev",
  "windows-sys 0.61.2",
 ]
 
@@ -4889,14 +4901,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fdea09d51e39c774984ca68a7d7486767e5b2935f5e686fa654aabcfc3c42d"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
- "cranelift-codegen 0.135.1",
+ "cranelift-codegen 0.136.0-dev",
  "log",
- "object 0.39.1",
- "wasmtime-environ 48.0.1",
+ "object 0.40.0",
+ "wasmtime-environ 49.0.0-dev",
 ]
 
 [[package]]
@@ -4912,9 +4923,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e48a5f514c38c2f74249724cb3501e45548d3311ca9e3881694859fd6ba116"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4940,16 +4950,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "48.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07429ab53576255be2d298e04b2e1f381e39645465adbaebd69314b5430165c0"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
  "heck",
  "indexmap 2.14.0",
- "wit-component",
- "wit-parser",
+ "wit-component 0.258.0",
+ "wit-parser 0.258.0",
 ]
 
 [[package]]
@@ -5265,9 +5274,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"
@@ -5289,9 +5298,28 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.254.0",
- "wasm-metadata",
+ "wasm-metadata 0.254.0",
  "wasmparser 0.254.0",
- "wit-parser",
+ "wit-parser 0.254.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.258.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "481b5c47b2ecce0389b5e08a05557d6a190c9cd761773b8880a8017ee04dc7ef"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.4",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.258.0",
+ "wasm-metadata 0.258.0",
+ "wasmparser 0.258.0",
+ "wit-parser 0.258.0",
 ]
 
 [[package]]
@@ -5311,6 +5339,25 @@ dependencies = [
  "serde_json",
  "unicode-ident",
  "wasmparser 0.254.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.258.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4daaa3cd97ae49ecd0a99dc009d453f93e0f083dd3be38c0f24a83a93e37ac"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-ident",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ tracing = { version = "0.1.44", default-features = false }
 wasm-encoder = "0.254.0"
 wasmprinter = "0.254.0"
 wasmparser = "0.254.0"
-wasmtime = { version = "48.0.1", default-features = false }
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "56cce8cfef552f458c2044187ad2ba1512e3e2df", default-features = false }
 wit-component = "0.254.0"
 wit-parser = "0.254.0"
 

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -174,90 +174,145 @@ fn link_event_instance<T: Host>(
     Ok(())
 }
 
+/// Link UTXO downcast.
+#[instrument(level = "trace", skip_all)]
+fn link_utxo_downcast<T: Host>(
+    component: Component,
+    linker: &mut LinkerInstance<T>,
+    instance_idx: ComponentExportIndex,
+) -> wasmtime::Result<()> {
+    linker.func_wrap("downcast", move |mut store, (utxo,)| {
+        let utxo = store
+            .data_mut()
+            .table()
+            .get::<Utxo<T::UtxoContext>>(&utxo)?;
+        if !Component::same(&utxo.component, &component) {
+            return Ok((None,));
+        }
+        if utxo.instance_idx != instance_idx {
+            return Ok((None,));
+        }
+        let utxo = utxo.clone();
+        let utxo = store.data_mut().table().push(utxo)?;
+        Ok((Some(utxo),))
+    })
+}
+
+/// Link UTXO upcast.
+#[instrument(level = "trace", skip_all)]
+fn link_utxo_upcast<T: Host>(linker: &mut LinkerInstance<T>) -> wasmtime::Result<()> {
+    linker.func_wrap("upcast", move |mut store, (utxo,)| {
+        let utxo = store
+            .data_mut()
+            .table()
+            .get::<Utxo<T::UtxoContext>>(&utxo)
+            .cloned()?;
+        let utxo = store.data_mut().table().push(utxo)?;
+        Ok((utxo,))
+    })
+}
+
+/// Link typed UTXO main in a [`LinkerInstance`]
+#[instrument(level = "trace", skip_all)]
+fn link_typed_utxo_main<T: Host>(
+    target: &ContractImportTarget<'_, T>,
+    linker: &mut LinkerInstance<T>,
+    ty: types::ComponentFunc,
+    instance_idx: ComponentExportIndex,
+    idx: ComponentExportIndex,
+    name: &str,
+) -> wasmtime::Result<()> {
+    let mut result_tys = ty.results();
+    let (Some(Type::Own(..)), None) = (result_tys.next(), result_tys.next()) else {
+        bail!("`main fn` import does not return a single resource value")
+    };
+    let contract = target.contract().cloned();
+    linker.func_new_async(name, move |mut store, _ty, params, results| {
+        let contract = contract.clone();
+        Box::new(async move {
+            let contract = contract.unwrap_or_else(|| T::contract(store.as_context_mut()));
+            let instance = contract.instantiate(&mut store).await?;
+
+            let mut params = {
+                let mut ps = Vec::with_capacity(params.len().saturating_add(1));
+                ps.push(Val::Bool(false));
+                for p in params {
+                    ps.push(p.clone());
+                }
+                ps
+            };
+            let utxo = T::call_utxo_main(store.as_context_mut(), move |mut store, cx| {
+                Box::pin(async move {
+                    let cx_res = store.data_mut().table().push(cx.clone())?;
+                    let cx_res = cx_res.try_into_resource_any(&mut store)?;
+                    params[0] = Val::Resource(cx_res);
+                    instance
+                        .construct_utxo(&mut store, instance_idx, idx, params, cx)
+                        .await
+                })
+            })
+            .await?;
+            let utxo = store.data_mut().table().push(utxo)?;
+            let utxo = utxo.try_into_resource_any(store.as_context_mut())?;
+            results[0] = Val::Resource(utxo);
+            Ok(())
+        })
+    })
+}
+
+/// Link typed UTXO method in a [`LinkerInstance`]
+#[instrument(level = "trace", skip_all)]
+fn link_typed_utxo_method<T: Host>(
+    linker: &mut LinkerInstance<T>,
+    ty: types::ComponentFunc,
+    idx: ComponentExportIndex,
+    name: &str,
+) -> wasmtime::Result<()> {
+    let Some((_, Type::Borrow(..))) = ty.params().next() else {
+        bail!("function does not take borrowed resource type as first parameter");
+    };
+    linker.func_new_async(name, move |mut store, _ty, params, results| {
+        Box::new(async move {
+            let Some(Val::Resource(utxo)) = params.first() else {
+                bail!("first parameter is not a resource")
+            };
+            let utxo = utxo.try_into_resource::<Utxo<T::UtxoContext>>(&mut store)?;
+            let &Utxo {
+                instance, resource, ..
+            } = store.data_mut().table().get(&utxo)?;
+            let f = instance
+                .get_func(&mut store, idx)
+                .context("method export not found")?;
+            let params = {
+                let mut ps = Vec::with_capacity(params.len());
+                ps.push(Val::Resource(resource));
+                for p in &params[1..] {
+                    ps.push(p.clone());
+                }
+                ps
+            };
+            f.call_async(&mut store, &params, results).await?;
+            Ok(())
+        })
+    })
+}
+
 /// Link typed UTXO [`types::ComponentFunc`] in a [`LinkerInstance`]
-#[instrument(level = "trace", skip(target, linker, ty, instance))]
+#[instrument(level = "trace", skip(target, linker, ty, instance_idx))]
 fn link_typed_utxo_function<T: Host>(
     target: &ContractImportTarget<'_, T>,
     linker: &mut LinkerInstance<T>,
     ty: types::ComponentFunc,
-    instance: &ComponentExportIndex,
+    instance_idx: &ComponentExportIndex,
     name: &str,
 ) -> wasmtime::Result<()> {
     let idx = target
         .component()
-        .get_export_index(Some(instance), name)
+        .get_export_index(Some(instance_idx), name)
         .with_context(|| format!("`{name}` export was not found"))?;
     match name.split_once(']') {
-        Some(("[static", ..)) => {
-            let (Some(Type::Own(..)), None) = ({
-                let mut result_tys = ty.results();
-                (result_tys.next(), result_tys.next())
-            }) else {
-                bail!("function does not return a single resource value")
-            };
-            let instance_idx = *instance;
-            let contract = target.contract().cloned();
-            linker.func_new_async(name, move |mut store, _ty, params, results| {
-                let contract = contract.clone();
-                Box::new(async move {
-                    let contract = contract.unwrap_or_else(|| T::contract(store.as_context_mut()));
-                    let instance = contract.instantiate(&mut store).await?;
-
-                    let mut params = {
-                        let mut ps = Vec::with_capacity(params.len().saturating_add(1));
-                        ps.push(Val::Bool(false));
-                        for p in params {
-                            ps.push(p.clone());
-                        }
-                        ps
-                    };
-                    let utxo = T::call_utxo_main(store.as_context_mut(), move |mut store, cx| {
-                        Box::pin(async move {
-                            let cx_res = store.data_mut().table().push(cx.clone())?;
-                            let cx_res = cx_res.try_into_resource_any(&mut store)?;
-                            params[0] = Val::Resource(cx_res);
-                            instance
-                                .construct_utxo(&mut store, instance_idx, idx, params, cx)
-                                .await
-                        })
-                    })
-                    .await?;
-                    let utxo = store.data_mut().table().push(utxo)?;
-                    let utxo = utxo.try_into_resource_any(store.as_context_mut())?;
-                    results[0] = Val::Resource(utxo);
-                    Ok(())
-                })
-            })
-        }
-        Some(("[method", ..)) => {
-            let Some((_, Type::Borrow(..))) = ty.params().next() else {
-                bail!("function does not take borrowed resource type as first parameter");
-            };
-            linker.func_new_async(name, move |mut store, _ty, params, results| {
-                Box::new(async move {
-                    let Some(Val::Resource(utxo)) = params.first() else {
-                        bail!("first parameter is not a resource")
-                    };
-                    let utxo = utxo.try_into_resource::<Utxo<T::UtxoContext>>(&mut store)?;
-                    let &Utxo {
-                        instance, resource, ..
-                    } = store.data_mut().table().get(&utxo)?;
-                    let f = instance
-                        .get_func(&mut store, idx)
-                        .context("method export not found")?;
-                    let params = {
-                        let mut ps = Vec::with_capacity(params.len());
-                        ps.push(Val::Resource(resource));
-                        for p in &params[1..] {
-                            ps.push(p.clone());
-                        }
-                        ps
-                    };
-                    f.call_async(&mut store, &params, results).await?;
-                    Ok(())
-                })
-            })
-        }
+        Some(("[static", ..)) => link_typed_utxo_main(target, linker, ty, *instance_idx, idx, name),
+        Some(("[method", ..)) => link_typed_utxo_method(linker, ty, idx, name),
         _ => bail!("unexpected typed UTXO instance function import `{name}`"),
     }
 }
@@ -271,14 +326,20 @@ fn link_typed_utxo_instance<T: Host>(
     name: &str,
 ) -> wasmtime::Result<()> {
     let component = target.component();
-    let idx = component
+    let instance_idx = component
         .get_export_index(None, name)
         .with_context(|| format!("`{name}` export was not found"))?;
     for (name, types::ComponentExtern { ty, .. }) in ty.exports(component.engine()) {
         debug!(name, "linking typed UTXO instance item");
         match ty {
+            types::ComponentItem::ComponentFunc(..) if name == "downcast" => {
+                link_utxo_downcast(component.clone(), linker, instance_idx)?;
+            }
+            types::ComponentItem::ComponentFunc(..) if name == "upcast" => {
+                link_utxo_upcast(linker)?;
+            }
             types::ComponentItem::ComponentFunc(ty) => {
-                link_typed_utxo_function(target, linker, ty, &idx, name)?;
+                link_typed_utxo_function(target, linker, ty, &instance_idx, name)?;
             }
             types::ComponentItem::CoreFunc(..) => {
                 bail!("typed UTXO instance core function imports unsupported")
@@ -1268,18 +1329,29 @@ impl<T: Host> Contract<T> {
             .instantiate_async(store)
             .await
             .context("failed to instantiate component")?;
-        Ok(ContractInstance(instance))
+        Ok(ContractInstance {
+            component: self.pre.component().clone(),
+            instance,
+        })
     }
 }
 
 /// Single instantiation of a [Contract]
-#[derive(Debug, Copy, Clone)]
-pub struct ContractInstance(Instance);
+#[derive(Debug, Clone)]
+pub struct ContractInstance {
+    component: Component,
+    instance: Instance,
+}
 
 impl ContractInstance {
     #[must_use]
+    pub fn component(&self) -> &Component {
+        &self.component
+    }
+
+    #[must_use]
     pub fn instance(&self) -> Instance {
-        self.0
+        self.instance
     }
 
     #[instrument(level = "trace", skip_all)]
@@ -1292,7 +1364,7 @@ impl ContractInstance {
         cx: T,
     ) -> wasmtime::Result<Utxo<T>> {
         let f = self
-            .0
+            .instance
             .get_func(store.as_context_mut(), name)
             .context("constructor function export not found")?;
         debug!("calling constructor function");
@@ -1304,7 +1376,8 @@ impl ContractInstance {
             bail!("invalid return value")
         };
         Ok(Utxo {
-            instance: self.0,
+            component: self.component.clone(),
+            instance: self.instance,
             instance_idx,
             resource,
             cx,
@@ -1346,7 +1419,7 @@ impl ContractInstance {
         mut results: impl AsMut<[Val]>,
     ) -> wasmtime::Result<()> {
         let f = self
-            .0
+            .instance
             .get_func(&mut store, idx)
             .context("method export not found")?;
         f.call_async(store, params.as_ref(), results.as_mut())
@@ -1363,7 +1436,7 @@ impl ContractInstance {
         fields: impl Into<Vec<(String, Val)>>,
     ) -> wasmtime::Result<Token> {
         let f = self
-            .0
+            .instance
             .get_func(store.as_context_mut(), set)
             .context("`set-storage` export not found")?;
         debug!("calling `set-storage`");
@@ -1375,7 +1448,7 @@ impl ContractInstance {
             bail!("invalid return value")
         };
         Ok(Token {
-            instance: self.0,
+            instance: self.instance,
             resource,
         })
     }
@@ -1389,7 +1462,7 @@ impl ContractInstance {
         mut results: impl AsMut<[Val]>,
     ) -> wasmtime::Result<()> {
         let f = self
-            .0
+            .instance
             .get_func(store.as_context_mut(), idx)
             .context("coordination script export not found")?;
         debug!("calling coordination script");
@@ -1497,8 +1570,9 @@ impl CoordinationScriptExport {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct Utxo<T> {
+    component: Component,
     instance: Instance,
     instance_idx: ComponentExportIndex,
     resource: ResourceAny,


### PR DESCRIPTION
Implement `upcast` and `downcast`

- `upcast` simply "wraps" the UTXO resource and returns the new owned handle
- `downcast` "unwraps" the UTXO resource and checks that:
   - `component` the UTXO resource originated from matches the link-time target (i.e. it's either "self" or a contract, which was looked up by digest using `external-id`)
   - instance export index the UTXO resource is "typed" by matches the link-time target instance export index

We need the component equality check for this to work, therefore filed an upstream PR https://github.com/bytecodealliance/wasmtime/pull/14257 and switched to a git rev in this PR

closes #175 