### PR TITLE
ledger: add `/rpc` endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 2.0.106",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1746,7 +1746,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2306,6 +2306,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128-tokio"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e94e2f8143ae63a07c670a27f2fc42a333293c249566f8d4cd6609689656bb"
+dependencies = [
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,7 +2520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -3117,6 +3128,16 @@ dependencies = [
  "arrayvec 0.5.2",
  "typed-arena",
  "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3931,10 +3952,15 @@ dependencies = [
  "starstream-to-wasm",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-util",
  "tracing",
+ "wasm-tokio",
  "wasmtime",
  "wasmtime-wizer",
+ "wit-bindgen-wrpc",
  "wit-component 0.254.0",
+ "wrpc-http",
+ "wrpc-transport",
 ]
 
 [[package]]
@@ -4330,6 +4356,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4549,10 +4586,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
+name = "utf8-tokio"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692aa1d5479fe22dac6ce581e8c6e83a9f8d90238250c1036b0139019a783a87"
+dependencies = [
+ "tokio",
+ "tokio-util",
+]
 
 [[package]]
 name = "utf8parse"
@@ -4612,6 +4665,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
 
 [[package]]
 name = "wasip2"
@@ -4742,6 +4804,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-tokio"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89e5174a1312bd31d081a1dd6db8e48e2dc680b2988aba43befabb8459ea999"
+dependencies = [
+ "leb128-tokio",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "utf8-tokio",
+]
+
+[[package]]
 name = "wasm-wave"
 version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4751,6 +4826,17 @@ dependencies = [
  "logos",
  "thiserror 2.0.17",
  "wit-parser 0.258.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
+dependencies = [
+ "bitflags 2.9.4",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -5327,6 +5413,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
+name = "wit-bindgen-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4738d1c9a78e97bc7f664bfafd5d8e67d7bb26faa5c41e6d628e8bbdad3ec351"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser 0.251.0",
+]
+
+[[package]]
+name = "wit-bindgen-wrpc"
+version = "0.11.0"
+source = "git+https://github.com/bytecodealliance/wrpc?rev=68d2a8e0c306cfa960dc840fd8207bf8a1ec7270#68d2a8e0c306cfa960dc840fd8207bf8a1ec7270"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.4",
+ "bytes",
+ "futures",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "wasm-tokio",
+ "wit-bindgen-wrpc-rust-macro",
+ "wrpc-transport",
+]
+
+[[package]]
+name = "wit-bindgen-wrpc-rust"
+version = "0.11.0"
+source = "git+https://github.com/bytecodealliance/wrpc?rev=68d2a8e0c306cfa960dc840fd8207bf8a1ec7270#68d2a8e0c306cfa960dc840fd8207bf8a1ec7270"
+dependencies = [
+ "anyhow",
+ "heck",
+ "prettyplease",
+ "syn 2.0.106",
+ "wit-bindgen-core",
+ "wrpc-introspect",
+]
+
+[[package]]
+name = "wit-bindgen-wrpc-rust-macro"
+version = "0.11.0"
+source = "git+https://github.com/bytecodealliance/wrpc?rev=68d2a8e0c306cfa960dc840fd8207bf8a1ec7270#68d2a8e0c306cfa960dc840fd8207bf8a1ec7270"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wit-bindgen-core",
+ "wit-bindgen-wrpc-rust",
+]
+
+[[package]]
 name = "wit-component"
 version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5366,6 +5507,25 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.251.0",
+]
+
+[[package]]
+name = "wit-parser"
 version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1655131e4f7d3f0cb141f6eca71315ca40eff0f3d4de7cff0a82bacedd8c89b4"
