### PR TITLE
rt-next: add AOT contract import lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3934,6 +3934,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wizer",
+ "wit-component 0.254.0",
 ]
 
 [[package]]
@@ -3987,7 +3988,6 @@ dependencies = [
  "test-log",
  "tokio",
  "tracing",
- "wasmparser 0.254.0",
  "wasmtime",
  "wit-component 0.254.0",
 ]

--- a/starstream-cli/src/run.rs
+++ b/starstream-cli/src/run.rs
@@ -11,7 +11,7 @@ use sha2::{Digest as _, Sha256};
 use starstream_runtime_next::{Contract, ContractLookup, Host, Utxo, bindings};
 use tokio::fs;
 use tracing::{debug, info, instrument};
-use wasmtime::component::{Resource, ResourceTable, Val};
+use wasmtime::component::{Component, Resource, ResourceTable, Val};
 use wasmtime::error::Context as _;
 use wasmtime::{AsContextMut as _, Store, StoreContextMut, ensure};
 
@@ -187,7 +187,9 @@ async fn exec(
         let wasm = fs::read(&import)
             .await
             .with_context(|| format!("failed to read import contract `{}`", import.display()))?;
-        let contract = Contract::new(&engine, &lookup, &wasm)
+        let component =
+            Component::new(&engine, &wasm).context("failed to compile import contract")?;
+        let contract = Contract::new(&component, &lookup)
             .with_context(|| format!("failed to load import contract `{}`", import.display()))?;
         let digest = Sha256::digest(&wasm);
         let digest = format!("{digest:02x}");
@@ -196,7 +198,8 @@ async fn exec(
     }
 
     let wasm = fs::read(&wasm).await.context("failed to read contract")?;
-    let contract = Contract::new(&engine, &lookup, wasm).context("failed to load contract")?;
+    let component = Component::new(&engine, &wasm).context("failed to compile contract")?;
+    let contract = Contract::new(&component, &lookup).context("failed to load contract")?;
     let mut store = Store::new(
         &engine,
         Ctx {

--- a/starstream-ledger-cli/tests/cli.rs
+++ b/starstream-ledger-cli/tests/cli.rs
@@ -1,43 +1,48 @@
 use core::net::Ipv6Addr;
 
-use std::process::Output;
+use std::ffi::OsStr;
+use std::process::{Output, Stdio};
 use std::sync::{Arc, LazyLock};
-use std::{ffi::OsStr, process::Stdio};
 
-use anyhow::Context as _;
+use anyhow::{Context as _, anyhow, ensure};
 use ed25519_dalek::SigningKey;
+use starstream_compiler::typecheck::TypecheckSuccess;
+use starstream_compiler::{TypecheckFailure, TypecheckOptions, parse_program, typecheck_program};
 use starstream_ledger::client::build_publish_envelope;
 use starstream_ledger::server::Ledger;
+use starstream_to_wasm::CompileResult;
 use tempfile::NamedTempFile;
 use tokio::fs;
 use tokio::net::TcpListener;
 use tokio::process::Command;
+use wit_component::ComponentEncoder;
 
-fn compile_contract(source: &str) -> Vec<u8> {
-    let (program, errors) = starstream_compiler::parse_program(source).into_output_errors();
-    assert!(errors.is_empty(), "parsing failed: {errors:?}");
-    let program = program.expect("parser produced no program");
-    let typed = starstream_compiler::typecheck_program(&program, Default::default())
-        .unwrap_or_else(|failure| panic!("typechecking failed: {:?}", failure.errors));
-    let result = starstream_to_wasm::compile(&typed.program);
-    assert!(
-        result.errors.is_empty(),
-        "compiling failed: {:?}",
-        result.errors
-    );
-    let wasm = result.wasm.expect("compiling produced no Wasm");
-    wit_component::ComponentEncoder::default()
+fn compile_contract(source: &str) -> anyhow::Result<Vec<u8>> {
+    let (program, errs) = parse_program(source).into_output_errors();
+    ensure!(errs.is_empty(), "failed to parse program: {errs:?}");
+    let program = program.context("parser did not produce a program")?;
+
+    let TypecheckSuccess { program, .. } = typecheck_program(&program, TypecheckOptions::default())
+        .map_err(|TypecheckFailure { errors, .. }| {
+            anyhow!("failed to typecheck program: {:?}", errors)
+        })?;
+
+    let CompileResult { errors, wasm, .. } = starstream_to_wasm::compile(&program);
+    ensure!(errors.is_empty(), "failed to compile program: {errors:?}");
+
+    let wasm = wasm.context("compilation did not produce Wasm")?;
+    ComponentEncoder::default()
         .validate(true)
         .module(&wasm)
-        .expect("failed to set core component module")
+        .context("failed to set core component module")?
         .encode()
-        .expect("failed to encode a component")
+        .context("failed to encode a component")
 }
 
 const NETWORK: &str = "starstream:test";
 
 static SCORE_WASM: LazyLock<Vec<u8>> =
-    LazyLock::new(|| compile_contract(include_str!("../../examples/score.star")));
+    LazyLock::new(|| compile_contract(include_str!("../../examples/score.star")).unwrap());
 
 static ADMIN: LazyLock<SigningKey> = LazyLock::new(|| SigningKey::from_bytes(&[0x42; 32]));
 

--- a/starstream-ledger-node/src/main.rs
+++ b/starstream-ledger-node/src/main.rs
@@ -74,7 +74,9 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let engine = wasmtime::Engine::default();
+    let mut config = wasmtime::Config::default();
+    config.wasm_component_model_implements(true);
+    let engine = wasmtime::Engine::new(&config)?;
 
     let ledger = Ledger::new(engine, max_requests, network, admin);
     let ledger = Arc::new(ledger);

--- a/starstream-ledger/Cargo.toml
+++ b/starstream-ledger/Cargo.toml
@@ -72,3 +72,4 @@ tokio = { workspace = true, features = [
     "macros",
     "rt-multi-thread",
 ] }
+wit-component = { workspace = true }

--- a/starstream-ledger/src/server/http/error.rs
+++ b/starstream-ledger/src/server/http/error.rs
@@ -116,6 +116,10 @@ pub enum ContractPutError {
     Http(http::Error),
     #[error("instrumentation failed: {0:#}")]
     Wizer(wasmtime::Error),
+    #[error("failed to parse `external-id` `{0}` as multibase multihash: {1}")]
+    ContractImportDigestParsing(Box<str>, DigestParseError),
+    #[error("contract import identified by `external-id` `{0}` not found")]
+    ContractImportNotFound(Box<str>),
 }
 
 impl ContractPutError {
@@ -130,12 +134,14 @@ impl ContractPutError {
             | Self::NonceOverflow
             | Self::DigestMismatch(..)
             | Self::Runtime(..)
+            | Self::ContractImportDigestParsing(..)
             | Self::Wizer(..) => http::StatusCode::BAD_REQUEST,
             Self::Envelope(err) => err.http_status_code(),
             Self::NonceTooLow { .. } => http::StatusCode::CONFLICT,
             Self::AccountNotFound(..) | Self::InsufficientBalance { .. } => {
                 http::StatusCode::PAYMENT_REQUIRED
             }
+            Self::ContractImportNotFound { .. } => http::StatusCode::NOT_FOUND,
             Self::Http(..) => http::StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/starstream-ledger/src/server/http/mod.rs
+++ b/starstream-ledger/src/server/http/mod.rs
@@ -23,11 +23,15 @@ use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::graceful::GracefulShutdown;
 use mediatype::MediaType;
 use sha2::{Digest as _, Sha256};
+use starstream_runtime_next::{
+    CoordinationScriptImport, UtxoImport, get_coordination_script_instance_import, utxo_imports,
+};
 use tokio::net::TcpSocket;
 use tokio::sync::{Notify, TryAcquireError};
 use tokio::task::JoinSet;
 use tokio::time::sleep;
 use tracing::{Instrument as _, debug, error, info, instrument, warn};
+use wasmtime::component::Component;
 
 use crate::server::lookup::ContractLookup;
 use crate::server::{Contract, Ledger};
@@ -319,45 +323,83 @@ impl Ledger {
                 });
             }
         }
-
-        let envelope = Bytes::from(envelope);
         {
             let contracts = self.contracts.read().await;
             if contracts.contains_key(&digest) {
                 return build_text_response(http::StatusCode::OK, "")
                     .map_err(ContractPutError::Http);
             }
+        }
 
-            // TODO: Split component
-
-            let (_wizer_cx, contract_wasm) = self
-                .wizer
-                .instrument_component(&wasm)
-                .map_err(ContractPutError::Wizer)?;
-            let contract = starstream_runtime_next::Contract::new(
-                &self.engine,
-                ContractLookup(&contracts),
-                &contract_wasm,
-            )
+        let (_wizer_cx, contract_wasm) = self
+            .wizer
+            .instrument_component(&wasm)
+            .map_err(ContractPutError::Wizer)?;
+        let component = Component::from_binary(&self.engine, &contract_wasm)
             .map_err(ContractPutError::Runtime)?;
-            drop(contracts);
-
-            let mut scripts = HashMap::default();
-            for (name, export) in contract.coordination_scripts() {
-                let export = export.map_err(ContractPutError::Runtime)?;
-                scripts.insert(name.into(), export);
+        let ty = component.component_type();
+        let script_instance = get_coordination_script_instance_import(&self.engine, &ty);
+        let mut imports = HashMap::default();
+        {
+            let contracts = self.contracts.read().await;
+            if contracts.contains_key(&digest) {
+                return build_text_response(http::StatusCode::OK, "")
+                    .map_err(ContractPutError::Http);
             }
-            let mut utxos = HashMap::default();
-            for (name, export) in contract.utxos() {
-                let export = export.map_err(ContractPutError::Runtime)?;
-                utxos.insert(name.into(), export);
-            }
+            for import in utxo_imports(&self.engine, &ty) {
+                let UtxoImport { external_id, .. } = import.map_err(ContractPutError::Runtime)?;
+                if imports.contains_key(external_id) {
+                    continue;
+                }
 
+                let digest = parse_digest(external_id).map_err(|err| {
+                    ContractPutError::ContractImportDigestParsing(external_id.into(), err)
+                })?;
+                let contract = contracts
+                    .get(&digest)
+                    .ok_or_else(|| ContractPutError::ContractImportNotFound(external_id.into()))?;
+                imports.insert(external_id, Arc::clone(contract));
+            }
+            if let Some(script_instance) = &script_instance {
+                for import in script_instance.coordination_scripts() {
+                    let CoordinationScriptImport { external_id, .. } =
+                        import.map_err(ContractPutError::Runtime)?;
+                    if imports.contains_key(external_id) {
+                        continue;
+                    }
+
+                    let digest = parse_digest(external_id).map_err(|err| {
+                        ContractPutError::ContractImportDigestParsing(external_id.into(), err)
+                    })?;
+                    let contract = contracts.get(&digest).ok_or_else(|| {
+                        ContractPutError::ContractImportNotFound(external_id.into())
+                    })?;
+                    imports.insert(external_id, Arc::clone(contract));
+                }
+            }
+        }
+
+        let contract = starstream_runtime_next::Contract::new(&component, ContractLookup(&imports))
+            .map_err(ContractPutError::Runtime)?;
+        let mut scripts = HashMap::default();
+        for (name, export) in contract.coordination_scripts() {
+            let export = export.map_err(ContractPutError::Runtime)?;
+            scripts.insert(name.into(), export);
+        }
+        let mut utxos = HashMap::default();
+        for (name, export) in contract.utxos() {
+            let export = export.map_err(ContractPutError::Runtime)?;
+            utxos.insert(name.into(), export);
+        }
+
+        let envelope = Bytes::from(envelope);
+        {
             let mut contracts = self.contracts.write().await;
             let hash_map::Entry::Vacant(entry) = contracts.entry(digest) else {
                 return build_text_response(http::StatusCode::OK, "")
                     .map_err(ContractPutError::Http);
             };
+            // TODO: Split component
             entry.insert(Arc::new(Contract {
                 contract,
                 contract_wasm: contract_wasm.into(),

--- a/starstream-ledger/src/server/lookup.rs
+++ b/starstream-ledger/src/server/lookup.rs
@@ -1,22 +1,20 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use tracing::error;
 use wasmtime::error::Context as _;
 
-use crate::parse_digest;
 use crate::server::{Contract, Ctx};
 
-pub struct ContractLookup<'a>(pub &'a HashMap<[u8; 32], Arc<Contract>>);
+pub struct ContractLookup<'a>(pub &'a HashMap<&'a str, Arc<Contract>>);
 
 impl starstream_runtime_next::ContractLookup<Ctx> for ContractLookup<'_> {
     fn get_contract(
         &self,
         external_id: &str,
     ) -> wasmtime::Result<starstream_runtime_next::Contract<Ctx>> {
-        let digest = parse_digest(external_id).with_context(|| {
-            format!("failed to parse `external-id` `{external_id}` as multibase multihash")
-        })?;
-        let contract = self.0.get(&digest).with_context(|| {
+        let contract = self.0.get(external_id).with_context(|| {
+            error!(external_id, "unresolved contract import");
             format!("contract identified by `external-id` `{external_id}` not found")
         })?;
         Ok(contract.contract.clone())

--- a/starstream-ledger/tests/ledger.rs
+++ b/starstream-ledger/tests/ledger.rs
@@ -5,7 +5,7 @@ use core::str::FromStr as _;
 
 use std::sync::{Arc, LazyLock};
 
-use anyhow::Context as _;
+use anyhow::{Context as _, anyhow, ensure};
 use bytes::Bytes;
 use coset::{CoseSign1Builder, HeaderBuilder, TaggedCborSerializable as _, iana};
 use ed25519_dalek::{Signer as _, SigningKey};
@@ -15,34 +15,44 @@ use http_body_util::{BodyExt as _, Full};
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
 use sha2::{Digest as _, Sha256};
+use starstream_compiler::typecheck::TypecheckSuccess;
+use starstream_compiler::{TypecheckFailure, TypecheckOptions, parse_program, typecheck_program};
 use starstream_ledger::client::build_publish_envelope;
 use starstream_ledger::client::http::{
     ClientBuilder, build_contract_get_request, build_contract_publish_request, build_fund_request,
 };
 use starstream_ledger::encode_digest;
 use starstream_ledger::server::Ledger;
+use starstream_to_wasm::CompileResult;
 use tokio::net::TcpListener;
+use wit_component::ComponentEncoder;
 
-fn compile_contract(source: &str) -> Vec<u8> {
-    let (program, errors) = starstream_compiler::parse_program(source).into_output_errors();
-    assert!(errors.is_empty(), "parsing failed: {errors:?}");
-    let program = program.expect("parser produced no program");
-    let typed = starstream_compiler::typecheck_program(&program, Default::default())
-        .unwrap_or_else(|failure| panic!("typechecking failed: {:?}", failure.errors));
-    let result = starstream_to_wasm::compile(&typed.program);
-    assert!(
-        result.errors.is_empty(),
-        "compiling failed: {:?}",
-        result.errors
-    );
-    let wasm = result.wasm.expect("compiling produced no Wasm");
-    starstream_runtime_next::componentize(wasm).expect("failed to componentize contract")
+fn compile_contract(source: &str) -> anyhow::Result<Vec<u8>> {
+    let (program, errs) = parse_program(source).into_output_errors();
+    ensure!(errs.is_empty(), "failed to parse program: {errs:?}");
+    let program = program.context("parser did not produce a program")?;
+
+    let TypecheckSuccess { program, .. } = typecheck_program(&program, TypecheckOptions::default())
+        .map_err(|TypecheckFailure { errors, .. }| {
+            anyhow!("failed to typecheck program: {:?}", errors)
+        })?;
+
+    let CompileResult { errors, wasm, .. } = starstream_to_wasm::compile(&program);
+    ensure!(errors.is_empty(), "failed to compile program: {errors:?}");
+
+    let wasm = wasm.context("compilation did not produce Wasm")?;
+    ComponentEncoder::default()
+        .validate(true)
+        .module(&wasm)
+        .context("failed to set core component module")?
+        .encode()
+        .context("failed to encode a component")
 }
 
 const NETWORK: &str = "starstream:test";
 
 static SCORE_WASM: LazyLock<Vec<u8>> =
-    LazyLock::new(|| compile_contract(include_str!("../../examples/score.star")));
+    LazyLock::new(|| compile_contract(include_str!("../../examples/score.star")).unwrap());
 static SCORE_WASM_DIGEST: LazyLock<[u8; 32]> =
     LazyLock::new(|| Sha256::digest(&*SCORE_WASM).into());
 
@@ -74,12 +84,11 @@ async fn http() -> anyhow::Result<()> {
             .context("failed to get TCP listener local address")?
     };
 
-    let ledger = Ledger::new(
-        wasmtime::Engine::default(),
-        128,
-        NETWORK,
-        ADMIN.verifying_key(),
-    );
+    let mut config = wasmtime::Config::default();
+    config.wasm_component_model_implements(true);
+    let engine = wasmtime::Engine::new(&config)?;
+
+    let ledger = Ledger::new(engine, 128, NETWORK, ADMIN.verifying_key());
     let ledger = Arc::new(ledger);
     let (ledger, shutdown) = ledger
         .handle_http(addr)

--- a/starstream-runtime-next/Cargo.toml
+++ b/starstream-runtime-next/Cargo.toml
@@ -14,7 +14,6 @@ wasmtime-custom-virtual-memory = ["wasmtime/custom-virtual-memory"]
 [dependencies]
 anyhow = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
-wasmparser = { workspace = true }
 wasmtime = { workspace = true, features = [
     "anyhow",
     "async",
@@ -22,7 +21,6 @@ wasmtime = { workspace = true, features = [
     "cranelift",
     "runtime",
 ] }
-wit-component = { workspace = true }
 
 [dev-dependencies]
 sha2 = { workspace = true }
@@ -30,3 +28,4 @@ starstream-compiler = { workspace = true }
 starstream-to-wasm = { workspace = true }
 test-log = { workspace = true, features = ["color", "trace"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
+wit-component = { workspace = true }

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -1,4 +1,5 @@
-use std::pin::Pin;
+use core::pin::Pin;
+
 use std::sync::{Arc, OnceLock};
 
 use tracing::{debug, instrument};
@@ -7,7 +8,7 @@ use wasmtime::component::{
     LinkerInstance, Resource, ResourceAny, ResourceTable, ResourceType, Type, Val, types,
 };
 use wasmtime::error::Context as _;
-use wasmtime::{AsContextMut, Engine, StoreContextMut, bail, ensure};
+use wasmtime::{AsContextMut, Engine, StoreContextMut, bail, ensure, format_err};
 
 pub mod bindings {
     // NOTE: `starstream:std/{builtin,utxo-context}` bindings are hand-written
@@ -24,6 +25,103 @@ pub mod bindings {
             default: tracing | trappable,
         }
     });
+}
+
+#[derive(Clone, Debug)]
+pub struct UtxoImport<'a> {
+    pub name: &'a str,
+    pub external_id: &'a str,
+    pub ty: types::ComponentInstance,
+}
+
+/// Iterate over UTXOs imported by this [Contract].
+#[instrument(level = "trace", skip_all)]
+pub fn utxo_imports<'a>(
+    engine: &'a Engine,
+    ty: &'a types::Component,
+) -> impl Iterator<Item = wasmtime::Result<UtxoImport<'a>>> {
+    ty.imports(engine).filter_map(
+        |(
+            name,
+            types::ComponentExtern {
+                ty, external_id, ..
+            },
+        )| {
+            let types::ComponentItem::ComponentInstance(ty) = ty else {
+                return None;
+            };
+            let ("starstream:utxo", name) = name.split_once('/')? else {
+                return None;
+            };
+            if let Some(external_id) = external_id {
+                Some(Ok(UtxoImport {
+                    name,
+                    external_id,
+                    ty,
+                }))
+            } else {
+                Some(Err(format_err!(
+                    "`external-id` missing for UTXO import `{name}`"
+                )))
+            }
+        },
+    )
+}
+
+#[derive(Clone, Debug)]
+pub struct CoordinationScriptImport<'a> {
+    pub name: &'a str,
+    pub external_id: &'a str,
+    pub ty: types::ComponentFunc,
+}
+
+pub struct CoordinationScriptInstanceImport<'a> {
+    engine: &'a Engine,
+    ty: types::ComponentInstance,
+}
+
+impl<'a> CoordinationScriptInstanceImport<'a> {
+    /// Iterate over coordination scripts exported by this [ContractInstanceImport].
+    pub fn coordination_scripts<'b: 'a>(
+        &'b self,
+    ) -> impl Iterator<Item = wasmtime::Result<CoordinationScriptImport<'b>>> {
+        self.ty.exports(self.engine).filter_map(
+            |(
+                name,
+                types::ComponentExtern {
+                    ty, external_id, ..
+                },
+            )| {
+                let types::ComponentItem::ComponentFunc(ty) = ty else {
+                    return None;
+                };
+                if let Some(external_id) = external_id {
+                    Some(Ok(CoordinationScriptImport {
+                        name,
+                        external_id,
+                        ty,
+                    }))
+                } else {
+                    Some(Err(format_err!(
+                        "`external-id` missing for coordination script import `{name}`"
+                    )))
+                }
+            },
+        )
+    }
+}
+
+/// Lookup a `starstream:contract` instance import.
+#[instrument(level = "trace", skip_all)]
+pub fn get_coordination_script_instance_import<'a>(
+    engine: &'a Engine,
+    ty: &types::Component,
+) -> Option<CoordinationScriptInstanceImport<'a>> {
+    let types::ComponentExtern { ty, .. } = ty.get_import(engine, "starstream:contract/scripts")?;
+    let types::ComponentItem::ComponentInstance(ty) = ty else {
+        return None;
+    };
+    Some(CoordinationScriptInstanceImport { engine, ty })
 }
 
 pub trait ContractLookup<T> {
@@ -82,28 +180,6 @@ pub trait Host: bindings::starstream::std::cardano::Host + Send + Sized + 'stati
         name: &Arc<str>,
         params: &[Val],
     ) -> wasmtime::Result<()>;
-}
-
-pub fn componentize(wasm: impl AsRef<[u8]>) -> anyhow::Result<Vec<u8>> {
-    use anyhow::Context as _;
-
-    wit_component::ComponentEncoder::default()
-        .validate(true)
-        .module(wasm.as_ref())
-        .context("failed to set core component module")?
-        .encode()
-        .context("failed to encode a component")
-}
-
-#[instrument(level = "trace", skip_all)]
-fn load_component(engine: &Engine, wasm: impl AsRef<[u8]>) -> wasmtime::Result<Component> {
-    let wasm = wasm.as_ref();
-    if wasmparser::Parser::is_core_wasm(wasm) {
-        let wasm = componentize(wasm).map_err(wasmtime::Error::from_anyhow)?;
-        Component::from_binary(engine, &wasm)
-    } else {
-        Component::from_binary(engine, wasm)
-    }
 }
 
 enum ContractImportTarget<'a, T: 'static> {
@@ -816,33 +892,25 @@ fn lookup_get_storage_export(
 impl<T: Host> Contract<T> {
     /// Compile and pre-instantiate a Starstream [Contract]
     #[instrument(level = "trace", skip_all)]
-    pub fn new(
-        engine: &Engine,
-        contracts: impl ContractLookup<T>,
-        wasm: impl AsRef<[u8]>,
-    ) -> wasmtime::Result<Self> {
-        let wasm = wasm.as_ref();
-
-        debug!("loading component");
-        let component = load_component(engine, wasm)?;
+    pub fn new(component: &Component, contracts: impl ContractLookup<T>) -> wasmtime::Result<Self> {
         let contract = Arc::default();
 
-        let mut linker = Linker::new(engine);
+        let mut linker = Linker::new(component.engine());
 
         debug!("linking component imports");
         bindings::Host_::add_to_linker::<_, HasSelf<_>>(&mut linker, |cx| cx)
             .context("failed to link generated bindings")?;
         link_builtin(&mut linker).context("failed to link `starstream:std/builtin`")?;
         link_utxo_context(&mut linker).context("failed to link `starstream:std/utxo-context`")?;
-        link_imports(&contract, &component, &mut linker, &contracts)?;
+        link_imports(&contract, component, &mut linker, &contracts)?;
 
         let ty = linker
-            .substituted_component_type(&component)
+            .substituted_component_type(component)
             .context("failed to derive component type")?;
 
         debug!("pre-instantiating component");
         let pre = linker
-            .instantiate_pre(&component)
+            .instantiate_pre(component)
             .context("failed to pre-instantiate component")?;
 
         let this = Self { pre, ty };

--- a/starstream-runtime-next/tests/common/mod.rs
+++ b/starstream-runtime-next/tests/common/mod.rs
@@ -1,27 +1,46 @@
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use sha2::{Digest as _, Sha256};
-use starstream_compiler::{TypecheckOptions, parse_program, typecheck_program};
+use starstream_compiler::typecheck::TypecheckSuccess;
+use starstream_compiler::{TypecheckFailure, TypecheckOptions, parse_program, typecheck_program};
 use starstream_runtime_next::{Contract, ContractLookup, Host, Utxo, bindings};
-use starstream_to_wasm::compile;
+use starstream_to_wasm::CompileResult;
 use tracing::instrument;
-use wasmtime::component::{Resource, ResourceTable, Val};
-use wasmtime::{AsContextMut as _, StoreContextMut, bail};
+use wasmtime::component::{Component, Resource, ResourceTable, Val};
+use wasmtime::error::Context as _;
+use wasmtime::{AsContextMut as _, StoreContextMut, bail, ensure, format_err};
+use wit_component::ComponentEncoder;
 
-pub fn compile_contract(source: &str) -> Vec<u8> {
-    let (program, errors) = parse_program(source).into_output_errors();
-    assert!(errors.is_empty(), "parsing failed: {errors:?}");
-    let program = program.expect("parser produced no program");
-    let typed = typecheck_program(&program, TypecheckOptions::default())
-        .unwrap_or_else(|failure| panic!("typechecking failed: {:?}", failure.errors));
-    let result = compile(&typed.program);
-    assert!(
-        result.errors.is_empty(),
-        "compiling failed: {:?}",
-        result.errors
-    );
-    result.wasm.expect("compiling produced no Wasm")
+pub static ENGINE: LazyLock<wasmtime::Engine> = LazyLock::new(|| {
+    let mut config = wasmtime::Config::default();
+    let config = config.wasm_component_model_implements(true);
+    wasmtime::Engine::new(config).expect("failed to construct engine")
+});
+
+pub fn compile_contract(source: &str) -> wasmtime::Result<Component> {
+    let (program, errs) = parse_program(source).into_output_errors();
+    ensure!(errs.is_empty(), "failed to parse program: {errs:?}");
+    let program = program.context("parser did not produce a program")?;
+
+    let TypecheckSuccess { program, .. } = typecheck_program(&program, TypecheckOptions::default())
+        .map_err(|TypecheckFailure { errors, .. }| {
+            format_err!("failed to typecheck program: {:?}", errors)
+        })?;
+
+    let CompileResult { errors, wasm, .. } = starstream_to_wasm::compile(&program);
+    ensure!(errors.is_empty(), "failed to compile program: {errors:?}");
+
+    let wasm = wasm.context("compilation did not produce Wasm")?;
+    let wasm = ComponentEncoder::default()
+        .validate(true)
+        .module(&wasm)
+        .map_err(wasmtime::error::Error::from_anyhow)
+        .context("failed to set core component module")?
+        .encode()
+        .map_err(wasmtime::error::Error::from_anyhow)
+        .context("failed to encode a component")?;
+    Component::from_binary(&ENGINE, &wasm).context("failed to compile component")
 }
 
 pub fn method_hash(name: &str) -> (u64, u64, u64, u64) {

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -5,17 +5,19 @@ use std::sync::{Arc, LazyLock, Mutex};
 
 use starstream_runtime_next::{
     Contract, CoordinationScriptExport, Host, MethodExport, StorageExport, Utxo, UtxoExport,
-    UtxoMainExport,
+    UtxoMainExport, get_coordination_script_instance_import, utxo_imports,
 };
 use tracing::{Instrument as _, info_span, instrument};
-use wasmtime::component::{Resource, ResourceTable, Val};
+use wasmtime::component::{Component, Resource, ResourceTable, Val};
 use wasmtime::error::Context as _;
 use wasmtime::{Store, bail};
 
-use crate::common::{Ctx, Event, NoopContractLookup, UtxoCtx, compile_contract, method_hash};
+use crate::common::{
+    Ctx, ENGINE, Event, NoopContractLookup, UtxoCtx, compile_contract, method_hash,
+};
 
-static CONTRACT: LazyLock<Vec<u8>> =
-    LazyLock::new(|| compile_contract(include_str!("../../examples/score.star")));
+static CONTRACT: LazyLock<Component> =
+    LazyLock::new(|| compile_contract(include_str!("../../examples/score.star")).unwrap());
 
 /// The methods of the `Score` ABI, in declaration (and `yield`) order.
 static METHODS: LazyLock<[(u64, u64, u64, u64); 4]> =
@@ -365,16 +367,15 @@ async fn assert_call_finish(
 
 #[test_log::test(tokio::test)]
 async fn score_main_new() -> wasmtime::Result<()> {
-    let engine = wasmtime::Engine::default();
-    let contract = Contract::new(&engine, NoopContractLookup, CONTRACT.as_slice())
-        .context("failed to create contract")?;
+    let contract =
+        Contract::new(&CONTRACT, NoopContractLookup).context("failed to create contract")?;
     let ty = assert_progress_utxo(&contract)?;
 
     let mut table = ResourceTable::default();
     let utxo_cx = Arc::new(Mutex::new(UtxoCtx::default()));
     let utxo_cx_res = table.push(Arc::clone(&utxo_cx))?;
     let mut store = wasmtime::Store::new(
-        &engine,
+        &ENGINE,
         Ctx {
             table,
             events: Vec::default(),
@@ -549,13 +550,16 @@ async fn score_main_new() -> wasmtime::Result<()> {
 
 #[test_log::test(tokio::test)]
 async fn score_script_example() -> wasmtime::Result<()> {
-    let engine = wasmtime::Engine::default();
-    let contract = Contract::new(&engine, NoopContractLookup, CONTRACT.as_slice())
-        .context("failed to create contract")?;
+    let ty = CONTRACT.component_type();
+    assert!(get_coordination_script_instance_import(&ENGINE, &ty).is_none());
+    assert!(utxo_imports(&ENGINE, &ty).next().is_none());
+
+    let contract =
+        Contract::new(&CONTRACT, NoopContractLookup).context("failed to create contract")?;
     let ty = assert_progress_utxo(&contract)?;
 
     let mut store = wasmtime::Store::new(
-        &engine,
+        &ENGINE,
         Ctx {
             table: ResourceTable::default(),
             events: Vec::default(),

--- a/starstream-runtime-next/tests/token_mint_burn.rs
+++ b/starstream-runtime-next/tests/token_mint_burn.rs
@@ -3,18 +3,22 @@ pub mod common;
 use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
-use starstream_runtime_next::{Contract, Host, StorageExport, Token, TokenFunctionExport};
+use starstream_runtime_next::{
+    Contract, Host, StorageExport, Token, TokenFunctionExport,
+    get_coordination_script_instance_import, utxo_imports,
+};
 use tracing::{Instrument as _, info_span};
-use wasmtime::component::{ResourceTable, Val};
+use wasmtime::component::{Component, ResourceTable, Val};
 use wasmtime::error::Context as _;
 use wasmtime::{Store, bail};
 
-use crate::common::{Ctx, NoopContractLookup, compile_contract};
+use crate::common::{Ctx, ENGINE, NoopContractLookup, compile_contract};
 
-static CONTRACT: LazyLock<Vec<u8>> = LazyLock::new(|| {
+static CONTRACT: LazyLock<Component> = LazyLock::new(|| {
     compile_contract(include_str!(
         "../../starstream-to-wasm/tests/inputs/token_mint_burn.star"
     ))
+    .unwrap()
 });
 
 struct MyToken {
@@ -93,13 +97,16 @@ async fn get_my_token_storage(
 
 #[test_log::test(tokio::test)]
 async fn token_mint_burn() -> wasmtime::Result<()> {
-    let engine = wasmtime::Engine::default();
-    let contract = Contract::new(&engine, NoopContractLookup, CONTRACT.as_slice())
-        .context("failed to create contract")?;
+    let ty = CONTRACT.component_type();
+    assert!(get_coordination_script_instance_import(&ENGINE, &ty).is_none());
+    assert!(utxo_imports(&ENGINE, &ty).next().is_none());
+
+    let contract =
+        Contract::new(&CONTRACT, NoopContractLookup).context("failed to create contract")?;
     let ty = assert_my_token(&contract)?;
 
     let mut store = Store::new(
-        &engine,
+        &ENGINE,
         Ctx {
             table: ResourceTable::default(),
             events: Vec::default(),


### PR DESCRIPTION
Add API to the runtime to allow contract import lookups on a compiled component and use this new functionality in the ledger to minimize lock contention.