### PR TITLE
begin ledger implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -96,15 +111,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -593,10 +617,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
+name = "base256emoji"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
+dependencies = [
+ "const-str",
+ "match-lookup",
+]
+
+[[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "beef"
@@ -819,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.49"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -829,11 +881,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.49"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -841,21 +893,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -907,6 +959,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-str"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +981,16 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "coset"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8cc80f631f8307b887faca24dcc3abc427cd0367f6eb6188f6e8f5b7ad8fb"
+dependencies = [
+ "ciborium",
+ "ciborium-io",
+]
 
 [[package]]
 name = "cpp_demangle"
@@ -1156,6 +1230,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,12 +1271,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a127ecbb3c4632e1525380e04c0c3fcf8dcb44d32a79ea290d8a36906edcd8"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
+dependencies = [
+ "data-encoding",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -1236,6 +1373,31 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "educe"
@@ -1317,7 +1479,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "env_filter",
  "log",
@@ -1399,6 +1561,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1649,6 +1817,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,6 +1935,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers-accept"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78beb98ea9a8f76b4a38c5ca651db6aa84701f307b63b4e0d78342ad4219c7e4"
+dependencies = [
+ "headers-core",
+ "http",
+ "mediatype",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,10 +1976,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -2122,6 +2410,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
+name = "match-lookup"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549e39695cc0b640f3cb378053832db3d2133422d49e8dcae5c866a2aaf1f730"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2428,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata 0.4.13",
 ]
+
+[[package]]
+name = "mediatype"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120fa187be19d9962f0926633453784691731018a2bf936ddb4e29101b79c4a7"
 
 [[package]]
 name = "memchr"
@@ -2206,6 +2511,28 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
+dependencies = [
+ "base-x",
+ "base256emoji",
+ "base45",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
+dependencies = [
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2688,6 +3015,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2784,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2823,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3079,6 +3416,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3309,6 +3655,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,6 +3754,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3541,6 +3906,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "starstream-ledger"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "ciborium",
+ "coset",
+ "ed25519-dalek",
+ "headers-accept",
+ "headers-core",
+ "hex",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mediatype",
+ "multibase",
+ "multihash",
+ "sha2",
+ "starstream-compiler",
+ "starstream-runtime-next",
+ "starstream-to-wasm",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "wasmtime",
+ "wasmtime-wizer",
+]
+
+[[package]]
+name = "starstream-ledger-cli"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ed25519-dalek",
+ "hex",
+ "http",
+ "hyper-util",
+ "rand_core 0.6.4",
+ "sha2",
+ "starstream-compiler",
+ "starstream-ledger",
+ "starstream-to-wasm",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wasmtime",
+ "wit-component 0.254.0",
+ "zeroize",
+]
+
+[[package]]
+name = "starstream-ledger-node"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ed25519-dalek",
+ "hex",
+ "sha2",
+ "starstream-ledger",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wasmtime",
+]
+
+[[package]]
 name = "starstream-runtime-next"
 version = "0.0.0"
 dependencies = [
@@ -3666,6 +4102,17 @@ name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3883,6 +4330,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4012,9 +4473,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4038,6 +4499,12 @@ dependencies = [
  "num-integer",
  "strength_reduce",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-arena"
@@ -4082,6 +4549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4123,6 +4596,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -4541,6 +5023,17 @@ dependencies = [
  "indexmap 2.14.0",
  "wit-component 0.258.0",
  "wit-parser 0.258.0",
+]
+
+[[package]]
+name = "wasmtime-wizer"
+version = "49.0.0-dev"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+dependencies = [
+ "log",
+ "wasm-encoder 0.258.0",
+ "wasmparser 0.258.0",
+ "wasmtime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ members = [
   "starstream-interpreter",
   "starstream-language-server",
   "starstream-language-server-web",
+  "starstream-ledger",
+  "starstream-ledger-cli",
+  "starstream-ledger-node",
   "starstream-runtime-next",
   "starstream-sandbox-web",
   "starstream-to-wasm",
@@ -28,18 +31,39 @@ license = "MIT/Apache-2.0"
 [workspace.dependencies]
 anyhow = { version = "1.0.102", default-features = false }
 ariadne = "0.5.1"
+bytes = { version = "1", default-features = false }
 chumsky = "0.11.1"
+ciborium = { version = "0.2", default-features = false }
+clap = { version = "4.6.1", default-features = false }
+coset = { version = "0.3", default-features = false }
+ed25519-dalek = { version = "2", default-features = false }
+headers-accept = { version = "0.3", default-features = false }
+headers-core = { version = "0.3", default-features = false }
+hex = { version = "0.4.3", default-features = false }
+http = { version = "1", default-features = false }
+http-body = { version = "1", default-features = false }
+http-body-util = { version = "0.1", default-features = false }
+hyper = { version = "1", default-features = false }
+hyper-util = { version = "0.1", default-features = false }
 indoc = "2.0"
 insta = "1.43"
+mediatype = { version = "0.21", default-features = false }
 miette = "7.6.0"
+multibase = { version = "0.9", default-features = false }
+multihash = { version = "0.19", default-features = false }
+rand_core = { version = "0.6", default-features = false }
 sha2 = "0.10.9"
 serde = "1.0.219"
 serde_json = "1.0"
 starstream-compiler = { path = "starstream-compiler" }
 starstream-language-server = { path = "starstream-language-server" }
+starstream-ledger = { path = "starstream-ledger", default-features = false }
+starstream-ledger-cli = { path = "starstream-ledger-cli" }
+starstream-ledger-node = { path = "starstream-ledger-node" }
 starstream-runtime-next = { path = "starstream-runtime-next" }
 starstream-to-wasm = { path = "starstream-to-wasm" }
 starstream-types = { path = "starstream-types" }
+tempfile = { version = "3.27", default-features = false }
 test-log = { version = "0.2.18", default-features = false }
 thiserror = "2.0.17"
 tokio = { version = "1.47.1", default-features = false }
@@ -47,12 +71,15 @@ tower-lsp-server = { version = "0.22.1", default-features = false, features = [
   "runtime-agnostic",
 ] }
 tracing = { version = "0.1.44", default-features = false }
+tracing-subscriber = { version = "0.3.23", default-features = false }
 wasm-encoder = "0.254.0"
 wasmprinter = "0.254.0"
 wasmparser = "0.254.0"
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "56cce8cfef552f458c2044187ad2ba1512e3e2df", default-features = false }
+wasmtime-wizer = { git = "https://github.com/bytecodealliance/wasmtime", rev = "56cce8cfef552f458c2044187ad2ba1512e3e2df", default-features = false }
 wit-component = "0.254.0"
 wit-parser = "0.254.0"
+zeroize = { version = "1.8.2", default-features = false }
 
 neo-fold-clean = { git = "https://github.com/LFDT-Nightstream/Nightstream.git", rev = "675f2ce9d9b05553d518c7ccb36abe2eddbad048" }
 neo-math = { git = "https://github.com/LFDT-Nightstream/Nightstream.git", rev = "675f2ce9d9b05553d518c7ccb36abe2eddbad048" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 version = "0.0.0"
 authors = []
 edition = "2024"
-rust-version = "1.94.0"
+rust-version = "1.95.0"
 repository = "https://github.com/LFDT-Nightstream/Starstream"
 license = "MIT/Apache-2.0"
 

--- a/starstream-ledger-cli/Cargo.toml
+++ b/starstream-ledger-cli/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+name = "starstream-ledger-cli"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true, features = ["std"] }
+clap = { workspace = true, features = [
+    "color",
+    "derive",
+    "error-context",
+    "help",
+    "std",
+    "string",
+    "suggestions",
+    "usage",
+] }
+ed25519-dalek = { workspace = true, features = ["fast", "rand_core", "zeroize"] }
+hex = { workspace = true, features = ["std"] }
+http = { workspace = true, features = ["std"] }
+hyper-util = { workspace = true, features = [
+    "client-legacy",
+    "http1",
+    "http2",
+    "tokio",
+] }
+rand_core = { workspace = true, features = ["getrandom", "std"] }
+sha2 = { workspace = true }
+starstream-ledger = { workspace = true, features = ["client"] }
+tokio = { workspace = true, features = [
+    "fs",
+    "io-std",
+    "macros",
+    "rt-multi-thread",
+] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = [
+    "ansi",
+    "env-filter",
+    "fmt",
+    "smallvec",
+    "tracing-log",
+] }
+zeroize = { workspace = true }
+
+[dev-dependencies]
+starstream-compiler = { workspace = true }
+starstream-ledger = { workspace = true, features = ["server"] }
+starstream-to-wasm = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["fs", "net", "process"] }
+wit-component = { workspace = true }
+wasmtime = { workspace = true }

--- a/starstream-ledger-cli/src/main.rs
+++ b/starstream-ledger-cli/src/main.rs
@@ -1,0 +1,185 @@
+//! Starstream ledger client.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+use clap::{Parser, Subcommand};
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use http::Uri;
+use hyper_util::rt::TokioExecutor;
+use rand_core::OsRng;
+use sha2::{Digest as _, Sha256};
+use starstream_ledger::client::http::ClientBuilder;
+use starstream_ledger::encode_digest;
+use tokio::fs;
+use tokio::io::{AsyncWriteExt as _, stdout};
+use tracing::info;
+use zeroize::Zeroizing;
+
+#[derive(Debug, Parser)]
+#[command(version, about)]
+struct Args {
+    /// Base URL of the ledger HTTP API.
+    #[arg(
+        long,
+        global = true,
+        value_name = "URL",
+        default_value = "http://[::1]:9000/"
+    )]
+    url: Uri,
+
+    /// Network identifier the transaction is bound to.
+    #[arg(long, global = true, default_value = "dev")]
+    network: Box<str>,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Manage accounts.
+    #[command(subcommand)]
+    Account(AccountCommand),
+
+    /// Manage published contracts.
+    #[command(subcommand)]
+    Contract(ContractCommand),
+
+    /// Manage signing keys.
+    #[command(subcommand)]
+    Key(KeyCommand),
+}
+
+/// Arguments common to every signed transaction.
+#[derive(Debug, clap::Args)]
+struct SigningArgs {
+    /// Path to a file containing the hex-encoded Ed25519 signing key.
+    #[arg(long, value_name = "PATH")]
+    key: PathBuf,
+
+    /// Transaction nonce.
+    #[arg(long)]
+    nonce: u64,
+}
+
+#[derive(Debug, Subcommand)]
+enum AccountCommand {
+    /// Fund an account with a credit signed by the admin key.
+    Fund {
+        #[command(flatten)]
+        signing: SigningArgs,
+
+        /// Hex-encoded Ed25519 public key of the account to fund.
+        #[arg(value_parser = parse_verifying_key)]
+        account: VerifyingKey,
+
+        /// Amount to credit the account with.
+        amount: u64,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+#[allow(clippy::large_enum_variant)]
+enum ContractCommand {
+    /// Compute contract digest.
+    Digest {
+        /// Path to the contract.
+        wasm: PathBuf,
+    },
+    /// Sign and publish a contract.
+    Publish {
+        #[command(flatten)]
+        signing: SigningArgs,
+
+        /// Path to the contract.
+        wasm: PathBuf,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum KeyCommand {
+    /// Generate a new Ed25519 key pair.
+    Generate,
+}
+
+async fn read_signing_key(path: &Path) -> anyhow::Result<SigningKey> {
+    let key = fs::read_to_string(path)
+        .await
+        .with_context(|| format!("failed to read signing key from `{}`", path.display()))?;
+    let key = Zeroizing::new(key);
+    let mut buf = Zeroizing::new([0u8; 32]);
+    hex::decode_to_slice(key.trim(), &mut *buf).context("key hex is not valid")?;
+    Ok(SigningKey::from_bytes(&buf))
+}
+
+fn parse_verifying_key(s: &str) -> anyhow::Result<VerifyingKey> {
+    let mut buf = [0u8; 32];
+    hex::decode_to_slice(s, &mut buf).context("key hex is not valid")?;
+    let key = VerifyingKey::from_bytes(&buf)?;
+    Ok(key)
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let Args {
+        url,
+        network,
+        command,
+    } = Args::parse();
+
+    tracing_subscriber::fmt()
+        .without_time()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_env_var("STARSTREAM_LEDGER_LOG")
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let http = hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build_http();
+    let client = ClientBuilder::new(http, url).network(network).build();
+    match command {
+        Command::Account(AccountCommand::Fund {
+            signing: SigningArgs { key, nonce },
+            account,
+            amount,
+        }) => {
+            let key = read_signing_key(&key).await?;
+            client.fund(key, nonce, &account, amount).await
+        }
+        Command::Contract(ContractCommand::Digest { wasm }) => {
+            let wasm = fs::read(&wasm)
+                .await
+                .with_context(|| format!("failed to read `{}`", wasm.display()))?;
+            let digest = Sha256::digest(&wasm);
+            stdout()
+                .write_all(encode_digest(&digest.into()).as_bytes())
+                .await
+                .context("failed to write digest to stdout")
+        }
+        Command::Contract(ContractCommand::Publish {
+            signing: SigningArgs { key, nonce },
+            wasm,
+        }) => {
+            let key = read_signing_key(&key).await?;
+            let wasm = fs::read(&wasm)
+                .await
+                .with_context(|| format!("failed to read `{}`", wasm.display()))?;
+            client.publish_contract(key, nonce, wasm).await
+        }
+        Command::Key(KeyCommand::Generate) => {
+            let key = SigningKey::generate(&mut OsRng);
+            info!(
+                public_key = hex::encode(key.verifying_key().to_bytes()),
+                "generated key pair"
+            );
+            stdout()
+                .write_all(hex::encode(key.to_bytes()).as_bytes())
+                .await
+                .context("failed to write signing key to stdout")
+        }
+    }
+}

--- a/starstream-ledger-cli/tests/cli.rs
+++ b/starstream-ledger-cli/tests/cli.rs
@@ -1,0 +1,146 @@
+use core::net::Ipv6Addr;
+
+use std::process::Output;
+use std::sync::{Arc, LazyLock};
+use std::{ffi::OsStr, process::Stdio};
+
+use anyhow::Context as _;
+use ed25519_dalek::SigningKey;
+use starstream_ledger::client::build_publish_envelope;
+use starstream_ledger::server::Ledger;
+use tempfile::NamedTempFile;
+use tokio::fs;
+use tokio::net::TcpListener;
+use tokio::process::Command;
+
+fn compile_contract(source: &str) -> Vec<u8> {
+    let (program, errors) = starstream_compiler::parse_program(source).into_output_errors();
+    assert!(errors.is_empty(), "parsing failed: {errors:?}");
+    let program = program.expect("parser produced no program");
+    let typed = starstream_compiler::typecheck_program(&program, Default::default())
+        .unwrap_or_else(|failure| panic!("typechecking failed: {:?}", failure.errors));
+    let result = starstream_to_wasm::compile(&typed.program);
+    assert!(
+        result.errors.is_empty(),
+        "compiling failed: {:?}",
+        result.errors
+    );
+    let wasm = result.wasm.expect("compiling produced no Wasm");
+    wit_component::ComponentEncoder::default()
+        .validate(true)
+        .module(&wasm)
+        .expect("failed to set core component module")
+        .encode()
+        .expect("failed to encode a component")
+}
+
+const NETWORK: &str = "starstream:test";
+
+static SCORE_WASM: LazyLock<Vec<u8>> =
+    LazyLock::new(|| compile_contract(include_str!("../../examples/score.star")));
+
+static ADMIN: LazyLock<SigningKey> = LazyLock::new(|| SigningKey::from_bytes(&[0x42; 32]));
+
+async fn run_cli(args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> anyhow::Result<Vec<u8>> {
+    let cmd = Command::new(env!("CARGO_BIN_EXE_starstream-ledger-cli"))
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .spawn()
+        .context("failed to spawn CLI process")?;
+    let Output {
+        status,
+        stdout,
+        stderr,
+    } = cmd
+        .wait_with_output()
+        .await
+        .context("failed to wait for CLI")?;
+    assert!(status.success());
+    assert_eq!(stderr, b"");
+    Ok(stdout)
+}
+
+#[tokio::test]
+async fn cli() -> anyhow::Result<()> {
+    let account = run_cli(["key", "generate"]).await?;
+    let mut buf = [0u8; 32];
+    hex::decode_to_slice(&account, &mut buf).context("failed to parse generated key")?;
+    let account = SigningKey::from_bytes(&buf);
+
+    let account_file = NamedTempFile::new()?;
+    fs::write(&account_file, hex::encode(account.to_bytes()))
+        .await
+        .context("failed to write account key file")?;
+
+    let admin_file = NamedTempFile::new()?;
+    fs::write(&admin_file, hex::encode(ADMIN.to_bytes()))
+        .await
+        .context("failed to write admin key file")?;
+
+    let addr = {
+        let lis = TcpListener::bind((Ipv6Addr::LOCALHOST, 0))
+            .await
+            .context("failed to bind TCP listener")?;
+        lis.local_addr()
+            .context("failed to get TCP listener local address")?
+    };
+
+    let ledger = Ledger::new(
+        wasmtime::Engine::default(),
+        128,
+        NETWORK,
+        ADMIN.verifying_key(),
+    );
+    let ledger = Arc::new(ledger);
+    let (ledger, shutdown) = ledger
+        .handle_http(addr)
+        .await
+        .context("failed to handle HTTP")?;
+    let ledger = tokio::spawn(ledger);
+
+    let wasm = NamedTempFile::new()?;
+    fs::write(&wasm, &*SCORE_WASM)
+        .await
+        .with_context(|| format!("failed to write Wasm to `{}`", wasm.path().display()))?;
+
+    let publish_envelope =
+        build_publish_envelope(account.clone(), NETWORK, 1, SCORE_WASM.as_slice())?;
+    let publish_cost = publish_envelope.len();
+
+    let stdout = run_cli([
+        "--url",
+        &format!("http://{addr}"),
+        "account",
+        "fund",
+        "--key",
+        &admin_file.path().to_string_lossy(),
+        "--network",
+        NETWORK,
+        "--nonce",
+        "1",
+        &hex::encode(account.verifying_key().to_bytes()),
+        &publish_cost.to_string(),
+    ])
+    .await?;
+    assert_eq!(stdout, b"");
+
+    let stdout = run_cli([
+        "--url",
+        &format!("http://{addr}"),
+        "contract",
+        "publish",
+        "--key",
+        &account_file.path().to_string_lossy(),
+        "--network",
+        NETWORK,
+        "--nonce",
+        "1",
+        &wasm.path().to_string_lossy(),
+    ])
+    .await?;
+    assert_eq!(stdout, b"");
+
+    shutdown.notify_waiters();
+    ledger.await.context("ledger task panicked")
+}

--- a/starstream-ledger-cli/tests/cli.rs
+++ b/starstream-ledger-cli/tests/cli.rs
@@ -141,6 +141,6 @@ async fn cli() -> anyhow::Result<()> {
     .await?;
     assert_eq!(stdout, b"");
 
-    shutdown.notify_waiters();
+    shutdown.notify_one();
     ledger.await.context("ledger task panicked")
 }

--- a/starstream-ledger-node/Cargo.toml
+++ b/starstream-ledger-node/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "starstream-ledger-node"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = [
+    "color",
+    "derive",
+    "error-context",
+    "help",
+    "std",
+    "string",
+    "suggestions",
+    "usage",
+] }
+ed25519-dalek = { workspace = true, features = ["fast", "zeroize"] }
+hex = { workspace = true, features = ["std"] }
+sha2 = { workspace = true }
+starstream-ledger = { workspace = true, features = ["server"] }
+tokio = { workspace = true, features = [
+    "macros",
+    "rt-multi-thread",
+    "signal",
+    "time",
+] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = [
+    "ansi",
+    "env-filter",
+    "fmt",
+    "smallvec",
+    "tracing-log",
+] }
+wasmtime = { workspace = true }

--- a/starstream-ledger-node/src/main.rs
+++ b/starstream-ledger-node/src/main.rs
@@ -125,7 +125,7 @@ async fn main() -> anyhow::Result<()> {
     })
     .await;
     info!("shutting down");
-    http_shutdown.notify_waiters();
+    http_shutdown.notify_one();
     if !http_ready {
         match timeout(shutdown_timeout, http).await {
             Ok(Ok(())) => {}

--- a/starstream-ledger-node/src/main.rs
+++ b/starstream-ledger-node/src/main.rs
@@ -1,0 +1,137 @@
+use core::future::poll_fn;
+use core::net::{IpAddr, Ipv6Addr, SocketAddr};
+use core::pin::pin;
+use core::task::Poll;
+use core::time::Duration;
+
+use std::sync::Arc;
+
+use anyhow::{Context as _, anyhow};
+use clap::Parser;
+use ed25519_dalek::VerifyingKey;
+use sha2::{Digest as _, Sha256};
+use starstream_ledger::server::Ledger;
+use tokio::signal;
+use tokio::time::timeout;
+use tracing::{error, info, warn};
+
+#[derive(Debug, Parser)]
+#[command(version, about)]
+struct Args {
+    /// Network identifier to use.
+    #[arg(long, default_value = "dev")]
+    network: Box<str>,
+
+    /// Hex-encoded Ed25519 public key of the admin account.
+    #[arg(long, value_name = "ADMIN", value_parser = parse_admin_key, default_value = default_admin_key())]
+    admin: VerifyingKey,
+
+    /// Address to serve API on.
+    #[arg(long, global = true, value_name = "ADDR", default_value_t = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 9000))]
+    addr: SocketAddr,
+
+    /// Maximum amount of concurrent requests.
+    #[arg(long, global = true, value_name = "MAX_REQUESTS", default_value_t = u32::from(u16::MAX))]
+    max_requests: u32,
+
+    /// Time to wait for graceful shutdown before exiting, in seconds.
+    #[arg(long, value_name = "SECONDS", default_value_t = 10)]
+    shutdown_timeout: u64,
+}
+
+fn default_admin_key() -> String {
+    let key = ed25519_dalek::SigningKey::from_bytes(&Sha256::digest("admin").into());
+    hex::encode(key.verifying_key())
+}
+
+fn parse_admin_key(key: &str) -> Result<VerifyingKey, String> {
+    let mut buf = [0u8; 32];
+    hex::decode_to_slice(key, &mut buf)
+        .map_err(|err| format!("public key is not a valid hex-encoded 32 bytes: {err}"))?;
+    VerifyingKey::from_bytes(&buf)
+        .map_err(|err| format!("public key is not a valid Ed25519 public key: {err}"))
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let Args {
+        network,
+        admin,
+        addr,
+        max_requests,
+        shutdown_timeout,
+    } = Args::parse();
+    let shutdown_timeout = Duration::from_secs(shutdown_timeout);
+
+    tracing_subscriber::fmt()
+        .without_time()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_env_var("STARSTREAM_LEDGER_LOG")
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let engine = wasmtime::Engine::default();
+
+    let ledger = Ledger::new(engine, max_requests, network, admin);
+    let ledger = Arc::new(ledger);
+
+    let (http, http_shutdown) = ledger.handle_http(addr).await?;
+    let http = tokio::spawn(http);
+    let mut http = pin!(http);
+
+    let ctrl_c = signal::ctrl_c();
+    let mut ctrl_c = pin!(ctrl_c);
+
+    #[cfg(unix)]
+    let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
+        .context("failed to listen for SIGTERM")?;
+
+    info!(%addr, "ledger running");
+
+    let mut http_ready = false;
+    let res = poll_fn(|cx| {
+        debug_assert!(!http_ready);
+        if let Poll::Ready(res) = http.as_mut().poll(cx) {
+            http_ready = true;
+            if let Err(err) = res {
+                return Poll::Ready(Err(anyhow!(err).context("HTTP API task panicked")));
+            } else {
+                info!("HTTP API task finished");
+                return Poll::Ready(Ok(()));
+            }
+        }
+        if let Poll::Ready(res) = ctrl_c.as_mut().poll(cx) {
+            return match res {
+                Ok(()) => {
+                    info!("^C received");
+                    Poll::Ready(Ok(()))
+                }
+                Err(err) => {
+                    warn!(?err, "failed to listen for ^C");
+                    Poll::Ready(Err(err.into()))
+                }
+            };
+        }
+        #[cfg(unix)]
+        if sigterm.poll_recv(cx).is_ready() {
+            info!("SIGTERM received");
+            return Poll::Ready(Ok(()));
+        }
+        Poll::Pending
+    })
+    .await;
+    info!("shutting down");
+    http_shutdown.notify_waiters();
+    if !http_ready {
+        match timeout(shutdown_timeout, http).await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => error!(?err, "HTTP API task panicked"),
+            Err(..) => error!("HTTP API failed to shut down within {shutdown_timeout:?}"),
+        }
+    }
+    res
+}

--- a/starstream-ledger/Cargo.toml
+++ b/starstream-ledger/Cargo.toml
@@ -1,0 +1,74 @@
+[package]
+name = "starstream-ledger"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[features]
+default = ["client", "server"]
+client = ["hyper-util/client", "hyper-util/client-legacy"]
+server = [
+    "dep:headers-accept",
+    "dep:headers-core",
+    "dep:hex",
+    "dep:http-body",
+    "dep:hyper",
+    "dep:starstream-runtime-next",
+    "dep:tokio",
+    "dep:wasmtime",
+    "dep:wasmtime-wizer",
+    "hyper-util/server",
+    "hyper-util/server-auto",
+    "hyper-util/server-graceful",
+    "hyper-util/tokio",
+]
+
+[dependencies]
+anyhow = { workspace = true }
+bytes = { workspace = true }
+ciborium = { workspace = true, features = ["std"] }
+coset = { workspace = true, features = ["std"] }
+ed25519-dalek = { workspace = true, features = ["fast", "std", "zeroize"] }
+headers-accept = { workspace = true, optional = true }
+headers-core = { workspace = true, optional = true }
+hex = { workspace = true, optional = true, features = ["std"] }
+http = { workspace = true, features = ["std"] }
+http-body = { workspace = true, optional = true }
+http-body-util = { workspace = true }
+hyper = { workspace = true, optional = true, features = ["server"] }
+hyper-util = { workspace = true, features = ["http1", "http2"] }
+mediatype = { workspace = true }
+multibase = { workspace = true, features = ["std"] }
+multihash = { workspace = true, features = ["std"] }
+sha2 = { workspace = true }
+starstream-runtime-next = { workspace = true, optional = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, optional = true, features = [
+    "net",
+    "rt",
+    "sync",
+    "time",
+] }
+tracing = { workspace = true, features = ["attributes"] }
+wasmtime = { workspace = true, optional = true, features = [
+    "anyhow",
+    "async",
+    "component-model",
+    "cranelift",
+] }
+wasmtime-wizer = { workspace = true, optional = true, features = [
+    "component-model",
+    "wasmtime",
+] }
+
+[dev-dependencies]
+starstream-compiler = { workspace = true }
+starstream-to-wasm = { workspace = true }
+tokio = { workspace = true, features = [
+    "io-util",
+    "macros",
+    "rt-multi-thread",
+] }

--- a/starstream-ledger/src/client/http.rs
+++ b/starstream-ledger/src/client/http.rs
@@ -1,0 +1,277 @@
+use anyhow::{Context as _, bail, ensure};
+use bytes::Bytes;
+use coset::{CborSerializable as _, CoseSign1, TaggedCborSerializable as _, iana};
+use ed25519_dalek::{Signature, SigningKey, VerifyingKey};
+use http::header::{ACCEPT, CONTENT_TYPE};
+use http::{Method, Request, Uri};
+use http_body_util::{BodyExt as _, Full};
+use mediatype::MediaType;
+use sha2::{Digest as _, Sha256};
+use tracing::{instrument, warn};
+
+use crate::client::{build_fund_envelope, build_publish_envelope};
+use crate::{APPLICATION_COSE, APPLICATION_WASM, PUBLISH_CONTEXT, encode_digest};
+
+/// Default network used by the client
+pub const DEFAULT_NETWORK: &str = "dev";
+
+fn endpoint_uri(base: &Uri, endpoint: impl AsRef<str>) -> anyhow::Result<String> {
+    ensure!(
+        base.query().is_none(),
+        "base URL `{base}` must not contain a query"
+    );
+    let endpoint = endpoint.as_ref();
+    let base = base.to_string();
+    let base = base.trim_end_matches('/');
+    Ok(format!("{base}/{endpoint}"))
+}
+
+/// Build a signed fund request.
+pub fn build_fund_request(
+    base: &Uri,
+    key: SigningKey,
+    network: impl Into<String>,
+    nonce: u64,
+    account: &VerifyingKey,
+    amount: u64,
+) -> anyhow::Result<http::Request<Full<Bytes>>> {
+    let envelope = build_fund_envelope(key, network, nonce, account, amount)?;
+    let uri = endpoint_uri(base, "fund")?;
+    Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header(CONTENT_TYPE, APPLICATION_COSE.to_string())
+        .body(Full::new(Bytes::from(envelope)))
+        .context("failed to build request")
+}
+
+/// Build a signed contract publish request.
+pub fn build_contract_publish_request(
+    base: &Uri,
+    key: SigningKey,
+    network: impl Into<String>,
+    nonce: u64,
+    wasm: impl Into<Vec<u8>>,
+) -> anyhow::Result<http::Request<Full<Bytes>>> {
+    let wasm = wasm.into();
+    let digest = Sha256::digest(&wasm);
+    let digest = encode_digest(&digest.into());
+    let envelope = build_publish_envelope(key, network, nonce, wasm)?;
+    let uri = endpoint_uri(base, format!("contracts/{digest}"))?;
+    Request::builder()
+        .method(Method::PUT)
+        .uri(uri)
+        .header(CONTENT_TYPE, APPLICATION_COSE.to_string())
+        .body(Full::new(Bytes::from(envelope)))
+        .context("failed to build request")
+}
+
+/// Build a contract get request.
+pub fn build_contract_get_request(
+    base: &Uri,
+    digest: &[u8; 32],
+    accept: Option<MediaType>,
+) -> anyhow::Result<http::Request<Full<Bytes>>> {
+    let digest = encode_digest(digest);
+    let uri = endpoint_uri(base, format!("contracts/{digest}"))?;
+    let req = Request::builder().method(Method::GET).uri(uri);
+    let req = if let Some(accept) = accept {
+        req.header(ACCEPT, accept.to_string())
+    } else {
+        req
+    };
+    req.body(Full::default()).context("failed to build request")
+}
+
+#[derive(Clone, Debug)]
+pub struct ClientBuilder<C> {
+    http: hyper_util::client::legacy::Client<C, Full<Bytes>>,
+    api_base: Uri,
+    network: Box<str>,
+}
+
+impl<C> ClientBuilder<C> {
+    pub fn new(
+        http: hyper_util::client::legacy::Client<C, Full<Bytes>>,
+        api_base: impl Into<Uri>,
+    ) -> Self {
+        Self {
+            http,
+            api_base: api_base.into(),
+            network: DEFAULT_NETWORK.into(),
+        }
+    }
+
+    pub fn network(mut self, network: impl Into<Box<str>>) -> Self {
+        self.network = network.into();
+        self
+    }
+
+    pub fn build(self) -> Client<C> {
+        self.into()
+    }
+}
+
+pub struct Client<C> {
+    http: hyper_util::client::legacy::Client<C, Full<Bytes>>,
+    api_base: Uri,
+    network: Box<str>,
+}
+
+impl<C> From<ClientBuilder<C>> for Client<C> {
+    fn from(
+        ClientBuilder {
+            http,
+            api_base,
+            network,
+        }: ClientBuilder<C>,
+    ) -> Self {
+        Self {
+            http,
+            api_base,
+            network,
+        }
+    }
+}
+
+impl<C> Client<C> {
+    pub fn new(
+        http: hyper_util::client::legacy::Client<C, Full<Bytes>>,
+        api_base: impl Into<Uri>,
+    ) -> Self {
+        ClientBuilder::new(http, api_base).build()
+    }
+}
+
+impl<C> Client<C>
+where
+    C: hyper_util::client::legacy::connect::Connect + Clone + Send + Sync + 'static,
+{
+    #[instrument(skip_all)]
+    async fn request(
+        &self,
+        req: http::Request<Full<Bytes>>,
+    ) -> anyhow::Result<(http::response::Parts, Bytes)> {
+        let res = self
+            .http
+            .request(req)
+            .await
+            .context("failed to send request")?;
+        let (parts, body) = res.into_parts();
+        let body = body
+            .collect()
+            .await
+            .context("failed to receive response body")?;
+        Ok((parts, body.to_bytes()))
+    }
+
+    #[instrument(skip_all)]
+    pub async fn fund(
+        &self,
+        key: SigningKey,
+        nonce: u64,
+        account: &VerifyingKey,
+        amount: u64,
+    ) -> anyhow::Result<()> {
+        let req = build_fund_request(
+            &self.api_base,
+            key,
+            self.network.as_ref(),
+            nonce,
+            account,
+            amount,
+        )?;
+        let (http::response::Parts { status, .. }, body) = self.request(req).await?;
+        let body = String::from_utf8_lossy(&body);
+        ensure!(status.is_success(), "{body}");
+        if !body.is_empty() {
+            warn!("received unexpected body: {body}")
+        }
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    pub async fn publish_contract(
+        &self,
+        key: SigningKey,
+        nonce: u64,
+        wasm: impl Into<Vec<u8>>,
+    ) -> anyhow::Result<()> {
+        let req = build_contract_publish_request(
+            &self.api_base,
+            key,
+            self.network.as_ref(),
+            nonce,
+            wasm,
+        )?;
+        let (http::response::Parts { status, .. }, body) = self.request(req).await?;
+        let body = String::from_utf8_lossy(&body);
+        ensure!(status.is_success(), "{body}");
+        if !body.is_empty() {
+            warn!("received unexpected body: {body}")
+        }
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    pub async fn get_contract_wasm(&self, digest: &[u8; 32]) -> anyhow::Result<Bytes> {
+        let req = build_contract_get_request(&self.api_base, digest, Some(APPLICATION_WASM))?;
+        let (http::response::Parts { status, .. }, body) = self.request(req).await?;
+        ensure!(status.is_success(), "{}", String::from_utf8_lossy(&body));
+        let wasm_digest: [u8; 32] = Sha256::digest(&body).into();
+        ensure!(
+            wasm_digest == *digest,
+            "contract digest mismatch, got `{}`",
+            encode_digest(&wasm_digest)
+        );
+        Ok(body)
+    }
+
+    #[instrument(skip_all)]
+    pub async fn get_contract_envelope(&self, digest: &[u8; 32]) -> anyhow::Result<Bytes> {
+        let req = build_contract_get_request(&self.api_base, digest, Some(APPLICATION_COSE))?;
+        let (http::response::Parts { status, .. }, body) = self.request(req).await?;
+        ensure!(status.is_success(), "{}", String::from_utf8_lossy(&body));
+        let sign1 = CoseSign1::from_tagged_slice(&body)
+            .or_else(|_| CoseSign1::from_slice(&body))
+            .context("invalid COSE_Sign1")?;
+        ensure!(
+            sign1.protected.header.alg == Some(coset::Algorithm::Assigned(iana::Algorithm::EdDSA)),
+            "unsupported signature algorithm"
+        );
+        let key = <[u8; 32]>::try_from(sign1.protected.header.key_id.as_slice())
+            .context("invalid `kid` header")?;
+        let key = VerifyingKey::from_bytes(&key).context("invalid Ed25519 key")?;
+        sign1
+            .verify_signature(b"", |signature, data| {
+                Signature::from_slice(signature)
+                    .and_then(|signature| key.verify_strict(data, &signature))
+            })
+            .context("signature verification failed")?;
+        let payload = sign1.payload.as_deref().context("payload missing")?;
+        let ciborium::Value::Array(payload) =
+            ciborium::from_reader(payload).context("invalid payload")?
+        else {
+            bail!("invalid publish transaction");
+        };
+        let Ok(
+            [
+                ciborium::Value::Text(context),
+                _,
+                _,
+                ciborium::Value::Bytes(wasm),
+            ],
+        ) = <[_; _]>::try_from(payload)
+        else {
+            bail!("invalid publish transaction");
+        };
+        ensure!(context == PUBLISH_CONTEXT, "unexpected context `{context}`");
+        let wasm_digest: [u8; 32] = Sha256::digest(&wasm).into();
+        ensure!(
+            wasm_digest == *digest,
+            "contract digest mismatch, got `{}`",
+            encode_digest(&wasm_digest)
+        );
+        Ok(body)
+    }
+}

--- a/starstream-ledger/src/client/mod.rs
+++ b/starstream-ledger/src/client/mod.rs
@@ -1,0 +1,68 @@
+//! Starstream ledger client.
+
+use anyhow::Context as _;
+use coset::{TaggedCborSerializable as _, iana};
+use ed25519_dalek::{Signer as _, SigningKey, VerifyingKey};
+
+use crate::{FUND_CONTEXT, PUBLISH_CONTEXT};
+
+pub mod http;
+
+/// Build a signed envelope.
+fn build_envelope(key: SigningKey, payload: impl Into<Vec<u8>>) -> anyhow::Result<Vec<u8>> {
+    let protected = coset::HeaderBuilder::new()
+        .algorithm(iana::Algorithm::EdDSA)
+        .key_id(key.verifying_key().to_bytes().into())
+        .build();
+    coset::CoseSign1Builder::new()
+        .protected(protected)
+        .payload(payload.into())
+        .create_signature(b"", |data| key.sign(data).to_bytes().into())
+        .build()
+        .to_tagged_vec()
+        .context("failed to serialize envelope")
+}
+
+/// Build and sign [FUND_CONTEXT] envelope.
+pub fn build_fund_envelope(
+    key: SigningKey,
+    network: impl Into<String>,
+    nonce: u64,
+    account: &VerifyingKey,
+    amount: u64,
+) -> anyhow::Result<Vec<u8>> {
+    let mut payload = Vec::default();
+    ciborium::into_writer(
+        &ciborium::Value::Array(vec![
+            ciborium::Value::Text(FUND_CONTEXT.into()),
+            ciborium::Value::Text(network.into()),
+            ciborium::Value::Integer(nonce.into()),
+            ciborium::Value::Bytes(account.to_bytes().into()),
+            ciborium::Value::Integer(amount.into()),
+        ]),
+        &mut payload,
+    )
+    .context("failed to encode CBOR")?;
+    build_envelope(key, payload)
+}
+
+/// Build and sign [PUBLISH_CONTEXT] envelope.
+pub fn build_publish_envelope(
+    key: SigningKey,
+    network: impl Into<String>,
+    nonce: u64,
+    wasm: impl Into<Vec<u8>>,
+) -> anyhow::Result<Vec<u8>> {
+    let mut payload = Vec::default();
+    ciborium::into_writer(
+        &ciborium::Value::Array(vec![
+            ciborium::Value::Text(PUBLISH_CONTEXT.into()),
+            ciborium::Value::Text(network.into()),
+            ciborium::Value::Integer(nonce.into()),
+            ciborium::Value::Bytes(wasm.into()),
+        ]),
+        &mut payload,
+    )
+    .context("failed to encode CBOR")?;
+    build_envelope(key, payload)
+}

--- a/starstream-ledger/src/lib.rs
+++ b/starstream-ledger/src/lib.rs
@@ -1,0 +1,78 @@
+//! Starstream ledger
+
+use bytes::Bytes;
+use mediatype::MediaType;
+use thiserror::Error;
+
+#[cfg(feature = "client")]
+pub mod client;
+#[cfg(feature = "server")]
+pub mod server;
+
+/// The domain-separation context every publish transaction must carry as its
+/// first element, binding the signature to this protocol.
+pub const PUBLISH_CONTEXT: &str = "starstream:publish";
+
+/// The domain-separation context every fund transaction must carry as
+/// its first element, binding the signature to this protocol.
+pub const FUND_CONTEXT: &str = "starstream:fund";
+
+/// COSE media type
+pub const APPLICATION_COSE: MediaType =
+    MediaType::new(mediatype::names::APPLICATION, mediatype::names::COSE);
+
+/// Wasm media type
+pub const APPLICATION_WASM: MediaType =
+    MediaType::new(mediatype::names::APPLICATION, mediatype::names::WASM);
+
+/// The [multihash] code of sha2-256.
+///
+/// [multihash]: https://github.com/multiformats/multihash
+const MULTIHASH_SHA2_256: u64 = 0x12;
+
+pub enum Action {
+    UploadContract(Bytes),
+    FundAccount(Bytes),
+}
+
+pub struct Block {
+    pub height: usize,
+    pub actions: Box<[Action]>,
+    // TODO: Add proofs
+}
+
+#[derive(Debug, Error)]
+pub enum DigestParseError {
+    #[error(transparent)]
+    Base(multibase::Error),
+    #[error(transparent)]
+    Hash(multihash::Error),
+    #[error("unexpected multihash code `{0}`")]
+    Code(u64),
+    #[error("unexpected multihash size {0}")]
+    Size(u8),
+}
+
+pub fn parse_digest(s: &str) -> Result<[u8; 32], DigestParseError> {
+    let (_, buf) = multibase::decode(s).map_err(DigestParseError::Base)?;
+    let mh = multihash::Multihash::<32>::from_bytes(&buf).map_err(DigestParseError::Hash)?;
+    let (code, digest, size) = mh.into_inner();
+    if code != MULTIHASH_SHA2_256 {
+        return Err(DigestParseError::Code(code));
+    }
+    if size != 32 {
+        return Err(DigestParseError::Size(size));
+    }
+    Ok(digest)
+}
+
+/// Encode a raw SHA-256 contract digest in the canonical ledger form: the
+/// multibase base32-lower encoding of its sha2-256 multihash. The result is
+/// always a 56-character lowercase alphanumeric string starting with `b` — a
+/// valid component-model label and URL path segment.
+pub fn encode_digest(digest: &[u8; 32]) -> String {
+    let Ok(digest) = multihash::Multihash::<32>::wrap(MULTIHASH_SHA2_256, digest) else {
+        unreachable!();
+    };
+    multibase::encode(multibase::Base::Base32Lower, digest.to_bytes())
+}

--- a/starstream-ledger/src/server/host.rs
+++ b/starstream-ledger/src/server/host.rs
@@ -1,0 +1,95 @@
+use core::pin::Pin;
+
+use std::sync::Arc;
+
+use starstream_runtime_next::Utxo;
+use starstream_runtime_next::bindings::starstream;
+use wasmtime::StoreContextMut;
+use wasmtime::bail;
+use wasmtime::component::{Resource, ResourceTable, Val};
+
+use crate::server::Ctx;
+
+impl starstream::std::cardano::Host for Ctx {
+    fn block_height(&mut self) -> wasmtime::Result<i64> {
+        bail!("TODO")
+    }
+
+    fn current_slot(&mut self) -> wasmtime::Result<i64> {
+        bail!("TODO")
+    }
+}
+
+impl starstream_runtime_next::Host for Ctx {
+    type UtxoContext = ();
+    type Token = ();
+
+    fn table(&mut self) -> &mut ResourceTable {
+        &mut self.table
+    }
+
+    async fn call_utxo_main(
+        _store: StoreContextMut<'_, Self>,
+        _f: impl for<'a> FnOnce(
+            StoreContextMut<'a, Self>,
+            Self::UtxoContext,
+        ) -> Pin<
+            Box<dyn Future<Output = wasmtime::Result<Utxo<Self::UtxoContext>>> + Send + 'a>,
+        > + Send,
+    ) -> wasmtime::Result<Utxo<Self::UtxoContext>> {
+        bail!("TODO")
+    }
+
+    fn has_method(
+        _store: StoreContextMut<Self>,
+        _utxo: Resource<Utxo<Self::UtxoContext>>,
+        _hash: (u64, u64, u64, u64),
+    ) -> wasmtime::Result<bool> {
+        bail!("TODO")
+    }
+
+    fn drop_utxo(
+        _store: StoreContextMut<Self>,
+        _utxo: Resource<Utxo<Self::UtxoContext>>,
+    ) -> wasmtime::Result<()> {
+        bail!("TODO")
+    }
+
+    fn implements_method(
+        _store: StoreContextMut<Self>,
+        _cx: Resource<Self::UtxoContext>,
+        __hash: (u64, u64, u64, u64),
+    ) -> wasmtime::Result<()> {
+        bail!("TODO")
+    }
+
+    fn resume(
+        _store: StoreContextMut<Self>,
+        _cx: Resource<Self::UtxoContext>,
+    ) -> wasmtime::Result<()> {
+        bail!("TODO")
+    }
+
+    fn drop_utxo_context(
+        _store: StoreContextMut<Self>,
+        _cx: Resource<Self::UtxoContext>,
+    ) -> wasmtime::Result<()> {
+        bail!("TODO")
+    }
+
+    fn drop_token(
+        _store: StoreContextMut<Self>,
+        _token: Resource<Self::Token>,
+    ) -> wasmtime::Result<()> {
+        bail!("TODO")
+    }
+
+    fn emit_event(
+        _store: StoreContextMut<Self>,
+        _abi_name: &Arc<str>,
+        _name: &Arc<str>,
+        _params: &[Val],
+    ) -> wasmtime::Result<()> {
+        bail!("TODO")
+    }
+}

--- a/starstream-ledger/src/server/http/error.rs
+++ b/starstream-ledger/src/server/http/error.rs
@@ -50,6 +50,8 @@ pub enum EnvelopeReadError {
     Reencode(coset::CoseError),
     #[error("envelope must not contain unprotected headers")]
     UnprotectedHeader,
+    #[error("envelope must not contain critical headers")]
+    CriticalHeader,
     #[error("protected `alg` header must be EdDSA")]
     Algorithm,
     #[error("protected `kid` header must be a raw 32-byte Ed25519 public key")]
@@ -68,6 +70,7 @@ impl EnvelopeReadError {
             | Self::Body(..)
             | Self::CoseSign1Parsing(..)
             | Self::UnprotectedHeader
+            | Self::CriticalHeader
             | Self::Algorithm
             | Self::KeyIdFormat
             | Self::Key(..) => http::StatusCode::BAD_REQUEST,

--- a/starstream-ledger/src/server/http/error.rs
+++ b/starstream-ledger/src/server/http/error.rs
@@ -1,0 +1,217 @@
+use std::sync::Arc;
+
+use ed25519_dalek::VerifyingKey;
+use mediatype::MediaType;
+use thiserror::Error;
+
+use crate::server::http::APPLICATION_COSE;
+use crate::{DigestParseError, FUND_CONTEXT, PUBLISH_CONTEXT, encode_digest};
+
+#[derive(Debug, Error)]
+pub enum ContractGetError {
+    #[error("failed to parse contract digest: {0}")]
+    DigestParsing(DigestParseError),
+    #[error("contract not found")]
+    ContractNotFound,
+    #[error(transparent)]
+    AcceptHeader(AcceptHeaderError),
+    #[error(transparent)]
+    Http(http::Error),
+}
+
+impl ContractGetError {
+    pub fn http_status_code(&self) -> http::StatusCode {
+        match self {
+            Self::DigestParsing(..) => http::StatusCode::BAD_REQUEST,
+            Self::ContractNotFound => http::StatusCode::NOT_FOUND,
+            Self::AcceptHeader(err) => err.http_status_code(),
+            Self::Http(..) => http::StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum EnvelopeReadError {
+    #[error(transparent)]
+    ContentTypeToStr(http::header::ToStrError),
+    #[error(transparent)]
+    ContentTypeParsing(mediatype::MediaTypeError),
+    #[error("expected `{APPLICATION_COSE}` content-type, got `{0}`")]
+    UnsupportedContentType(Box<str>),
+    #[error("missing content-type, expected `{APPLICATION_COSE}`")]
+    ContentTypeMissing,
+    #[error("body exceeds {0}-byte limit")]
+    BodyTooLarge(u64),
+    #[error(transparent)]
+    Body(Box<dyn std::error::Error + Send + Sync>),
+    #[error("body is not a valid COSE_Sign1: {0}")]
+    CoseSign1Parsing(coset::CoseError),
+    #[error("failed to reencode envelope: {0}")]
+    Reencode(coset::CoseError),
+    #[error("envelope must not contain unprotected headers")]
+    UnprotectedHeader,
+    #[error("protected `alg` header must be EdDSA")]
+    Algorithm,
+    #[error("protected `kid` header must be a raw 32-byte Ed25519 public key")]
+    KeyIdFormat,
+    #[error("`kid` is not a valid Ed25519 public key: {0}")]
+    Key(ed25519_dalek::SignatureError),
+    #[error("signature verification failed: {0}")]
+    SignatureVerification(ed25519_dalek::SignatureError),
+}
+
+impl EnvelopeReadError {
+    fn http_status_code(&self) -> http::StatusCode {
+        match self {
+            Self::ContentTypeToStr(..)
+            | Self::ContentTypeParsing(..)
+            | Self::Body(..)
+            | Self::CoseSign1Parsing(..)
+            | Self::UnprotectedHeader
+            | Self::Algorithm
+            | Self::KeyIdFormat
+            | Self::Key(..) => http::StatusCode::BAD_REQUEST,
+            Self::BodyTooLarge(..) => http::StatusCode::PAYLOAD_TOO_LARGE,
+            Self::UnsupportedContentType(..) | Self::ContentTypeMissing => {
+                http::StatusCode::UNSUPPORTED_MEDIA_TYPE
+            }
+            Self::SignatureVerification(..) => http::StatusCode::UNAUTHORIZED,
+            Self::Reencode(..) => http::StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ContractPutError {
+    #[error(transparent)]
+    DigestParsing(DigestParseError),
+    #[error(transparent)]
+    Envelope(EnvelopeReadError),
+    #[error("COSE_Sign1 payload missing")]
+    PayloadMissing,
+    #[error("COSE_Sign1 payload is not valid CBOR: {0}")]
+    PayloadParsing(ciborium::de::Error<std::io::Error>),
+    #[error("publish transaction must be a `[context, network, nonce, wasm]` array")]
+    TransactionFormat,
+    #[error("unexpected context `{0}`, expected `{PUBLISH_CONTEXT}`")]
+    Context(Box<str>),
+    #[error("unexpected network `{got}`, expected `{expected}`")]
+    Network { got: Box<str>, expected: Arc<str> },
+    #[error("publish transaction nonce does not fit in u64")]
+    NonceOverflow,
+    #[error("digest mismatch, got: `{}`", encode_digest(.0))]
+    DigestMismatch([u8; 32]),
+    #[error("account ID `{}` not found", hex::encode(.0))]
+    AccountNotFound(VerifyingKey),
+    #[error("nonce must be higher than {last_nonce}, got {nonce}")]
+    NonceTooLow { last_nonce: u64, nonce: u64 },
+    #[error("balance insufficient, required at least {required}, available {available}")]
+    InsufficientBalance { required: u64, available: u64 },
+    #[error("{0:#}")]
+    Runtime(wasmtime::Error),
+    #[error(transparent)]
+    Http(http::Error),
+    #[error("instrumentation failed: {0:#}")]
+    Wizer(wasmtime::Error),
+}
+
+impl ContractPutError {
+    pub fn http_status_code(&self) -> http::StatusCode {
+        match self {
+            Self::DigestParsing(..)
+            | Self::PayloadMissing
+            | Self::PayloadParsing(..)
+            | Self::TransactionFormat
+            | Self::Context(..)
+            | Self::Network { .. }
+            | Self::NonceOverflow
+            | Self::DigestMismatch(..)
+            | Self::Runtime(..)
+            | Self::Wizer(..) => http::StatusCode::BAD_REQUEST,
+            Self::Envelope(err) => err.http_status_code(),
+            Self::NonceTooLow { .. } => http::StatusCode::CONFLICT,
+            Self::AccountNotFound(..) | Self::InsufficientBalance { .. } => {
+                http::StatusCode::PAYMENT_REQUIRED
+            }
+            Self::Http(..) => http::StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum AccountFundError {
+    #[error(transparent)]
+    Envelope(EnvelopeReadError),
+    #[error("COSE_Sign1 payload missing")]
+    PayloadMissing,
+    #[error("COSE_Sign1 payload is not valid CBOR: {0}")]
+    PayloadParsing(ciborium::de::Error<std::io::Error>),
+    #[error("fund transaction must be a `[context, network, nonce, account, amount]` array")]
+    TransactionFormat,
+    #[error("unexpected context `{0}`, expected `{FUND_CONTEXT}`")]
+    Context(Box<str>),
+    #[error("unexpected network `{got}`, expected `{expected}`")]
+    Network { got: Box<str>, expected: Arc<str> },
+    #[error("fund transaction nonce does not fit in u64")]
+    NonceOverflow,
+    #[error("fund transaction account must be a raw 32-byte Ed25519 public key")]
+    KeyIdFormat,
+    #[error("fund transaction account is not a valid Ed25519 public key: {0}")]
+    Key(ed25519_dalek::SignatureError),
+    #[error("fund transaction account is a weak Ed25519 public key")]
+    WeakKey,
+    #[error("fund transaction amount does not fit in u64")]
+    AmountOverflow,
+    #[error("signer `{}` is not the admin account", hex::encode(.0))]
+    NotAdmin(VerifyingKey),
+    #[error("nonce must be higher than {last_nonce}, got {nonce}")]
+    NonceTooLow { last_nonce: u64, nonce: u64 },
+    #[error(transparent)]
+    Http(http::Error),
+}
+
+impl AccountFundError {
+    pub fn http_status_code(&self) -> http::StatusCode {
+        match self {
+            Self::PayloadMissing
+            | Self::PayloadParsing(..)
+            | Self::TransactionFormat
+            | Self::Context(..)
+            | Self::Network { .. }
+            | Self::NonceOverflow
+            | Self::KeyIdFormat
+            | Self::Key(..)
+            | Self::WeakKey
+            | Self::AmountOverflow => http::StatusCode::BAD_REQUEST,
+            Self::Envelope(err) => err.http_status_code(),
+            Self::NotAdmin(..) => http::StatusCode::FORBIDDEN,
+            Self::NonceTooLow { .. } => http::StatusCode::CONFLICT,
+            Self::Http(..) => http::StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+fn format_media_types(available: &[MediaType<'_>]) -> String {
+    available
+        .iter()
+        .map(|mt| format!("`{mt}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[derive(Debug, Error)]
+pub enum AcceptHeaderError {
+    #[error("failed to decode `Accept` header: {0}")]
+    Decoding(headers_core::Error),
+    #[error("no acceptable media type, available: {}", format_media_types(.0))]
+    NotAcceptable(&'static [MediaType<'static>]),
+}
+
+impl AcceptHeaderError {
+    pub fn http_status_code(&self) -> http::StatusCode {
+        match self {
+            Self::Decoding(..) => http::StatusCode::BAD_REQUEST,
+            Self::NotAcceptable(..) => http::StatusCode::NOT_ACCEPTABLE,
+        }
+    }
+}

--- a/starstream-ledger/src/server/http/mod.rs
+++ b/starstream-ledger/src/server/http/mod.rs
@@ -15,7 +15,7 @@ use ed25519_dalek::{Signature, VerifyingKey};
 use headers_accept::Accept;
 use headers_core::Header as _;
 use http::HeaderValue;
-use http::header::{ACCEPT, ALLOW, CONTENT_LENGTH, CONTENT_TYPE, X_CONTENT_TYPE_OPTIONS};
+use http::header::{ACCEPT, ALLOW, CONTENT_LENGTH, CONTENT_TYPE, VARY, X_CONTENT_TYPE_OPTIONS};
 use http_body::Body as _;
 use http_body_util::BodyExt as _;
 use hyper::service::service_fn;
@@ -101,6 +101,9 @@ async fn read_signed_envelope<const MAX: u64>(
         .map_err(EnvelopeReadError::CoseSign1Parsing)?;
     if !sign1.unprotected.is_empty() {
         return Err(EnvelopeReadError::UnprotectedHeader);
+    }
+    if !sign1.protected.header.crit.is_empty() {
+        return Err(EnvelopeReadError::CriticalHeader);
     }
     if sign1.protected.header.alg != Some(coset::Algorithm::Assigned(iana::Algorithm::EdDSA)) {
         return Err(EnvelopeReadError::Algorithm);
@@ -205,13 +208,14 @@ impl Ledger {
             .get(&digest)
             .ok_or(ContractGetError::ContractNotFound)?;
 
+        let res = http::Response::builder()
+            .header(VARY, ACCEPT.as_str())
+            .header(X_CONTENT_TYPE_OPTIONS, "nosniff");
         if accept == Some(&APPLICATION_WASM) {
-            http::Response::builder()
-                .header(CONTENT_TYPE, APPLICATION_WASM.to_string())
+            res.header(CONTENT_TYPE, APPLICATION_WASM.to_string())
                 .body(http_body_util::Full::new(contract.wasm.clone()))
         } else {
-            http::Response::builder()
-                .header(CONTENT_TYPE, APPLICATION_COSE.to_string())
+            res.header(CONTENT_TYPE, APPLICATION_COSE.to_string())
                 .body(http_body_util::Full::new(contract.envelope.clone()))
         }
         .map_err(ContractGetError::Http)
@@ -235,13 +239,14 @@ impl Ledger {
             .get(&digest)
             .ok_or(ContractGetError::ContractNotFound)?;
 
+        let res = http::Response::builder()
+            .header(VARY, ACCEPT.as_str())
+            .header(X_CONTENT_TYPE_OPTIONS, "nosniff");
         if accept == Some(&APPLICATION_WASM) {
-            http::Response::builder()
-                .header(CONTENT_TYPE, APPLICATION_WASM.to_string())
+            res.header(CONTENT_TYPE, APPLICATION_WASM.to_string())
                 .header(CONTENT_LENGTH, contract.wasm.len())
         } else {
-            http::Response::builder()
-                .header(CONTENT_TYPE, APPLICATION_COSE.to_string())
+            res.header(CONTENT_TYPE, APPLICATION_COSE.to_string())
                 .header(CONTENT_LENGTH, contract.envelope.len())
         }
         .body(http_body_util::Full::default())
@@ -446,6 +451,10 @@ impl Ledger {
     }
 
     /// Bind `address` and return the future serving the ledger HTTP API.
+    ///
+    /// Calling [`Notify::notify_one`] on the returned handle shuts the server
+    /// down; [`Notify::notify_waiters`] is lost if it races the first poll of
+    /// the future.
     #[instrument(skip_all)]
     pub async fn handle_http(
         self: Arc<Self>,

--- a/starstream-ledger/src/server/http/mod.rs
+++ b/starstream-ledger/src/server/http/mod.rs
@@ -1,0 +1,623 @@
+use core::future::poll_fn;
+use core::net::SocketAddr;
+use core::pin::pin;
+use core::sync::atomic::{AtomicU64, Ordering};
+use core::task::{Poll, ready};
+use core::time::Duration;
+
+use std::collections::{HashMap, hash_map};
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use bytes::{Buf, Bytes};
+use coset::{CborSerializable as _, CoseSign1, TaggedCborSerializable as _, iana};
+use ed25519_dalek::{Signature, VerifyingKey};
+use headers_accept::Accept;
+use headers_core::Header as _;
+use http::HeaderValue;
+use http::header::{ACCEPT, ALLOW, CONTENT_LENGTH, CONTENT_TYPE, X_CONTENT_TYPE_OPTIONS};
+use http_body::Body as _;
+use http_body_util::BodyExt as _;
+use hyper::service::service_fn;
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::server::graceful::GracefulShutdown;
+use mediatype::MediaType;
+use sha2::{Digest as _, Sha256};
+use tokio::net::TcpSocket;
+use tokio::sync::{Notify, TryAcquireError};
+use tokio::task::JoinSet;
+use tokio::time::sleep;
+use tracing::{Instrument as _, debug, error, info, instrument, warn};
+
+use crate::server::lookup::ContractLookup;
+use crate::server::{Contract, Ledger};
+use crate::{
+    APPLICATION_COSE, APPLICATION_WASM, Action, Block, FUND_CONTEXT, PUBLISH_CONTEXT, parse_digest,
+};
+
+mod error;
+use error::*;
+
+const MAX_CONTRACT_PUT_BODY_SIZE: u64 = 1 << 20;
+const MAX_FUND_POST_BODY_SIZE: u64 = 1 << 10;
+
+fn bind_tcp(address: SocketAddr) -> anyhow::Result<TcpSocket> {
+    debug!("binding TCP socket");
+    let sock = match address {
+        SocketAddr::V4(..) => TcpSocket::new_v4(),
+        SocketAddr::V6(..) => TcpSocket::new_v6(),
+    }
+    .context("failed to create HTTP TCP socket")?;
+    // Conditionally enable `SO_REUSEADDR` depending on the current
+    // platform. On Unix we want this to be able to rebind an address in
+    // the `TIME_WAIT` state which can happen then a server is killed with
+    // active TCP connections and then restarted. On Windows though if
+    // `SO_REUSEADDR` is specified then it enables multiple applications to
+    // bind the port at the same time which is not something we want. Hence
+    // this is conditionally set based on the platform (and deviates from
+    // Tokio's default from always-on).
+    sock.set_reuseaddr(!cfg!(windows))?;
+    sock.bind(address)
+        .with_context(|| format!("failed to bind on `{address}`"))?;
+    Ok(sock)
+}
+
+async fn read_signed_envelope<const MAX: u64>(
+    headers: &http::HeaderMap,
+    body: hyper::body::Incoming,
+) -> Result<(Vec<u8>, VerifyingKey, Option<Vec<u8>>), EnvelopeReadError> {
+    debug_assert!(usize::try_from(MAX).is_ok());
+
+    match headers.get(CONTENT_TYPE).map(HeaderValue::to_str) {
+        None => return Err(EnvelopeReadError::ContentTypeMissing),
+        Some(Ok(ct)) => match MediaType::parse(ct) {
+            Ok(ct) if ct.essence() == APPLICATION_COSE => {}
+            Ok(ct) => {
+                return Err(EnvelopeReadError::UnsupportedContentType(
+                    ct.to_string().into(),
+                ));
+            }
+            Err(err) => return Err(EnvelopeReadError::ContentTypeParsing(err)),
+        },
+        Some(Err(err)) => return Err(EnvelopeReadError::ContentTypeToStr(err)),
+    }
+
+    if body.size_hint().lower() > MAX {
+        return Err(EnvelopeReadError::BodyTooLarge(MAX));
+    }
+    let envelope = http_body_util::Limited::new(body, MAX as _)
+        .collect()
+        .await
+        .map_err(|err| {
+            if err.is::<http_body_util::LengthLimitError>() {
+                EnvelopeReadError::BodyTooLarge(MAX)
+            } else {
+                EnvelopeReadError::Body(err)
+            }
+        })?
+        .to_bytes();
+    let sign1 = CoseSign1::from_tagged_slice(&envelope)
+        .or_else(|_| CoseSign1::from_slice(&envelope))
+        .map_err(EnvelopeReadError::CoseSign1Parsing)?;
+    if !sign1.unprotected.is_empty() {
+        return Err(EnvelopeReadError::UnprotectedHeader);
+    }
+    if sign1.protected.header.alg != Some(coset::Algorithm::Assigned(iana::Algorithm::EdDSA)) {
+        return Err(EnvelopeReadError::Algorithm);
+    }
+    let key = <[u8; 32]>::try_from(sign1.protected.header.key_id.as_slice())
+        .map_err(|_| EnvelopeReadError::KeyIdFormat)?;
+    let key = VerifyingKey::from_bytes(&key).map_err(EnvelopeReadError::Key)?;
+    sign1
+        .verify_signature(b"", |sig, data| {
+            Signature::from_slice(sig).and_then(|sig| key.verify_strict(data, &sig))
+        })
+        .map_err(EnvelopeReadError::SignatureVerification)?;
+    let payload = sign1.payload.clone();
+
+    // Reencode the envelope in a canonical form
+    let envelope = sign1.to_tagged_vec().map_err(EnvelopeReadError::Reencode)?;
+    Ok((envelope, key, payload))
+}
+
+fn negotiate_accept(
+    headers: &http::HeaderMap,
+    available: &'static [MediaType<'static>],
+) -> Option<Result<&'static MediaType<'static>, AcceptHeaderError>> {
+    headers.contains_key(http::header::ACCEPT).then(|| {
+        let accept = Accept::decode(&mut headers.get_all(ACCEPT).iter())
+            .map_err(AcceptHeaderError::Decoding)?;
+        accept
+            .negotiate(available)
+            .ok_or(AcceptHeaderError::NotAcceptable(available))
+    })
+}
+
+fn build_text_response<T>(
+    code: http::StatusCode,
+    body: impl Into<T>,
+) -> http::Result<http::Response<http_body_util::Full<T>>>
+where
+    T: Buf + Sync + Send + 'static,
+{
+    http::Response::builder()
+        .status(code)
+        .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+        .header(X_CONTENT_TYPE_OPTIONS, "nosniff")
+        .body(http_body_util::Full::new(body.into()))
+}
+
+fn build_method_not_allowed(
+    allow: &'static str,
+    method: &http::Method,
+    path: &str,
+) -> http::Result<http::Response<http_body_util::Full<Bytes>>> {
+    http::Response::builder()
+        .status(http::StatusCode::METHOD_NOT_ALLOWED)
+        .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+        .header(X_CONTENT_TYPE_OPTIONS, "nosniff")
+        .header(ALLOW, allow)
+        .body(http_body_util::Full::new(
+            format!("method `{method}` not allowed for path `{path}`").into(),
+        ))
+}
+
+/// Attempt to update the stored nonce.
+///
+/// On success, returns the previous nonce, which is lower than `nonce`.
+/// On failure returns the current nonce, which is greater than or equal to
+/// `nonce`.
+fn try_update_nonce(last_nonce: &AtomicU64, nonce: u64) -> Result<u64, u64> {
+    last_nonce.try_update(Ordering::Relaxed, Ordering::Relaxed, |last_nonce| {
+        if nonce > last_nonce {
+            Some(nonce)
+        } else {
+            None
+        }
+    })
+}
+
+fn is_connection_error(err: &std::io::Error) -> bool {
+    matches!(
+        err.kind(),
+        std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::ConnectionAborted
+            | std::io::ErrorKind::ConnectionReset
+    )
+}
+
+impl Ledger {
+    async fn handle_contract_get(
+        &self,
+        headers: http::HeaderMap,
+        digest: &str,
+    ) -> Result<http::Response<http_body_util::Full<Bytes>>, ContractGetError> {
+        const AVAILABLE_TYPES: &[MediaType] = &[APPLICATION_COSE, APPLICATION_WASM];
+
+        let digest = parse_digest(digest).map_err(ContractGetError::DigestParsing)?;
+
+        let accept = negotiate_accept(&headers, AVAILABLE_TYPES)
+            .transpose()
+            .map_err(ContractGetError::AcceptHeader)?;
+
+        let contracts = self.contracts.read().await;
+        let contract = contracts
+            .get(&digest)
+            .ok_or(ContractGetError::ContractNotFound)?;
+
+        if accept == Some(&APPLICATION_WASM) {
+            http::Response::builder()
+                .header(CONTENT_TYPE, APPLICATION_WASM.to_string())
+                .body(http_body_util::Full::new(contract.wasm.clone()))
+        } else {
+            http::Response::builder()
+                .header(CONTENT_TYPE, APPLICATION_COSE.to_string())
+                .body(http_body_util::Full::new(contract.envelope.clone()))
+        }
+        .map_err(ContractGetError::Http)
+    }
+
+    async fn handle_contract_head(
+        &self,
+        headers: http::HeaderMap,
+        digest: &str,
+    ) -> Result<http::Response<http_body_util::Full<Bytes>>, ContractGetError> {
+        const AVAILABLE_TYPES: &[MediaType] = &[APPLICATION_COSE, APPLICATION_WASM];
+
+        let digest = parse_digest(digest).map_err(ContractGetError::DigestParsing)?;
+
+        let accept = negotiate_accept(&headers, AVAILABLE_TYPES)
+            .transpose()
+            .map_err(ContractGetError::AcceptHeader)?;
+
+        let contracts = self.contracts.read().await;
+        let contract = contracts
+            .get(&digest)
+            .ok_or(ContractGetError::ContractNotFound)?;
+
+        if accept == Some(&APPLICATION_WASM) {
+            http::Response::builder()
+                .header(CONTENT_TYPE, APPLICATION_WASM.to_string())
+                .header(CONTENT_LENGTH, contract.wasm.len())
+        } else {
+            http::Response::builder()
+                .header(CONTENT_TYPE, APPLICATION_COSE.to_string())
+                .header(CONTENT_LENGTH, contract.envelope.len())
+        }
+        .body(http_body_util::Full::default())
+        .map_err(ContractGetError::Http)
+    }
+
+    async fn handle_contract_put(
+        &self,
+        headers: http::HeaderMap,
+        digest: &str,
+        body: hyper::body::Incoming,
+    ) -> Result<http::Response<http_body_util::Full<Bytes>>, ContractPutError> {
+        let digest = parse_digest(digest).map_err(ContractPutError::DigestParsing)?;
+
+        let (envelope, account, payload) =
+            read_signed_envelope::<MAX_CONTRACT_PUT_BODY_SIZE>(&headers, body)
+                .await
+                .map_err(ContractPutError::Envelope)?;
+        let payload = payload.as_deref().ok_or(ContractPutError::PayloadMissing)?;
+        let payload = match ciborium::from_reader(payload) {
+            Ok(ciborium::Value::Array(payload)) => payload,
+            Ok(..) => return Err(ContractPutError::TransactionFormat),
+            Err(err) => return Err(ContractPutError::PayloadParsing(err)),
+        };
+        let Ok(
+            [
+                ciborium::Value::Text(context),
+                ciborium::Value::Text(network),
+                ciborium::Value::Integer(nonce),
+                ciborium::Value::Bytes(wasm),
+            ],
+        ) = <[_; _]>::try_from(payload)
+        else {
+            return Err(ContractPutError::TransactionFormat);
+        };
+        if context != PUBLISH_CONTEXT {
+            return Err(ContractPutError::Context(context.into()));
+        }
+        if network != *self.network {
+            return Err(ContractPutError::Network {
+                got: network.into(),
+                expected: Arc::clone(&self.network),
+            });
+        }
+        let nonce = u64::try_from(nonce).map_err(|_| ContractPutError::NonceOverflow)?;
+        let wasm_digest: [u8; 32] = Sha256::digest(&wasm).into();
+        if wasm_digest != digest {
+            return Err(ContractPutError::DigestMismatch(wasm_digest));
+        }
+
+        {
+            let accounts = self.accounts.read().await;
+            let Some(account) = accounts.get(&account) else {
+                return Err(ContractPutError::AccountNotFound(account));
+            };
+            if let Err(last_nonce) = try_update_nonce(&account.last_nonce, nonce) {
+                return Err(ContractPutError::NonceTooLow { last_nonce, nonce });
+            }
+            let required = envelope.len() as _;
+            if let Err(available) =
+                account
+                    .balance
+                    .try_update(Ordering::Relaxed, Ordering::Relaxed, |balance| {
+                        balance.checked_sub(required)
+                    })
+            {
+                return Err(ContractPutError::InsufficientBalance {
+                    required,
+                    available,
+                });
+            }
+        }
+
+        let envelope = Bytes::from(envelope);
+        {
+            let contracts = self.contracts.read().await;
+            if contracts.contains_key(&digest) {
+                return build_text_response(http::StatusCode::OK, "")
+                    .map_err(ContractPutError::Http);
+            }
+
+            // TODO: Split component
+
+            let (_wizer_cx, contract_wasm) = self
+                .wizer
+                .instrument_component(&wasm)
+                .map_err(ContractPutError::Wizer)?;
+            let contract = starstream_runtime_next::Contract::new(
+                &self.engine,
+                ContractLookup(&contracts),
+                &contract_wasm,
+            )
+            .map_err(ContractPutError::Runtime)?;
+            drop(contracts);
+
+            let mut scripts = HashMap::default();
+            for (name, export) in contract.coordination_scripts() {
+                let export = export.map_err(ContractPutError::Runtime)?;
+                scripts.insert(name.into(), export);
+            }
+            let mut utxos = HashMap::default();
+            for (name, export) in contract.utxos() {
+                let export = export.map_err(ContractPutError::Runtime)?;
+                utxos.insert(name.into(), export);
+            }
+
+            let mut contracts = self.contracts.write().await;
+            let hash_map::Entry::Vacant(entry) = contracts.entry(digest) else {
+                return build_text_response(http::StatusCode::OK, "")
+                    .map_err(ContractPutError::Http);
+            };
+            entry.insert(Arc::new(Contract {
+                contract,
+                contract_wasm: contract_wasm.into(),
+                scripts,
+                utxos,
+                wasm: wasm.into(),
+                envelope: envelope.clone(),
+            }));
+        }
+        {
+            let mut blocks = self.blocks.write().await;
+            let height = blocks.len().saturating_add(1);
+            blocks.push(Block {
+                actions: Box::from([Action::UploadContract(envelope)]),
+                height,
+            });
+        }
+        build_text_response(http::StatusCode::OK, "").map_err(ContractPutError::Http)
+    }
+
+    async fn handle_fund_post(
+        &self,
+        headers: http::HeaderMap,
+        body: hyper::body::Incoming,
+    ) -> Result<http::Response<http_body_util::Full<Bytes>>, AccountFundError> {
+        let (envelope, key, payload) =
+            read_signed_envelope::<MAX_FUND_POST_BODY_SIZE>(&headers, body)
+                .await
+                .map_err(AccountFundError::Envelope)?;
+        let payload = payload.as_deref().ok_or(AccountFundError::PayloadMissing)?;
+        let payload = match ciborium::from_reader(payload) {
+            Ok(ciborium::Value::Array(tx)) => tx,
+            Ok(..) => return Err(AccountFundError::TransactionFormat),
+            Err(err) => return Err(AccountFundError::PayloadParsing(err)),
+        };
+        let Ok(
+            [
+                ciborium::Value::Text(context),
+                ciborium::Value::Text(network),
+                ciborium::Value::Integer(nonce),
+                ciborium::Value::Bytes(account),
+                ciborium::Value::Integer(amount),
+            ],
+        ) = <[_; _]>::try_from(payload)
+        else {
+            return Err(AccountFundError::TransactionFormat);
+        };
+
+        if context != FUND_CONTEXT {
+            return Err(AccountFundError::Context(context.into()));
+        }
+        if network != *self.network {
+            return Err(AccountFundError::Network {
+                got: network.into(),
+                expected: Arc::clone(&self.network),
+            });
+        }
+        let nonce = u64::try_from(nonce).map_err(|_| AccountFundError::NonceOverflow)?;
+        let account =
+            <[u8; 32]>::try_from(account.as_slice()).map_err(|_| AccountFundError::KeyIdFormat)?;
+        let account = VerifyingKey::from_bytes(&account).map_err(AccountFundError::Key)?;
+        if account.is_weak() {
+            return Err(AccountFundError::WeakKey);
+        }
+        let amount = u64::try_from(amount).map_err(|_| AccountFundError::AmountOverflow)?;
+
+        if key != self.admin.key {
+            return Err(AccountFundError::NotAdmin(key));
+        }
+        if let Err(last_nonce) = try_update_nonce(&self.admin.last_nonce, nonce) {
+            return Err(AccountFundError::NonceTooLow { last_nonce, nonce });
+        }
+        {
+            let mut accounts = self.accounts.write().await;
+            let account = accounts.entry(account).or_default();
+            account
+                .balance
+                .update(Ordering::Relaxed, Ordering::Relaxed, |balance| {
+                    balance.saturating_add(amount)
+                });
+        }
+        {
+            let mut blocks = self.blocks.write().await;
+            let height = blocks.len().saturating_add(1);
+            blocks.push(Block {
+                actions: Box::from([Action::FundAccount(envelope.into())]),
+                height,
+            });
+        }
+        build_text_response(http::StatusCode::OK, "").map_err(AccountFundError::Http)
+    }
+
+    /// Bind `address` and return the future serving the ledger HTTP API.
+    #[instrument(skip_all)]
+    pub async fn handle_http(
+        self: Arc<Self>,
+        address: SocketAddr,
+    ) -> anyhow::Result<(impl Future<Output = ()> + use<>, Arc<Notify>)> {
+        let sock = bind_tcp(address)?;
+        let sock = sock
+            .listen(self.max_requests)
+            .context("failed to listen on TCP socket")?;
+
+        let permits = Arc::clone(&self.permits);
+        let ledger = self.clone();
+        let svc = service_fn(move |req: http::Request<hyper::body::Incoming>| {
+            let permits = Arc::clone(&permits);
+            let ledger = ledger.clone();
+            async move {
+                let _permit = match permits.try_acquire() {
+                    Ok(permit) => permit,
+                    Err(TryAcquireError::NoPermits) => {
+                        return build_text_response(
+                            http::StatusCode::SERVICE_UNAVAILABLE,
+                            "maximum concurrent request count reached",
+                        );
+                    }
+                    Err(TryAcquireError::Closed) => {
+                        return build_text_response(
+                            http::StatusCode::INTERNAL_SERVER_ERROR,
+                            "semaphore closed",
+                        );
+                    }
+                };
+                let (
+                    http::request::Parts {
+                        method,
+                        uri,
+                        headers,
+                        ..
+                    },
+                    body,
+                ) = req.into_parts();
+                let Some(pq) = uri.path_and_query() else {
+                    return build_text_response(
+                        http::StatusCode::BAD_REQUEST,
+                        "request target unsupported",
+                    );
+                };
+                let path = pq.path();
+                let path = path
+                    .strip_suffix('/')
+                    .filter(|path| !path.is_empty())
+                    .unwrap_or(path);
+                let mut path = path.split('/');
+                let Some("") = path.next() else {
+                    return build_text_response(
+                        http::StatusCode::BAD_REQUEST,
+                        "request target unsupported",
+                    );
+                };
+                match (
+                    method.as_str(),
+                    path.next(),
+                    path.next(),
+                    path.next(),
+                    path.next(),
+                ) {
+                    ("GET", Some("contracts"), Some(digest), None, ..) => match ledger
+                        .handle_contract_get(headers, digest)
+                        .await
+                    {
+                        Ok(res) => Ok(res),
+                        Err(err) => build_text_response(err.http_status_code(), err.to_string()),
+                    },
+                    ("HEAD", Some("contracts"), Some(digest), None, ..) => match ledger
+                        .handle_contract_head(headers, digest)
+                        .await
+                    {
+                        Ok(res) => Ok(res),
+                        Err(err) => build_text_response(err.http_status_code(), err.to_string()),
+                    },
+                    ("PUT", Some("contracts"), Some(digest), None, ..) => match ledger
+                        .handle_contract_put(headers, digest, body)
+                        .await
+                    {
+                        Ok(res) => Ok(res),
+                        Err(err) => build_text_response(err.http_status_code(), err.to_string()),
+                    },
+                    (_, Some("contracts"), Some(..), None, ..) => {
+                        build_method_not_allowed("GET, HEAD, PUT", &method, pq.path())
+                    }
+
+                    ("POST", Some("fund"), None, ..) => match ledger
+                        .handle_fund_post(headers, body)
+                        .await
+                    {
+                        Ok(res) => Ok(res),
+                        Err(err) => build_text_response(err.http_status_code(), err.to_string()),
+                    },
+                    (_, Some("fund"), None, ..) => {
+                        build_method_not_allowed("POST", &method, pq.path())
+                    }
+
+                    _ => build_text_response(
+                        http::StatusCode::NOT_FOUND,
+                        format!("path `{}` not found", pq.path()),
+                    ),
+                }
+            }
+        });
+        let shutdown = Arc::new(Notify::new());
+        let srv = hyper_util::server::conn::auto::Builder::<TokioExecutor>::default();
+        let max_connections = self.max_requests as usize;
+        Ok((
+            {
+                let shutdown = Arc::clone(&shutdown).notified_owned();
+                async move {
+                    let graceful = GracefulShutdown::default();
+                    let mut tasks = JoinSet::new();
+                    let mut shutdown = pin!(shutdown);
+                    loop {
+                        match poll_fn(|cx| {
+                            while let Poll::Ready(Some(res)) = tasks.poll_join_next(cx) {
+                                if let Err(err) = res {
+                                    error!(?err, "HTTP task panicked");
+                                }
+                            }
+                            match shutdown.as_mut().poll(cx) {
+                                Poll::Ready(()) => Poll::Ready(None),
+                                // Postpone accepting until a connection task
+                                // completes, which wakes this future via
+                                // `poll_join_next` above.
+                                Poll::Pending if tasks.len() >= max_connections => Poll::Pending,
+                                Poll::Pending => {
+                                    let res = ready!(sock.poll_accept(cx));
+                                    Poll::Ready(Some(res))
+                                }
+                            }
+                        })
+                        .await
+                        {
+                            Some(Ok((stream, addr))) => {
+                                info!(?addr, "accepted TCP connection");
+                                let conn = srv.serve_connection(TokioIo::new(stream), svc.clone());
+                                let conn = graceful.watch(conn.into_owned());
+                                tasks.spawn(
+                                    async move {
+                                        if let Err(err) = conn.await {
+                                            warn!(?err, "failed to serve HTTP connection");
+                                        }
+                                    }
+                                    .in_current_span(),
+                                );
+                            }
+                            Some(Err(err)) if is_connection_error(&err) => {
+                                debug!(?err, "failed to accept TCP connection")
+                            }
+                            Some(Err(err)) => {
+                                error!(?err, "failed to accept TCP connection");
+                                sleep(Duration::from_secs(1)).await;
+                            }
+                            None => break,
+                        }
+                    }
+                    graceful.shutdown().await;
+                    while let Some(res) = tasks.join_next().await {
+                        if let Err(err) = res {
+                            error!(?err, "HTTP task panicked");
+                        }
+                    }
+                }
+                .in_current_span()
+            },
+            shutdown,
+        ))
+    }
+}

--- a/starstream-ledger/src/server/lookup.rs
+++ b/starstream-ledger/src/server/lookup.rs
@@ -1,0 +1,24 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use wasmtime::error::Context as _;
+
+use crate::parse_digest;
+use crate::server::{Contract, Ctx};
+
+pub struct ContractLookup<'a>(pub &'a HashMap<[u8; 32], Arc<Contract>>);
+
+impl starstream_runtime_next::ContractLookup<Ctx> for ContractLookup<'_> {
+    fn get_contract(
+        &self,
+        external_id: &str,
+    ) -> wasmtime::Result<starstream_runtime_next::Contract<Ctx>> {
+        let digest = parse_digest(external_id).with_context(|| {
+            format!("failed to parse `external-id` `{external_id}` as multibase multihash")
+        })?;
+        let contract = self.0.get(&digest).with_context(|| {
+            format!("contract identified by `external-id` `{external_id}` not found")
+        })?;
+        Ok(contract.contract.clone())
+    }
+}

--- a/starstream-ledger/src/server/mod.rs
+++ b/starstream-ledger/src/server/mod.rs
@@ -1,0 +1,111 @@
+//! Starstream ledger server.
+
+use core::ops::{Deref, DerefMut};
+use core::sync::atomic::AtomicU64;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use ed25519_dalek::VerifyingKey;
+use starstream_runtime_next::{CoordinationScriptExport, UtxoExport};
+use tokio::sync::{RwLock, Semaphore};
+use wasmtime::component::ResourceTable;
+use wasmtime_wizer::Wizer;
+
+use crate::Block;
+
+mod host;
+mod http;
+mod lookup;
+
+/// The ledger-side state of a publishing account, identified by its Ed25519
+/// public key.
+///
+/// Publishing charges the balance one unit per byte of envelope and must carry a
+/// nonce strictly greater than `last_nonce`.
+#[derive(Debug, Default)]
+struct Account {
+    /// Account balance.
+    pub balance: AtomicU64,
+    /// Last nonce used by the account.
+    pub last_nonce: AtomicU64,
+}
+
+#[derive(Debug)]
+struct AdminAccount {
+    key: VerifyingKey,
+    /// Last nonce used by admin account.
+    /// This nonce is not taken into account for publish actions.
+    last_nonce: AtomicU64,
+}
+
+struct Ctx {
+    table: ResourceTable,
+}
+
+struct Contract {
+    contract: starstream_runtime_next::Contract<Ctx>,
+    #[expect(unused, reason = "TODO")]
+    contract_wasm: Bytes,
+    #[expect(unused, reason = "TODO")]
+    scripts: HashMap<Box<str>, CoordinationScriptExport>,
+    #[expect(unused, reason = "TODO")]
+    utxos: HashMap<Box<str>, UtxoExport>,
+    wasm: Bytes,
+    envelope: Bytes,
+}
+
+impl Deref for Contract {
+    type Target = starstream_runtime_next::Contract<Ctx>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.contract
+    }
+}
+
+impl DerefMut for Contract {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.contract
+    }
+}
+
+/// Starstream ledger
+pub struct Ledger {
+    engine: wasmtime::Engine,
+    wizer: Wizer,
+    blocks: Arc<RwLock<Vec<Block>>>,
+    contracts: Arc<RwLock<HashMap<[u8; 32], Arc<Contract>>>>,
+    accounts: Arc<RwLock<HashMap<VerifyingKey, Account>>>,
+    admin: AdminAccount,
+    network: Arc<str>,
+    max_requests: u32,
+    permits: Arc<Semaphore>,
+}
+
+impl Ledger {
+    pub fn new(
+        engine: wasmtime::Engine,
+        max_requests: u32,
+        network: impl Into<Arc<str>>,
+        admin: VerifyingKey,
+    ) -> Self {
+        let max_requests = usize::try_from(max_requests)
+            .unwrap_or(Semaphore::MAX_PERMITS)
+            .min(Semaphore::MAX_PERMITS);
+        Self {
+            engine,
+            wizer: Wizer::new(),
+            blocks: Arc::default(),
+            contracts: Arc::default(),
+            accounts: Arc::default(),
+            admin: AdminAccount {
+                key: admin,
+                last_nonce: AtomicU64::default(),
+            },
+            network: network.into(),
+            max_requests: max_requests as _,
+            permits: Arc::new(Semaphore::new(max_requests)),
+        }
+    }
+}

--- a/starstream-ledger/tests/ledger.rs
+++ b/starstream-ledger/tests/ledger.rs
@@ -1,0 +1,177 @@
+#![cfg(all(feature = "client", feature = "server"))]
+
+use core::net::Ipv6Addr;
+use core::str::FromStr as _;
+
+use std::sync::{Arc, LazyLock};
+
+use anyhow::Context as _;
+use bytes::Bytes;
+use ed25519_dalek::SigningKey;
+use http::{StatusCode, Uri};
+use http_body_util::{BodyExt as _, Full};
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioExecutor;
+use sha2::{Digest as _, Sha256};
+use starstream_ledger::client::build_publish_envelope;
+use starstream_ledger::client::http::{
+    ClientBuilder, build_contract_get_request, build_contract_publish_request, build_fund_request,
+};
+use starstream_ledger::server::Ledger;
+use tokio::net::TcpListener;
+
+fn compile_contract(source: &str) -> Vec<u8> {
+    let (program, errors) = starstream_compiler::parse_program(source).into_output_errors();
+    assert!(errors.is_empty(), "parsing failed: {errors:?}");
+    let program = program.expect("parser produced no program");
+    let typed = starstream_compiler::typecheck_program(&program, Default::default())
+        .unwrap_or_else(|failure| panic!("typechecking failed: {:?}", failure.errors));
+    let result = starstream_to_wasm::compile(&typed.program);
+    assert!(
+        result.errors.is_empty(),
+        "compiling failed: {:?}",
+        result.errors
+    );
+    let wasm = result.wasm.expect("compiling produced no Wasm");
+    starstream_runtime_next::componentize(wasm).expect("failed to componentize contract")
+}
+
+const NETWORK: &str = "starstream:test";
+
+static SCORE_WASM: LazyLock<Vec<u8>> =
+    LazyLock::new(|| compile_contract(include_str!("../../examples/score.star")));
+static SCORE_WASM_DIGEST: LazyLock<[u8; 32]> =
+    LazyLock::new(|| Sha256::digest(&*SCORE_WASM).into());
+
+static ADMIN: LazyLock<SigningKey> = LazyLock::new(|| SigningKey::from_bytes(&[0x42; 32]));
+
+async fn http_request(
+    client: &hyper_util::client::legacy::Client<HttpConnector, Full<Bytes>>,
+    req: http::Request<Full<Bytes>>,
+) -> anyhow::Result<(http::response::Parts, Bytes)> {
+    let res = client
+        .request(req)
+        .await
+        .context("failed to send request")?;
+    let (parts, body) = res.into_parts();
+    let body = body
+        .collect()
+        .await
+        .context("failed to receive response body")?;
+    Ok((parts, body.to_bytes()))
+}
+
+#[tokio::test]
+async fn http() -> anyhow::Result<()> {
+    let addr = {
+        let lis = TcpListener::bind((Ipv6Addr::LOCALHOST, 0))
+            .await
+            .context("failed to bind TCP listener")?;
+        lis.local_addr()
+            .context("failed to get TCP listener local address")?
+    };
+
+    let ledger = Ledger::new(
+        wasmtime::Engine::default(),
+        128,
+        NETWORK,
+        ADMIN.verifying_key(),
+    );
+    let ledger = Arc::new(ledger);
+    let (ledger, shutdown) = ledger
+        .handle_http(addr)
+        .await
+        .context("failed to handle HTTP")?;
+    let ledger = tokio::spawn(ledger);
+
+    let http = hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build_http();
+    let api_base = Uri::from_str(&format!("http://{addr}"))?;
+    let client = ClientBuilder::new(http.clone(), api_base.clone())
+        .network(NETWORK)
+        .build();
+
+    let score_publish_envelope =
+        build_publish_envelope(ADMIN.clone(), NETWORK, 1, SCORE_WASM.as_slice())?;
+    let score_publish_req = build_contract_publish_request(
+        &api_base,
+        ADMIN.clone(),
+        NETWORK,
+        1,
+        SCORE_WASM.as_slice(),
+    )?;
+
+    let (http::response::Parts { status, .. }, body) =
+        http_request(&http, score_publish_req.clone()).await?;
+    let body = String::from_utf8_lossy(&body);
+    assert_eq!(status, StatusCode::PAYMENT_REQUIRED, "{body}");
+    assert_eq!(
+        body,
+        "account ID `2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12` not found"
+    );
+
+    let score_publish_cost = score_publish_envelope.len();
+    let balance = score_publish_cost.saturating_sub(1000);
+
+    client
+        .fund(ADMIN.clone(), 1, &ADMIN.verifying_key(), balance as _)
+        .await?;
+
+    let req = build_fund_request(
+        &api_base,
+        ADMIN.clone(),
+        NETWORK,
+        1,
+        &ADMIN.verifying_key(),
+        balance as _,
+    )?;
+    let (http::response::Parts { status, .. }, body) = http_request(&http, req).await?;
+    let body = String::from_utf8_lossy(&body);
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert_eq!(body, "nonce must be higher than 1, got 1");
+
+    let (http::response::Parts { status, .. }, body) =
+        http_request(&http, score_publish_req.clone()).await?;
+    let body = String::from_utf8_lossy(&body);
+    assert_eq!(status, StatusCode::PAYMENT_REQUIRED, "{body}");
+    assert_eq!(
+        body,
+        format!(
+            "balance insufficient, required at least {score_publish_cost}, available {balance}"
+        )
+    );
+    let (http::response::Parts { status, .. }, body) =
+        http_request(&http, score_publish_req).await?;
+    let body = String::from_utf8_lossy(&body);
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert_eq!(body, "nonce must be higher than 1, got 1");
+
+    client
+        .fund(
+            ADMIN.clone(),
+            2,
+            &ADMIN.verifying_key(),
+            (score_publish_cost - balance) as _,
+        )
+        .await?;
+
+    client
+        .publish_contract(ADMIN.clone(), 2, SCORE_WASM.as_slice())
+        .await?;
+
+    let wasm = client.get_contract_wasm(&SCORE_WASM_DIGEST).await?;
+    assert_eq!(wasm, *SCORE_WASM);
+
+    let score_publish_envelope =
+        build_publish_envelope(ADMIN.clone(), NETWORK, 2, SCORE_WASM.as_slice())?;
+
+    let envelope = client.get_contract_envelope(&SCORE_WASM_DIGEST).await?;
+    assert_eq!(envelope, score_publish_envelope);
+
+    let req = build_contract_get_request(&api_base, &SCORE_WASM_DIGEST, None)?;
+    let (http::response::Parts { status, .. }, body) = http_request(&http, req).await?;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    assert_eq!(body, score_publish_envelope);
+
+    shutdown.notify_waiters();
+    ledger.await.context("ledger task panicked")
+}

--- a/starstream-ledger/tests/ledger.rs
+++ b/starstream-ledger/tests/ledger.rs
@@ -7,7 +7,9 @@ use std::sync::{Arc, LazyLock};
 
 use anyhow::Context as _;
 use bytes::Bytes;
-use ed25519_dalek::SigningKey;
+use coset::{CoseSign1Builder, HeaderBuilder, TaggedCborSerializable as _, iana};
+use ed25519_dalek::{Signer as _, SigningKey};
+use http::header::{CONTENT_TYPE, VARY, X_CONTENT_TYPE_OPTIONS};
 use http::{StatusCode, Uri};
 use http_body_util::{BodyExt as _, Full};
 use hyper_util::client::legacy::connect::HttpConnector;
@@ -17,6 +19,7 @@ use starstream_ledger::client::build_publish_envelope;
 use starstream_ledger::client::http::{
     ClientBuilder, build_contract_get_request, build_contract_publish_request, build_fund_request,
 };
+use starstream_ledger::encode_digest;
 use starstream_ledger::server::Ledger;
 use tokio::net::TcpListener;
 
@@ -109,6 +112,31 @@ async fn http() -> anyhow::Result<()> {
         "account ID `2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12` not found"
     );
 
+    let protected = HeaderBuilder::new()
+        .algorithm(iana::Algorithm::EdDSA)
+        .key_id(ADMIN.verifying_key().to_bytes().into())
+        .add_critical(iana::HeaderParameter::Alg)
+        .build();
+    let crit_envelope = CoseSign1Builder::new()
+        .protected(protected)
+        .payload(Vec::default())
+        .create_signature(b"", |data| ADMIN.sign(data).to_bytes().into())
+        .build()
+        .to_tagged_vec()
+        .context("failed to serialize envelope")?;
+    let req = http::Request::builder()
+        .method(http::Method::PUT)
+        .uri(format!(
+            "http://{addr}/contracts/{}",
+            encode_digest(&SCORE_WASM_DIGEST)
+        ))
+        .header(CONTENT_TYPE, "application/cose")
+        .body(Full::new(Bytes::from(crit_envelope)))?;
+    let (http::response::Parts { status, .. }, body) = http_request(&http, req).await?;
+    let body = String::from_utf8_lossy(&body);
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(body, "envelope must not contain critical headers");
+
     let score_publish_cost = score_publish_envelope.len();
     let balance = score_publish_cost.saturating_sub(1000);
 
@@ -168,10 +196,23 @@ async fn http() -> anyhow::Result<()> {
     assert_eq!(envelope, score_publish_envelope);
 
     let req = build_contract_get_request(&api_base, &SCORE_WASM_DIGEST, None)?;
-    let (http::response::Parts { status, .. }, body) = http_request(&http, req).await?;
+    let (
+        http::response::Parts {
+            status, headers, ..
+        },
+        body,
+    ) = http_request(&http, req).await?;
     assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
     assert_eq!(body, score_publish_envelope);
+    assert_eq!(
+        headers.get(VARY).map(|v| v.as_bytes()),
+        Some(b"accept".as_slice())
+    );
+    assert_eq!(
+        headers.get(X_CONTENT_TYPE_OPTIONS).map(|v| v.as_bytes()),
+        Some(b"nosniff".as_slice())
+    );
 
-    shutdown.notify_waiters();
+    shutdown.notify_one();
     ledger.await.context("ledger task panicked")
 }

--- a/starstream-runtime-next/tests/common/mod.rs
+++ b/starstream-runtime-next/tests/common/mod.rs
@@ -9,12 +9,6 @@ use tracing::instrument;
 use wasmtime::component::{Resource, ResourceTable, Val};
 use wasmtime::{AsContextMut as _, StoreContextMut, bail};
 
-/// Compile a single Starstream contract source to a core Wasm module in-process.
-///
-/// Mirrors the browser sandbox's compile path: parse the source, typecheck it,
-/// then emit the contract. The result carries a `component-type` custom section,
-/// so `Contract::new`'s `componentize` step wraps it into a component at run
-/// time.
 pub fn compile_contract(source: &str) -> Vec<u8> {
     let (program, errors) = parse_program(source).into_output_errors();
     assert!(errors.is_empty(), "parsing failed: {errors:?}");
@@ -30,9 +24,6 @@ pub fn compile_contract(source: &str) -> Vec<u8> {
     result.wasm.expect("compiling produced no Wasm")
 }
 
-/// The ABI method identity hash the guest reports via `implements-method`:
-/// the SHA-256 of the method name, split into four little-endian `u64`s. Mirrors
-/// the codegen in `starstream-to-wasm`.
 pub fn method_hash(name: &str) -> (u64, u64, u64, u64) {
     let digest = Sha256::digest(name.as_bytes());
     let mut chunks = digest


### PR DESCRIPTION
Some of this is extracted from #182, and a big part is reworked/refactored.

This first, minimal ledger supports:
- funding accounts (used to pay for publishing)
- publishing contracts
- fetching contracts (COSE envelope or raw Wasm via `Accept` negotiation; `HEAD` supported)

Transactions are Ed25519-signed COSE_Sign1 envelopes (verified with `verify_strict`), bound to a network identifier and a strictly-increasing per-account nonce. The server rejects unprotected COSE headers and re-encodes each envelope into canonical tagged form before charging, storing, or serving it, so the retained bytes are fully covered by the signature. Publishing costs one unit per envelope byte.

The ledger produces blocks, which are stored in memory. Each block contains exactly one action (currently either contract publish or account fund).

Contract digests are represented as multibase-multihash sha256. The client verifies what it fetches against the requested digest: Wasm by hash, envelopes by signature and payload digest. Accounts are Ed25519 public keys; funding a weak (small-order) key is rejected, since `verify_strict` would refuse its signatures at publish time anyway.

Default private admin key is the sha256 digest of the word `admin` and default network is `dev`.

Server behavior worth noting: `content-type: application/cose` is required on submissions; concurrent connections are bounded by `--max-requests`. The node shuts down gracefully on ^C or SIGTERM, bounded by `--shutdown-timeout` (10 s default).

The CLI takes signing keys as a file path (`--key <PATH>`), never on the command line, and zeroizes key material after signing.

Example usage (against ledger node running with default config with compiled score example at `./score.wasm`):

```
$ starstream-ledger-cli key generate > key
 INFO starstream_ledger_cli: generated key pair public_key="ea1fe9aef4b7bcf768fe7614dae347db3911f33d389f7da83532de08783397c5"

$ printf admin | sha256sum | cut -d' ' -f1 > admin.key

$ starstream-ledger-cli account fund --key admin.key --nonce 1 "ea1fe9aef4b7bcf768fe7614dae347db3911f33d389f7da83532de08783397c5" 1000000

$ starstream-ledger-cli contract publish --key key --nonce 1 ./score.wasm

$ curl -s -H 'Accept: application/wasm' http://[::1]:9000/contracts/$(starstream-ledger-cli contract digest ./score.wasm) | wasm-tools print | tail
      (with "import-type-utxo" (type $"#type14 utxo"))
      (with "import-type-s-utxo-context" (type $utxo-context))
      (with "import-type-storage" (type 15))
    )
  )
  (export $score-progress (;6;) "score-progress" (instance $score-progress-shim-instance))
  (@producers
    (processed-by "wit-component" "0.254.0")
  )
)
```