@@ -5400,6 +5560,50 @@ dependencies = [
  "serde_json",
  "unicode-ident",
  "wasmparser 0.258.0",
+]
+
+[[package]]
+name = "wrpc-http"
+version = "0.1.0"
+source = "git+https://github.com/bytecodealliance/wrpc?rev=68d2a8e0c306cfa960dc840fd8207bf8a1ec7270#68d2a8e0c306cfa960dc840fd8207bf8a1ec7270"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "wrpc-transport",
+]
+
+[[package]]
+name = "wrpc-introspect"
+version = "0.7.0"
+source = "git+https://github.com/bytecodealliance/wrpc?rev=68d2a8e0c306cfa960dc840fd8207bf8a1ec7270#68d2a8e0c306cfa960dc840fd8207bf8a1ec7270"
+dependencies = [
+ "wit-parser 0.251.0",
+]
+
+[[package]]
+name = "wrpc-transport"
+version = "0.29.0"
+source = "git+https://github.com/bytecodealliance/wrpc?rev=68d2a8e0c306cfa960dc840fd8207bf8a1ec7270#68d2a8e0c306cfa960dc840fd8207bf8a1ec7270"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "wasi 0.14.7+wasi-0.2.4",
+ "wasm-tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,18 +67,23 @@ tempfile = { version = "3.27", default-features = false }
 test-log = { version = "0.2.18", default-features = false }
 thiserror = "2.0.17"
 tokio = { version = "1.47.1", default-features = false }
+tokio-util = { version = "0.7", default-features = false }
 tower-lsp-server = { version = "0.22.1", default-features = false, features = [
   "runtime-agnostic",
 ] }
 tracing = { version = "0.1.44", default-features = false }
 tracing-subscriber = { version = "0.3.23", default-features = false }
 wasm-encoder = "0.254.0"
+wasm-tokio = { version = "0.6", default-features = false }
 wasmprinter = "0.254.0"
 wasmparser = "0.254.0"
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "56cce8cfef552f458c2044187ad2ba1512e3e2df", default-features = false }
 wasmtime-wizer = { git = "https://github.com/bytecodealliance/wasmtime", rev = "56cce8cfef552f458c2044187ad2ba1512e3e2df", default-features = false }
+wit-bindgen-wrpc = { git = "https://github.com/bytecodealliance/wrpc", rev = "68d2a8e0c306cfa960dc840fd8207bf8a1ec7270", default-features = false }
 wit-component = "0.254.0"
 wit-parser = "0.254.0"
+wrpc-http = { git = "https://github.com/bytecodealliance/wrpc", rev = "68d2a8e0c306cfa960dc840fd8207bf8a1ec7270", default-features = false }
+wrpc-transport = { git = "https://github.com/bytecodealliance/wrpc", rev = "68d2a8e0c306cfa960dc840fd8207bf8a1ec7270", default-features = false }
 zeroize = { version = "1.8.2", default-features = false }
 
 neo-fold-clean = { git = "https://github.com/LFDT-Nightstream/Nightstream.git", rev = "675f2ce9d9b05553d518c7ccb36abe2eddbad048" }

--- a/starstream-ledger-cli/src/main.rs
+++ b/starstream-ledger-cli/src/main.rs
@@ -6,6 +6,7 @@ use anyhow::Context as _;
 use clap::{Parser, Subcommand};
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use http::Uri;
+use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
 use rand_core::OsRng;
 use sha2::{Digest as _, Sha256};
@@ -139,8 +140,10 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let http = hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build_http();
-    let client = ClientBuilder::new(http, url).network(network).build();
+    let http = hyper_util::client::legacy::Client::builder(TokioExecutor::new());
+    let client = ClientBuilder::new(http, HttpConnector::new(), url)
+        .network(network)
+        .build();
     match command {
         Command::Account(AccountCommand::Fund {
             signing: SigningArgs { key, nonce },

--- a/starstream-ledger-cli/src/main.rs
+++ b/starstream-ledger-cli/src/main.rs
@@ -43,6 +43,10 @@ enum Command {
     #[command(subcommand)]
     Account(AccountCommand),
 
+    /// Query ledger blocks.
+    #[command(subcommand)]
+    Block(BlockCommand),
+
     /// Manage published contracts.
     #[command(subcommand)]
     Contract(ContractCommand),
@@ -78,6 +82,12 @@ enum AccountCommand {
         /// Amount to credit the account with.
         amount: u64,
     },
+}
+
+#[derive(Debug, Subcommand)]
+enum BlockCommand {
+    /// Get the height of the latest ledger block.
+    Height,
 }
 
 #[derive(Debug, Subcommand)]
@@ -152,6 +162,13 @@ async fn main() -> anyhow::Result<()> {
         }) => {
             let key = read_signing_key(&key).await?;
             client.fund(key, nonce, &account, amount).await
+        }
+        Command::Block(BlockCommand::Height) => {
+            let height = client.block_height().await?;
+            stdout()
+                .write_all(height.to_string().as_bytes())
+                .await
+                .context("failed to write height to stdout")
         }
         Command::Contract(ContractCommand::Digest { wasm }) => {
             let wasm = fs::read(&wasm)

--- a/starstream-ledger-cli/tests/cli.rs
+++ b/starstream-ledger-cli/tests/cli.rs
@@ -113,6 +113,9 @@ async fn cli() -> anyhow::Result<()> {
         build_publish_envelope(account.clone(), NETWORK, 1, SCORE_WASM.as_slice())?;
     let publish_cost = publish_envelope.len();
 
+    let stdout = run_cli(["--url", &format!("http://{addr}"), "block", "height"]).await?;
+    assert_eq!(stdout, b"0");
+
     let stdout = run_cli([
         "--url",
         &format!("http://{addr}"),
@@ -145,6 +148,9 @@ async fn cli() -> anyhow::Result<()> {
     ])
     .await?;
     assert_eq!(stdout, b"");
+
+    let stdout = run_cli(["--url", &format!("http://{addr}"), "block", "height"]).await?;
+    assert_eq!(stdout, b"2");
 
     shutdown.notify_one();
     ledger.await.context("ledger task panicked")

--- a/starstream-ledger/Cargo.toml
+++ b/starstream-ledger/Cargo.toml
@@ -9,7 +9,12 @@ license.workspace = true
 
 [features]
 default = ["client", "server"]
-client = ["hyper-util/client", "hyper-util/client-legacy"]
+client = [
+    "dep:wit-bindgen-wrpc",
+    "hyper-util/client",
+    "hyper-util/client-legacy",
+    "wrpc-http/client-legacy",
+]
 server = [
     "dep:headers-accept",
     "dep:headers-core",
@@ -18,6 +23,8 @@ server = [
     "dep:hyper",
     "dep:starstream-runtime-next",
     "dep:tokio",
+    "dep:tokio-util",
+    "dep:wasm-tokio",
     "dep:wasmtime",
     "dep:wasmtime-wizer",
     "hyper-util/server",
@@ -52,7 +59,9 @@ tokio = { workspace = true, optional = true, features = [
     "sync",
     "time",
 ] }
+tokio-util = { workspace = true, optional = true, features = ["codec"] }
 tracing = { workspace = true, features = ["attributes"] }
+wasm-tokio = { workspace = true, optional = true }
 wasmtime = { workspace = true, optional = true, features = [
     "anyhow",
     "async",
@@ -63,6 +72,9 @@ wasmtime-wizer = { workspace = true, optional = true, features = [
     "component-model",
     "wasmtime",
 ] }
+wit-bindgen-wrpc = { workspace = true, optional = true }
+wrpc-http = { workspace = true }
+wrpc-transport = { workspace = true }
 
 [dev-dependencies]
 starstream-compiler = { workspace = true }

--- a/starstream-ledger/src/client/http.rs
+++ b/starstream-ledger/src/client/http.rs
@@ -5,11 +5,12 @@ use ed25519_dalek::{Signature, SigningKey, VerifyingKey};
 use http::header::{ACCEPT, CONTENT_TYPE};
 use http::{Method, Request, Uri};
 use http_body_util::{BodyExt as _, Full};
+use hyper_util::client::legacy::connect::Connect;
 use mediatype::MediaType;
 use sha2::{Digest as _, Sha256};
 use tracing::{instrument, warn};
 
-use crate::client::{build_fund_envelope, build_publish_envelope};
+use crate::client::{bindings, build_fund_envelope, build_publish_envelope};
 use crate::{APPLICATION_COSE, APPLICATION_WASM, PUBLISH_CONTEXT, encode_digest};
 
 /// Default network used by the client
@@ -83,20 +84,23 @@ pub fn build_contract_get_request(
     req.body(Full::default()).context("failed to build request")
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ClientBuilder<C> {
-    http: hyper_util::client::legacy::Client<C, Full<Bytes>>,
+    http: hyper_util::client::legacy::Builder,
+    connect: C,
     api_base: Uri,
     network: Box<str>,
 }
 
 impl<C> ClientBuilder<C> {
     pub fn new(
-        http: hyper_util::client::legacy::Client<C, Full<Bytes>>,
+        http: hyper_util::client::legacy::Builder,
+        connect: C,
         api_base: impl Into<Uri>,
     ) -> Self {
         Self {
             http,
+            connect,
             api_base: api_base.into(),
             network: DEFAULT_NETWORK.into(),
         }
@@ -107,26 +111,37 @@ impl<C> ClientBuilder<C> {
         self
     }
 
-    pub fn build(self) -> Client<C> {
+    pub fn build(self) -> Client<C>
+    where
+        C: Connect + Clone + Send + Sync + 'static,
+    {
         self.into()
     }
 }
 
 pub struct Client<C> {
+    wrpc: wrpc_http::Client<hyper_util::client::legacy::Client<C, wrpc_http::OutgoingBody>>,
     http: hyper_util::client::legacy::Client<C, Full<Bytes>>,
     api_base: Uri,
     network: Box<str>,
 }
 
-impl<C> From<ClientBuilder<C>> for Client<C> {
+impl<C> From<ClientBuilder<C>> for Client<C>
+where
+    C: Connect + Clone + Send + Sync + 'static,
+{
     fn from(
         ClientBuilder {
             http,
+            connect,
             api_base,
             network,
         }: ClientBuilder<C>,
     ) -> Self {
+        let wrpc = wrpc_http::Client::new(http.build(connect.clone()));
+        let http = http.build(connect.clone());
         Self {
+            wrpc,
             http,
             api_base,
             network,
@@ -134,18 +149,22 @@ impl<C> From<ClientBuilder<C>> for Client<C> {
     }
 }
 
-impl<C> Client<C> {
+impl<C> Client<C>
+where
+    C: Connect + Clone + Send + Sync + 'static,
+{
     pub fn new(
-        http: hyper_util::client::legacy::Client<C, Full<Bytes>>,
+        http: hyper_util::client::legacy::Builder,
+        connect: C,
         api_base: impl Into<Uri>,
     ) -> Self {
-        ClientBuilder::new(http, api_base).build()
+        ClientBuilder::new(http, connect, api_base).build()
     }
 }
 
 impl<C> Client<C>
 where
-    C: hyper_util::client::legacy::connect::Connect + Clone + Send + Sync + 'static,
+    C: Connect + Clone + Send + Sync + 'static,
 {
     #[instrument(skip_all)]
     async fn request(
@@ -163,6 +182,18 @@ where
             .await
             .context("failed to receive response body")?;
         Ok((parts, body.to_bytes()))
+    }
+
+    /// Get the height of the latest ledger block.
+    #[instrument(skip_all)]
+    pub async fn block_height(&self) -> anyhow::Result<u64> {
+        let uri = endpoint_uri(&self.api_base, "rpc")?;
+        let (cx, ()) = Request::builder()
+            .uri(uri)
+            .body(())
+            .context("failed to build request")?
+            .into_parts();
+        bindings::starstream::ledger::block::height(&self.wrpc, cx).await
     }
 
     #[instrument(skip_all)]

--- a/starstream-ledger/src/client/mod.rs
+++ b/starstream-ledger/src/client/mod.rs
@@ -8,6 +8,11 @@ use crate::{FUND_CONTEXT, PUBLISH_CONTEXT};
 
 pub mod http;
 
+/// Ledger wRPC bindings.
+pub mod bindings {
+    wit_bindgen_wrpc::generate!();
+}
+
 /// Build a signed envelope.
 fn build_envelope(key: SigningKey, payload: impl Into<Vec<u8>>) -> anyhow::Result<Vec<u8>> {
     let protected = coset::HeaderBuilder::new()

--- a/starstream-ledger/src/server/http/error.rs
+++ b/starstream-ledger/src/server/http/error.rs
@@ -200,6 +200,36 @@ impl AccountFundError {
     }
 }
 
+#[derive(Debug, Error)]
+pub enum RpcPostError {
+    #[error("failed to read wRPC invocation header: {0}")]
+    Header(wrpc_transport::frame::HeaderReadError),
+    #[error("instance `{0}` not found")]
+    InstanceNotFound(String),
+    #[error("function `{name}` not found in instance `{instance}`")]
+    FunctionNotFound { instance: String, name: String },
+    #[error("failed to encode result: {0}")]
+    ResultEncoding(std::io::Error),
+    #[error("failed to encode response frame: {0}")]
+    FrameEncoding(std::io::Error),
+    #[error(transparent)]
+    Http(http::Error),
+}
+
+impl RpcPostError {
+    pub fn http_status_code(&self) -> http::StatusCode {
+        match self {
+            Self::Header(..) => http::StatusCode::BAD_REQUEST,
+            Self::InstanceNotFound(..) | Self::FunctionNotFound { .. } => {
+                http::StatusCode::NOT_FOUND
+            }
+            Self::ResultEncoding(..) | Self::FrameEncoding(..) | Self::Http(..) => {
+                http::StatusCode::INTERNAL_SERVER_ERROR
+            }
+        }
+    }
+}
+
 fn format_media_types(available: &[MediaType<'_>]) -> String {
     available
         .iter()

--- a/starstream-ledger/src/server/http/mod.rs
+++ b/starstream-ledger/src/server/http/mod.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, hash_map};
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use bytes::{Buf, Bytes};
+use bytes::{Buf, Bytes, BytesMut};
 use coset::{CborSerializable as _, CoseSign1, TaggedCborSerializable as _, iana};
 use ed25519_dalek::{Signature, VerifyingKey};
 use headers_accept::Accept;
@@ -30,7 +30,9 @@ use tokio::net::TcpSocket;
 use tokio::sync::{Notify, TryAcquireError};
 use tokio::task::JoinSet;
 use tokio::time::sleep;
+use tokio_util::codec::Encoder as _;
 use tracing::{Instrument as _, debug, error, info, instrument, warn};
+use wasm_tokio::cm::U64Codec;
 use wasmtime::component::Component;
 
 use crate::server::lookup::ContractLookup;
@@ -41,6 +43,11 @@ use crate::{
 
 mod error;
 use error::*;
+
+const APPLICATION_OCTET_STREAM: MediaType = MediaType::new(
+    mediatype::names::APPLICATION,
+    mediatype::names::OCTET_STREAM,
+);
 
 const MAX_CONTRACT_PUT_BODY_SIZE: u64 = 1 << 20;
 const MAX_FUND_POST_BODY_SIZE: u64 = 1 << 10;
@@ -492,6 +499,47 @@ impl Ledger {
         build_text_response(http::StatusCode::OK, "").map_err(AccountFundError::Http)
     }
 
+    async fn handle_rpc_post(
+        &self,
+        body: hyper::body::Incoming,
+    ) -> Result<http::Response<http_body_util::Full<Bytes>>, RpcPostError> {
+        let mut body = wrpc_http::data_reader_from_incoming(body);
+        let wrpc_transport::frame::Header { instance, name } =
+            wrpc_transport::frame::Header::read(&mut body)
+                .await
+                .map_err(RpcPostError::Header)?;
+        let mut data = BytesMut::new();
+        match instance.as_str() {
+            "starstream:ledger/block" => match name.as_str() {
+                "height" => {
+                    let height = self.blocks.read().await.len();
+                    let height = u64::try_from(height)
+                        .map_err(|err| RpcPostError::ResultEncoding(std::io::Error::other(err)))?;
+                    U64Codec
+                        .encode(height, &mut data)
+                        .map_err(RpcPostError::ResultEncoding)?;
+                }
+                _ => return Err(RpcPostError::FunctionNotFound { instance, name }),
+            },
+            _ => return Err(RpcPostError::InstanceNotFound(instance)),
+        }
+        let mut buf = BytesMut::with_capacity(data.len().saturating_add(1 + 10));
+        wrpc_transport::FrameEncoder
+            .encode(
+                wrpc_transport::FrameRef {
+                    path: &[],
+                    data: &data,
+                },
+                &mut buf,
+            )
+            .map_err(RpcPostError::FrameEncoding)?;
+        http::Response::builder()
+            .header(CONTENT_TYPE, APPLICATION_OCTET_STREAM.to_string())
+            .header(X_CONTENT_TYPE_OPTIONS, "nosniff")
+            .body(http_body_util::Full::new(buf.freeze()))
+            .map_err(RpcPostError::Http)
+    }
+
     /// Bind `address` and return the future serving the ledger HTTP API.
     ///
     /// Calling [`Notify::notify_one`] on the returned handle shuts the server
@@ -595,6 +643,14 @@ impl Ledger {
                         Err(err) => build_text_response(err.http_status_code(), err.to_string()),
                     },
                     (_, Some("fund"), None, ..) => {
+                        build_method_not_allowed("POST", &method, pq.path())
+                    }
+
+                    ("POST", Some("rpc"), None, ..) => match ledger.handle_rpc_post(body).await {
+                        Ok(res) => Ok(res),
+                        Err(err) => build_text_response(err.http_status_code(), err.to_string()),
+                    },
+                    (_, Some("rpc"), None, ..) => {
                         build_method_not_allowed("POST", &method, pq.path())
                     }
 

--- a/starstream-ledger/tests/ledger.rs
+++ b/starstream-ledger/tests/ledger.rs
@@ -96,11 +96,15 @@ async fn http() -> anyhow::Result<()> {
         .context("failed to handle HTTP")?;
     let ledger = tokio::spawn(ledger);
 
-    let http = hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build_http();
+    let http = hyper_util::client::legacy::Client::builder(TokioExecutor::new());
     let api_base = Uri::from_str(&format!("http://{addr}"))?;
-    let client = ClientBuilder::new(http.clone(), api_base.clone())
+    let client = ClientBuilder::new(http.clone(), HttpConnector::new(), api_base.clone())
         .network(NETWORK)
         .build();
+    let http = http.build_http();
+
+    let height = client.block_height().await?;
+    assert_eq!(height, 0);
 
     let score_publish_envelope =
         build_publish_envelope(ADMIN.clone(), NETWORK, 1, SCORE_WASM.as_slice())?;
@@ -152,6 +156,9 @@ async fn http() -> anyhow::Result<()> {
     client
         .fund(ADMIN.clone(), 1, &ADMIN.verifying_key(), balance as _)
         .await?;
+
+    let height = client.block_height().await?;
+    assert_eq!(height, 1);
 
     let req = build_fund_request(
         &api_base,
@@ -221,6 +228,9 @@ async fn http() -> anyhow::Result<()> {
         headers.get(X_CONTENT_TYPE_OPTIONS).map(|v| v.as_bytes()),
         Some(b"nosniff".as_slice())
     );
+
+    let height = client.block_height().await?;
+    assert_eq!(height, 3);
 
     shutdown.notify_one();
     ledger.await.context("ledger task panicked")

--- a/starstream-ledger/wit/ledger.wit
+++ b/starstream-ledger/wit/ledger.wit
@@ -1,0 +1,9 @@
+package starstream:ledger;
+
+interface block {
+    height: func() -> u64;
+}
+
+world client {
+    import block;
+}


### PR DESCRIPTION
Add `/rpc` endpoint to the ledger.

For now the only endpoint is `starstream:ledger/block#height`, which returns the block height

Blocked on #223 (which I hope will get merged soon) because of the unfortunate merge conflict due to import updates. That's the only reason this one is in draft.