### PR TITLE
ledger: add coordination script invocation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3935,6 +3935,7 @@ dependencies = [
  "ciborium",
  "coset",
  "ed25519-dalek",
+ "futures",
  "headers-accept",
  "headers-core",
  "hex",
@@ -3968,6 +3969,7 @@ name = "starstream-ledger-cli"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "clap",
  "ed25519-dalek",
  "hex",
@@ -3980,10 +3982,14 @@ dependencies = [
  "starstream-to-wasm",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "wasm-wave",
  "wasmtime",
  "wit-component 0.254.0",
+ "wit-parser 0.258.0",
+ "wrpc-wave",
  "zeroize",
 ]
 
@@ -5604,6 +5610,21 @@ dependencies = [
  "tracing",
  "wasi 0.14.7+wasi-0.2.4",
  "wasm-tokio",
+]
+
+[[package]]
+name = "wrpc-wave"
+version = "0.1.0"
+source = "git+https://github.com/bytecodealliance/wrpc?rev=68d2a8e0c306cfa960dc840fd8207bf8a1ec7270#68d2a8e0c306cfa960dc840fd8207bf8a1ec7270"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "wasm-tokio",
+ "wasm-wave",
+ "wrpc-transport",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ ciborium = { version = "0.2", default-features = false }
 clap = { version = "4.6.1", default-features = false }
 coset = { version = "0.3", default-features = false }
 ed25519-dalek = { version = "2", default-features = false }
+futures = { version = "0.3", default-features = false }
 headers-accept = { version = "0.3", default-features = false }
 headers-core = { version = "0.3", default-features = false }
 hex = { version = "0.4.3", default-features = false }
@@ -75,6 +76,7 @@ tracing = { version = "0.1.44", default-features = false }
 tracing-subscriber = { version = "0.3.23", default-features = false }
 wasm-encoder = "0.254.0"
 wasm-tokio = { version = "0.6", default-features = false }
+wasm-wave = { version = "0.258.0", default-features = false }
 wasmprinter = "0.254.0"
 wasmparser = "0.254.0"
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "56cce8cfef552f458c2044187ad2ba1512e3e2df", default-features = false }
@@ -84,6 +86,7 @@ wit-component = "0.254.0"
 wit-parser = "0.254.0"
 wrpc-http = { git = "https://github.com/bytecodealliance/wrpc", rev = "68d2a8e0c306cfa960dc840fd8207bf8a1ec7270", default-features = false }
 wrpc-transport = { git = "https://github.com/bytecodealliance/wrpc", rev = "68d2a8e0c306cfa960dc840fd8207bf8a1ec7270", default-features = false }
+wrpc-wave = { git = "https://github.com/bytecodealliance/wrpc", rev = "68d2a8e0c306cfa960dc840fd8207bf8a1ec7270", default-features = false }
 zeroize = { version = "1.8.2", default-features = false }
 
 neo-fold-clean = { git = "https://github.com/LFDT-Nightstream/Nightstream.git", rev = "675f2ce9d9b05553d518c7ccb36abe2eddbad048" }

--- a/starstream-ledger-cli/Cargo.toml
+++ b/starstream-ledger-cli/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
+bytes = { workspace = true }
 clap = { workspace = true, features = [
     "color",
     "derive",
@@ -37,6 +38,7 @@ tokio = { workspace = true, features = [
     "macros",
     "rt-multi-thread",
 ] }
+tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = [
     "ansi",
@@ -45,6 +47,11 @@ tracing-subscriber = { workspace = true, features = [
     "smallvec",
     "tracing-log",
 ] }
+wasm-wave = { workspace = true, features = ["wit"] }
+wit-parser = { version = "0.258.0", default-features = false, features = [
+    "decoding",
+] }
+wrpc-wave = { workspace = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]
@@ -53,5 +60,5 @@ starstream-ledger = { workspace = true, features = ["server"] }
 starstream-to-wasm = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs", "net", "process"] }
-wit-component = { workspace = true }
 wasmtime = { workspace = true }
+wit-component = { workspace = true }

--- a/starstream-ledger-cli/src/main.rs
+++ b/starstream-ledger-cli/src/main.rs
@@ -1,8 +1,12 @@
 //! Starstream ledger client.
 
+use core::iter::zip;
+use core::pin::pin;
+
 use std::path::{Path, PathBuf};
 
-use anyhow::Context as _;
+use anyhow::{Context as _, bail, ensure};
+use bytes::BytesMut;
 use clap::{Parser, Subcommand};
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use http::Uri;
@@ -11,10 +15,12 @@ use hyper_util::rt::TokioExecutor;
 use rand_core::OsRng;
 use sha2::{Digest as _, Sha256};
 use starstream_ledger::client::http::ClientBuilder;
-use starstream_ledger::encode_digest;
+use starstream_ledger::{encode_digest, parse_digest};
 use tokio::fs;
 use tokio::io::{AsyncWriteExt as _, stdout};
+use tokio_util::codec::Encoder as _;
 use tracing::info;
+use wasm_wave::wasm::WasmFunc as _;
 use zeroize::Zeroizing;
 
 #[derive(Debug, Parser)]
@@ -106,6 +112,25 @@ enum ContractCommand {
         /// Path to the contract.
         wasm: PathBuf,
     },
+    /// Interact with contract coordination scripts.
+    #[command(subcommand)]
+    Script(ScriptCommand),
+}
+
+#[derive(Debug, Subcommand)]
+enum ScriptCommand {
+    /// Call a coordination script exported by a published contract.
+    Call {
+        /// Digest of the published contract.
+        #[arg(value_parser = parse_digest)]
+        digest: [u8; 32],
+
+        /// Script to call.
+        script: Box<str>,
+
+        /// WAVE-encoded script arguments.
+        args: Vec<Box<str>>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -189,6 +214,65 @@ async fn main() -> anyhow::Result<()> {
                 .await
                 .with_context(|| format!("failed to read `{}`", wasm.display()))?;
             client.publish_contract(key, nonce, wasm).await
+        }
+        Command::Contract(ContractCommand::Script(ScriptCommand::Call {
+            digest,
+            script,
+            args,
+        })) => {
+            let wasm = client.get_contract_wasm(&digest).await?;
+            let wasm =
+                wit_parser::decoding::decode(&wasm).context("failed to decode contract Wasm")?;
+            let wit_parser::decoding::DecodedWasm::Component(resolve, world) = wasm else {
+                bail!("contract is not a component")
+            };
+            let world = &resolve.worlds[world];
+            let ty = world
+                .exports
+                .iter()
+                .find_map(|(name, item)| {
+                    let wit_parser::WorldKey::Name(name) = name else {
+                        return None;
+                    };
+                    let wit_parser::WorldItem::Function(ty) = item else {
+                        return None;
+                    };
+                    if *name == *script { Some(ty) } else { None }
+                })
+                .with_context(|| format!("coordination script `{script}` not found"))?;
+            let ty = wasm_wave::value::resolve_wit_func_type(&resolve, ty)
+                .context("failed to resolve coordination script function type")?;
+
+            let params_ty = zip(ty.param_names(), ty.params());
+            let mut args = args.into_iter();
+            let mut buf = BytesMut::new();
+            for (name, ty) in params_ty {
+                let v = args
+                    .next()
+                    .with_context(|| format!("missing value for parameter `{name}`"))?;
+                let v = wasm_wave::from_str::<wasm_wave::value::Value>(&ty, &v)
+                    .with_context(|| format!("failed to parse value for parameter `{name}`"))?;
+                wrpc_wave::WaveEncoder::new(&ty)
+                    .encode(&v, &mut buf)
+                    .with_context(|| format!("failed to encode value of parameter `{name}`"))?;
+            }
+            ensure!(args.next().is_none(), "trailing arguments");
+
+            let rx = client
+                .call_coordination_script(&digest, &script, buf.freeze())
+                .await?;
+            let mut rx = pin!(rx);
+
+            if let Some(ty) = wasm_wave::value::Type::tuple(ty.results().collect::<Box<_>>()) {
+                let v = wrpc_wave::read_value(&mut rx, &ty)
+                    .await
+                    .context("failed to read result tuple")?;
+                let s = wasm_wave::to_string(&v).context("failed to encode result tuple")?;
+                stdout().write_all(s.as_bytes()).await
+            } else {
+                stdout().write_all(b"()").await
+            }
+            .context("failed to write result tuple to stdout")
         }
         Command::Key(KeyCommand::Generate) => {
             let key = SigningKey::generate(&mut OsRng);

--- a/starstream-ledger-cli/tests/cli.rs
+++ b/starstream-ledger-cli/tests/cli.rs
@@ -152,6 +152,21 @@ async fn cli() -> anyhow::Result<()> {
     let stdout = run_cli(["--url", &format!("http://{addr}"), "block", "height"]).await?;
     assert_eq!(stdout, b"2");
 
+    let digest = run_cli(["contract", "digest", &wasm.path().to_string_lossy()]).await?;
+    let digest = str::from_utf8(&digest).context("contract digest is not valid UTF-8")?;
+
+    let stdout = run_cli([
+        "--url",
+        &format!("http://{addr}"),
+        "contract",
+        "script",
+        "call",
+        digest,
+        "example",
+    ])
+    .await?;
+    assert_eq!(stdout, b"()");
+
     shutdown.notify_one();
     ledger.await.context("ledger task panicked")
 }

--- a/starstream-ledger/Cargo.toml
+++ b/starstream-ledger/Cargo.toml
@@ -16,6 +16,7 @@ client = [
     "wrpc-http/client-legacy",
 ]
 server = [
+    "dep:futures",
     "dep:headers-accept",
     "dep:headers-core",
     "dep:hex",
@@ -23,7 +24,6 @@ server = [
     "dep:hyper",
     "dep:starstream-runtime-next",
     "dep:tokio",
-    "dep:tokio-util",
     "dep:wasm-tokio",
     "dep:wasmtime",
     "dep:wasmtime-wizer",
@@ -39,6 +39,7 @@ bytes = { workspace = true }
 ciborium = { workspace = true, features = ["std"] }
 coset = { workspace = true, features = ["std"] }
 ed25519-dalek = { workspace = true, features = ["fast", "std", "zeroize"] }
+futures = { workspace = true, optional = true }
 headers-accept = { workspace = true, optional = true }
 headers-core = { workspace = true, optional = true }
 hex = { workspace = true, optional = true, features = ["std"] }
@@ -59,7 +60,7 @@ tokio = { workspace = true, optional = true, features = [
     "sync",
     "time",
 ] }
-tokio-util = { workspace = true, optional = true, features = ["codec"] }
+tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true, features = ["attributes"] }
 wasm-tokio = { workspace = true, optional = true }
 wasmtime = { workspace = true, optional = true, features = [

--- a/starstream-ledger/src/client/http.rs
+++ b/starstream-ledger/src/client/http.rs
@@ -9,8 +9,9 @@ use hyper_util::client::legacy::connect::Connect;
 use mediatype::MediaType;
 use sha2::{Digest as _, Sha256};
 use tracing::{instrument, warn};
+use wrpc_transport::{Invoke as _, InvokeExt as _, TupleDecode, TupleEncode};
 
-use crate::client::{bindings, build_fund_envelope, build_publish_envelope};
+use crate::client::{bindings, build_fund_envelope, build_publish_envelope, contract_instance};
 use crate::{APPLICATION_COSE, APPLICATION_WASM, PUBLISH_CONTEXT, encode_digest};
 
 /// Default network used by the client
@@ -25,6 +26,16 @@ fn endpoint_uri(base: &Uri, endpoint: impl AsRef<str>) -> anyhow::Result<String>
     let base = base.to_string();
     let base = base.trim_end_matches('/');
     Ok(format!("{base}/{endpoint}"))
+}
+
+fn wrpc_context(base: &Uri) -> anyhow::Result<http::request::Parts> {
+    let uri = endpoint_uri(base, "rpc")?;
+    let req = Request::builder()
+        .uri(uri)
+        .body(())
+        .context("failed to build request")?;
+    let (cx, ()) = req.into_parts();
+    Ok(cx)
 }
 
 /// Build a signed fund request.
@@ -160,12 +171,54 @@ where
     ) -> Self {
         ClientBuilder::new(http, connect, api_base).build()
     }
-}
 
-impl<C> Client<C>
-where
-    C: Connect + Clone + Send + Sync + 'static,
-{
+    /// Get the height of the latest ledger block.
+    #[instrument(skip_all)]
+    pub async fn block_height(&self) -> anyhow::Result<u64> {
+        let cx = wrpc_context(&self.api_base)?;
+        bindings::starstream::ledger::block::height(&self.wrpc, cx).await
+    }
+
+    /// Call the coordination script `name` exported by the contract
+    /// identified by `digest` with encoded `args`.
+    #[instrument(skip_all)]
+    pub async fn call_coordination_script(
+        &self,
+        digest: &[u8; 32],
+        name: &str,
+        args: Bytes,
+    ) -> anyhow::Result<wrpc_transport::frame::Incoming> {
+        let cx = wrpc_context(&self.api_base)?;
+        let instance = contract_instance(digest);
+        let (tx, rx) = self.wrpc.invoke(cx, &instance, name, args, [[]]).await?;
+        drop(tx);
+        Ok(rx)
+    }
+
+    /// Call the coordination script `name` exported by the contract
+    /// identified by `digest` with typed `args`.
+    #[instrument(skip_all)]
+    pub async fn call_coordination_script_typed<Params, Results>(
+        &self,
+        digest: &[u8; 32],
+        name: &str,
+        args: Params,
+    ) -> anyhow::Result<Results>
+    where
+        Params: TupleEncode + Send,
+        Results: TupleDecode + Send,
+        <Params::Encoder as tokio_util::codec::Encoder<Params>>::Error:
+            std::error::Error + Send + Sync + 'static,
+        <Results::Decoder as tokio_util::codec::Decoder>::Error:
+            std::error::Error + Send + Sync + 'static,
+    {
+        let cx = wrpc_context(&self.api_base)?;
+        let instance = contract_instance(digest);
+        self.wrpc
+            .invoke_values_blocking(cx, &instance, name, args, [[]])
+            .await
+    }
+
     #[instrument(skip_all)]
     async fn request(
         &self,
@@ -182,18 +235,6 @@ where
             .await
             .context("failed to receive response body")?;
         Ok((parts, body.to_bytes()))
-    }
-
-    /// Get the height of the latest ledger block.
-    #[instrument(skip_all)]
-    pub async fn block_height(&self) -> anyhow::Result<u64> {
-        let uri = endpoint_uri(&self.api_base, "rpc")?;
-        let (cx, ()) = Request::builder()
-            .uri(uri)
-            .body(())
-            .context("failed to build request")?
-            .into_parts();
-        bindings::starstream::ledger::block::height(&self.wrpc, cx).await
     }
 
     #[instrument(skip_all)]

--- a/starstream-ledger/src/client/mod.rs
+++ b/starstream-ledger/src/client/mod.rs
@@ -4,13 +4,19 @@ use anyhow::Context as _;
 use coset::{TaggedCborSerializable as _, iana};
 use ed25519_dalek::{Signer as _, SigningKey, VerifyingKey};
 
-use crate::{FUND_CONTEXT, PUBLISH_CONTEXT};
+use crate::wrpc::CONTRACT_PACKAGE;
+use crate::{FUND_CONTEXT, PUBLISH_CONTEXT, encode_digest};
 
 pub mod http;
 
 /// Ledger wRPC bindings.
 pub mod bindings {
     wit_bindgen_wrpc::generate!();
+}
+
+/// The wRPC instance name of the contract identified by `digest`.
+fn contract_instance(digest: &[u8; 32]) -> String {
+    format!("{CONTRACT_PACKAGE}/{}", encode_digest(digest))
 }
 
 /// Build a signed envelope.

--- a/starstream-ledger/src/lib.rs
+++ b/starstream-ledger/src/lib.rs
@@ -9,6 +9,8 @@ pub mod client;
 #[cfg(feature = "server")]
 pub mod server;
 
+pub mod wrpc;
+
 /// The domain-separation context every publish transaction must carry as its
 /// first element, binding the signature to this protocol.
 pub const PUBLISH_CONTEXT: &str = "starstream:publish";

--- a/starstream-ledger/src/server/host.rs
+++ b/starstream-ledger/src/server/host.rs
@@ -4,11 +4,10 @@ use std::sync::Arc;
 
 use starstream_runtime_next::Utxo;
 use starstream_runtime_next::bindings::starstream;
-use wasmtime::StoreContextMut;
-use wasmtime::bail;
 use wasmtime::component::{Resource, ResourceTable, Val};
+use wasmtime::{AsContextMut as _, StoreContextMut, bail, format_err};
 
-use crate::server::Ctx;
+use crate::server::{Ctx, UtxoCtx};
 
 impl starstream::std::cardano::Host for Ctx {
     fn block_height(&mut self) -> wasmtime::Result<i64> {
@@ -21,7 +20,7 @@ impl starstream::std::cardano::Host for Ctx {
 }
 
 impl starstream_runtime_next::Host for Ctx {
-    type UtxoContext = ();
+    type UtxoContext = Arc<std::sync::Mutex<UtxoCtx>>;
     type Token = ();
 
     fn table(&mut self) -> &mut ResourceTable {
@@ -29,52 +28,69 @@ impl starstream_runtime_next::Host for Ctx {
     }
 
     async fn call_utxo_main(
-        _store: StoreContextMut<'_, Self>,
-        _f: impl for<'a> FnOnce(
+        mut store: StoreContextMut<'_, Self>,
+        f: impl for<'a> FnOnce(
             StoreContextMut<'a, Self>,
             Self::UtxoContext,
         ) -> Pin<
             Box<dyn Future<Output = wasmtime::Result<Utxo<Self::UtxoContext>>> + Send + 'a>,
         > + Send,
     ) -> wasmtime::Result<Utxo<Self::UtxoContext>> {
-        bail!("TODO")
+        let utxo = f(store.as_context_mut(), Self::UtxoContext::default()).await?;
+        store.as_context_mut().data_mut().outputs.push(utxo.clone());
+        Ok(utxo)
     }
 
     fn has_method(
-        _store: StoreContextMut<Self>,
-        _utxo: Resource<Utxo<Self::UtxoContext>>,
-        _hash: (u64, u64, u64, u64),
+        store: StoreContextMut<Self>,
+        utxo: Resource<Utxo<Self::UtxoContext>>,
+        hash: (u64, u64, u64, u64),
     ) -> wasmtime::Result<bool> {
-        bail!("TODO")
+        let Ctx { table, .. } = store.data();
+        let utxo = table.get(&utxo)?;
+        let cx = utxo.context().lock().map_err(|err| format_err!("{err}"))?;
+        Ok(cx.methods.contains(&hash))
     }
 
     fn drop_utxo(
-        _store: StoreContextMut<Self>,
-        _utxo: Resource<Utxo<Self::UtxoContext>>,
+        mut store: StoreContextMut<Self>,
+        utxo: Resource<Utxo<Self::UtxoContext>>,
     ) -> wasmtime::Result<()> {
-        bail!("TODO")
+        let Ctx { table, .. } = store.data_mut();
+        table.delete(utxo)?;
+        Ok(())
     }
 
     fn implements_method(
-        _store: StoreContextMut<Self>,
-        _cx: Resource<Self::UtxoContext>,
-        __hash: (u64, u64, u64, u64),
+        mut store: StoreContextMut<Self>,
+        cx: Resource<Self::UtxoContext>,
+        hash: (u64, u64, u64, u64),
     ) -> wasmtime::Result<()> {
-        bail!("TODO")
+        let Ctx { table, .. } = store.data_mut();
+        let cx = table.get_mut(&cx)?;
+        let mut cx = cx.lock().map_err(|err| format_err!("{err}"))?;
+        cx.methods.push(hash);
+        Ok(())
     }
 
     fn resume(
-        _store: StoreContextMut<Self>,
-        _cx: Resource<Self::UtxoContext>,
+        mut store: StoreContextMut<Self>,
+        cx: Resource<Self::UtxoContext>,
     ) -> wasmtime::Result<()> {
-        bail!("TODO")
+        let Ctx { table, .. } = store.data_mut();
+        let cx = table.get_mut(&cx)?;
+        let mut cx = cx.lock().map_err(|err| format_err!("{err}"))?;
+        cx.methods.clear();
+        Ok(())
     }
 
     fn drop_utxo_context(
-        _store: StoreContextMut<Self>,
-        _cx: Resource<Self::UtxoContext>,
+        mut store: StoreContextMut<Self>,
+        cx: Resource<Self::UtxoContext>,
     ) -> wasmtime::Result<()> {
-        bail!("TODO")
+        let Ctx { table, .. } = store.data_mut();
+        table.delete(cx)?;
+        Ok(())
     }
 
     fn drop_token(

--- a/starstream-ledger/src/server/http/error.rs
+++ b/starstream-ledger/src/server/http/error.rs
@@ -4,8 +4,7 @@ use ed25519_dalek::VerifyingKey;
 use mediatype::MediaType;
 use thiserror::Error;
 
-use crate::server::http::APPLICATION_COSE;
-use crate::{DigestParseError, FUND_CONTEXT, PUBLISH_CONTEXT, encode_digest};
+use crate::{APPLICATION_COSE, DigestParseError, FUND_CONTEXT, PUBLISH_CONTEXT, encode_digest};
 
 #[derive(Debug, Error)]
 pub enum ContractGetError {
@@ -208,8 +207,18 @@ pub enum RpcPostError {
     InstanceNotFound(String),
     #[error("function `{name}` not found in instance `{instance}`")]
     FunctionNotFound { instance: String, name: String },
+    #[error("failed to parse contract digest: {0}")]
+    ContractDigestParsing(DigestParseError),
+    #[error("contract not found")]
+    ContractNotFound,
+    #[error("failed to decode parameters: {0}")]
+    ParameterDecoding(std::io::Error),
+    #[error("runtime failed: {0:#}")]
+    Runtime(wasmtime::Error),
     #[error("failed to encode result: {0}")]
     ResultEncoding(std::io::Error),
+    #[error("failed to encode call result: {0:#}")]
+    CallResultEncoding(wasmtime::Error),
     #[error("failed to encode response frame: {0}")]
     FrameEncoding(std::io::Error),
     #[error(transparent)]
@@ -219,13 +228,17 @@ pub enum RpcPostError {
 impl RpcPostError {
     pub fn http_status_code(&self) -> http::StatusCode {
         match self {
-            Self::Header(..) => http::StatusCode::BAD_REQUEST,
-            Self::InstanceNotFound(..) | Self::FunctionNotFound { .. } => {
+            Self::Header(..) | Self::ContractDigestParsing(..) | Self::ParameterDecoding(..) => {
+                http::StatusCode::BAD_REQUEST
+            }
+            Self::InstanceNotFound(..) | Self::FunctionNotFound { .. } | Self::ContractNotFound => {
                 http::StatusCode::NOT_FOUND
             }
-            Self::ResultEncoding(..) | Self::FrameEncoding(..) | Self::Http(..) => {
-                http::StatusCode::INTERNAL_SERVER_ERROR
-            }
+            Self::Runtime(..)
+            | Self::ResultEncoding(..)
+            | Self::CallResultEncoding(..)
+            | Self::FrameEncoding(..)
+            | Self::Http(..) => http::StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/starstream-ledger/src/server/http/mod.rs
+++ b/starstream-ledger/src/server/http/mod.rs
@@ -1,4 +1,6 @@
 use core::future::poll_fn;
+use core::iter::zip;
+use core::mem;
 use core::net::SocketAddr;
 use core::pin::pin;
 use core::sync::atomic::{AtomicU64, Ordering};
@@ -12,6 +14,7 @@ use anyhow::Context as _;
 use bytes::{Buf, Bytes, BytesMut};
 use coset::{CborSerializable as _, CoseSign1, TaggedCborSerializable as _, iana};
 use ed25519_dalek::{Signature, VerifyingKey};
+use futures::{StreamExt as _, TryStreamExt as _};
 use headers_accept::Accept;
 use headers_core::Header as _;
 use http::HeaderValue;
@@ -30,13 +33,17 @@ use tokio::net::TcpSocket;
 use tokio::sync::{Notify, TryAcquireError};
 use tokio::task::JoinSet;
 use tokio::time::sleep;
-use tokio_util::codec::Encoder as _;
+use tokio_util::codec::{Encoder as _, FramedRead};
+use tokio_util::io::StreamReader;
 use tracing::{Instrument as _, debug, error, info, instrument, warn};
 use wasm_tokio::cm::U64Codec;
-use wasmtime::component::Component;
+use wasmtime::component::{Component, Val};
+use wrpc_transport::FrameDecoder;
 
 use crate::server::lookup::ContractLookup;
-use crate::server::{Contract, Ledger};
+use crate::server::wrpc::{ValEncoder, read_value};
+use crate::server::{Contract, Ctx, Ledger};
+use crate::wrpc::{CONTRACT_PACKAGE, LEDGER_PACKAGE};
 use crate::{
     APPLICATION_COSE, APPLICATION_WASM, Action, Block, FUND_CONTEXT, PUBLISH_CONTEXT, parse_digest,
 };
@@ -509,8 +516,8 @@ impl Ledger {
                 .await
                 .map_err(RpcPostError::Header)?;
         let mut data = BytesMut::new();
-        match instance.as_str() {
-            "starstream:ledger/block" => match name.as_str() {
+        match instance.split_once('/') {
+            Some((LEDGER_PACKAGE, "block")) => match name.as_str() {
                 "height" => {
                     let height = self.blocks.read().await.len();
                     let height = u64::try_from(height)
@@ -521,6 +528,54 @@ impl Ledger {
                 }
                 _ => return Err(RpcPostError::FunctionNotFound { instance, name }),
             },
+            Some((CONTRACT_PACKAGE, digest)) => {
+                let digest = parse_digest(digest).map_err(RpcPostError::ContractDigestParsing)?;
+                let contract = {
+                    let contracts = self.contracts.read().await;
+                    let contract = contracts
+                        .get(&digest)
+                        .ok_or(RpcPostError::ContractNotFound)?;
+                    Arc::clone(contract)
+                };
+                let Some(export) = contract.scripts.get(name.as_str()) else {
+                    return Err(RpcPostError::FunctionNotFound { instance, name });
+                };
+
+                let param_tys = export.ty().params();
+                let mut params = vec![Val::Bool(false); param_tys.len()];
+                let body = FramedRead::new(body, FrameDecoder::default()).map(|frame| {
+                    let wrpc_transport::Frame { path, data } = frame?;
+                    anyhow::ensure!(path.is_empty(), "async values not supported");
+                    Ok(data)
+                });
+                let mut body = StreamReader::new(body.map_err(std::io::Error::other));
+                for (v, (_, ty)) in zip(&mut params, param_tys) {
+                    read_value(&mut body, v, &ty)
+                        .await
+                        .map_err(RpcPostError::ParameterDecoding)?;
+                }
+
+                let result_tys = export.ty().results();
+                let mut results = vec![Val::Bool(false); result_tys.len()];
+                let mut store = wasmtime::Store::new(&self.engine, Ctx::default());
+                let contract = contract
+                    .instantiate(&mut store)
+                    .await
+                    .map_err(RpcPostError::Runtime)?;
+                contract
+                    .call_coordination_script(&mut store, export, &params, &mut results)
+                    .await
+                    .map_err(RpcPostError::Runtime)?;
+                for (v, ty) in zip(results, result_tys) {
+                    ValEncoder::new(&ty)
+                        .encode(&v, &mut data)
+                        .map_err(RpcPostError::CallResultEncoding)?;
+                }
+                let Ctx { outputs, .. } = store.data_mut();
+                for utxo in mem::take(outputs) {
+                    let _cx = utxo.drop(&mut store).await.map_err(RpcPostError::Runtime)?;
+                }
+            }
             _ => return Err(RpcPostError::InstanceNotFound(instance)),
         }
         let mut buf = BytesMut::with_capacity(data.len().saturating_add(1 + 10));

--- a/starstream-ledger/src/server/mod.rs
+++ b/starstream-ledger/src/server/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use ed25519_dalek::VerifyingKey;
-use starstream_runtime_next::{CoordinationScriptExport, UtxoExport};
+use starstream_runtime_next::{CoordinationScriptExport, Utxo, UtxoExport};
 use tokio::sync::{RwLock, Semaphore};
 use wasmtime::component::ResourceTable;
 use wasmtime_wizer::Wizer;
@@ -18,6 +18,7 @@ use crate::Block;
 mod host;
 mod http;
 mod lookup;
+mod wrpc;
 
 /// The ledger-side state of a publishing account, identified by its Ed25519
 /// public key.
@@ -40,15 +41,21 @@ struct AdminAccount {
     last_nonce: AtomicU64,
 }
 
+#[derive(Debug, Default)]
 struct Ctx {
     table: ResourceTable,
+    outputs: Vec<Utxo<<Self as starstream_runtime_next::Host>::UtxoContext>>,
+}
+
+#[derive(Debug, Default)]
+struct UtxoCtx {
+    methods: Vec<(u64, u64, u64, u64)>,
 }
 
 struct Contract {
     contract: starstream_runtime_next::Contract<Ctx>,
     #[expect(unused, reason = "TODO")]
     contract_wasm: Bytes,
-    #[expect(unused, reason = "TODO")]
     scripts: HashMap<Box<str>, CoordinationScriptExport>,
     #[expect(unused, reason = "TODO")]
     utxos: HashMap<Box<str>, UtxoExport>,

--- a/starstream-ledger/src/server/wrpc.rs
+++ b/starstream-ledger/src/server/wrpc.rs
@@ -1,0 +1,561 @@
+//! The wRPC value codec over [`wasmtime::component::Val`], used for the
+//! parameters and results of `/rpc` invocations.
+
+use core::iter::zip;
+use core::ops::{BitOrAssign, Shl};
+
+use std::collections::HashSet;
+
+use bytes::{BufMut as _, BytesMut};
+use tokio::io::{AsyncRead, AsyncReadExt as _};
+use tokio_util::codec::Encoder;
+use wasm_tokio::cm::AsyncReadValue as _;
+use wasm_tokio::{
+    AsyncReadCore as _, AsyncReadLeb128 as _, AsyncReadUtf8 as _, CoreNameEncoder, Leb128Encoder,
+    Utf8Codec,
+};
+use wasmtime::bail;
+use wasmtime::component::types::{Case, Field};
+use wasmtime::component::{Type, Val};
+use wasmtime::error::Context as _;
+
+/// [`Encoder`] writing a [`Val`] of a given [`Type`] in the wRPC value
+/// encoding.
+pub struct ValEncoder<'a> {
+    pub ty: &'a Type,
+}
+
+impl<'a> ValEncoder<'a> {
+    #[must_use]
+    pub fn new(ty: &'a Type) -> Self {
+        Self { ty }
+    }
+}
+
+fn find_enum_discriminant<'a, T>(
+    iter: impl IntoIterator<Item = T>,
+    names: impl IntoIterator<Item = &'a str>,
+    discriminant: &str,
+) -> wasmtime::Result<T> {
+    zip(iter, names)
+        .find_map(|(i, name)| (name == discriminant).then_some(i))
+        .context("unknown enum discriminant")
+}
+
+fn find_variant_discriminant<'a, T>(
+    iter: impl IntoIterator<Item = T>,
+    cases: impl IntoIterator<Item = Case<'a>>,
+    discriminant: &str,
+) -> wasmtime::Result<(T, Option<Type>)> {
+    zip(iter, cases)
+        .find_map(|(i, Case { name, ty })| (name == discriminant).then_some((i, ty)))
+        .context("unknown variant discriminant")
+}
+
+#[inline]
+fn flag_bits<'a, T: BitOrAssign + Shl<u8, Output = T> + From<u8>>(
+    names: impl IntoIterator<Item = &'a str>,
+    flags: impl IntoIterator<Item = &'a str>,
+) -> T {
+    let mut v = T::from(0);
+    let flags: HashSet<&str> = flags.into_iter().collect();
+    for (i, name) in zip(0u8.., names) {
+        if flags.contains(name) {
+            v |= T::from(1) << i;
+        }
+    }
+    v
+}
+
+impl Encoder<&Val> for ValEncoder<'_> {
+    type Error = wasmtime::Error;
+
+    fn encode(&mut self, v: &Val, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        match (v, self.ty) {
+            (Val::Bool(v), Type::Bool) => {
+                dst.reserve(1);
+                dst.put_u8((*v).into());
+                Ok(())
+            }
+            (Val::S8(v), Type::S8) => {
+                dst.reserve(1);
+                dst.put_i8(*v);
+                Ok(())
+            }
+            (Val::U8(v), Type::U8) => {
+                dst.reserve(1);
+                dst.put_u8(*v);
+                Ok(())
+            }
+            (Val::S16(v), Type::S16) => Leb128Encoder
+                .encode(*v, dst)
+                .context("failed to encode s16"),
+            (Val::U16(v), Type::U16) => Leb128Encoder
+                .encode(*v, dst)
+                .context("failed to encode u16"),
+            (Val::S32(v), Type::S32) => Leb128Encoder
+                .encode(*v, dst)
+                .context("failed to encode s32"),
+            (Val::U32(v), Type::U32) => Leb128Encoder
+                .encode(*v, dst)
+                .context("failed to encode u32"),
+            (Val::S64(v), Type::S64) => Leb128Encoder
+                .encode(*v, dst)
+                .context("failed to encode s64"),
+            (Val::U64(v), Type::U64) => Leb128Encoder
+                .encode(*v, dst)
+                .context("failed to encode u64"),
+            (Val::Float32(v), Type::Float32) => {
+                dst.reserve(4);
+                dst.put_f32_le(*v);
+                Ok(())
+            }
+            (Val::Float64(v), Type::Float64) => {
+                dst.reserve(8);
+                dst.put_f64_le(*v);
+                Ok(())
+            }
+            (Val::Char(v), Type::Char) => {
+                Utf8Codec.encode(*v, dst).context("failed to encode char")
+            }
+            (Val::String(v), Type::String) => CoreNameEncoder
+                .encode(v.as_str(), dst)
+                .context("failed to encode string"),
+            (Val::List(vs), Type::List(ty)) => {
+                let ty = ty.ty();
+                let n = u32::try_from(vs.len()).context("list length does not fit in u32")?;
+                dst.reserve(5 + vs.len());
+                Leb128Encoder
+                    .encode(n, dst)
+                    .context("failed to encode list length")?;
+                for v in vs {
+                    ValEncoder::new(&ty)
+                        .encode(v, dst)
+                        .context("failed to encode list element")?;
+                }
+                Ok(())
+            }
+            (Val::Record(vs), Type::Record(ty)) => {
+                dst.reserve(vs.len());
+                for ((name, v), Field { ty, .. }) in zip(vs, ty.fields()) {
+                    ValEncoder::new(&ty)
+                        .encode(v, dst)
+                        .with_context(|| format!("failed to encode `{name}` field"))?;
+                }
+                Ok(())
+            }
+            (Val::Tuple(vs), Type::Tuple(ty)) => {
+                dst.reserve(vs.len());
+                for (v, ty) in zip(vs, ty.types()) {
+                    ValEncoder::new(&ty)
+                        .encode(v, dst)
+                        .context("failed to encode tuple element")?;
+                }
+                Ok(())
+            }
+            (Val::Variant(discriminant, v), Type::Variant(ty)) => {
+                let cases = ty.cases();
+                let ty = match u32::try_from(cases.len()) {
+                    Ok(..=0x0000_00ff) => {
+                        let (discriminant, ty) =
+                            find_variant_discriminant(0u8.., cases, discriminant)?;
+                        dst.reserve(2 + usize::from(v.is_some()));
+                        Leb128Encoder.encode(discriminant, dst)?;
+                        ty
+                    }
+                    Ok(0x0000_0100..=0x0000_ffff) => {
+                        let (discriminant, ty) =
+                            find_variant_discriminant(0u16.., cases, discriminant)?;
+                        dst.reserve(3 + usize::from(v.is_some()));
+                        Leb128Encoder.encode(discriminant, dst)?;
+                        ty
+                    }
+                    Ok(0x0001_0000..=0x00ff_ffff) => {
+                        let (discriminant, ty) =
+                            find_variant_discriminant(0u32.., cases, discriminant)?;
+                        dst.reserve(4 + usize::from(v.is_some()));
+                        Leb128Encoder.encode(discriminant, dst)?;
+                        ty
+                    }
+                    Ok(0x0100_0000..=0xffff_ffff) => {
+                        let (discriminant, ty) =
+                            find_variant_discriminant(0u32.., cases, discriminant)?;
+                        dst.reserve(5 + usize::from(v.is_some()));
+                        Leb128Encoder.encode(discriminant, dst)?;
+                        ty
+                    }
+                    Err(_) => bail!("case count does not fit in u32"),
+                };
+                if let Some(v) = v {
+                    let ty = ty.context("type missing for variant")?;
+                    ValEncoder::new(&ty)
+                        .encode(v, dst)
+                        .context("failed to encode variant value")?;
+                }
+                Ok(())
+            }
+            (Val::Enum(discriminant), Type::Enum(ty)) => {
+                let names = ty.names();
+                match u32::try_from(names.len()) {
+                    Ok(..=0x0000_00ff) => {
+                        let discriminant = find_enum_discriminant(0u8.., names, discriminant)?;
+                        dst.reserve(2);
+                        Leb128Encoder.encode(discriminant, dst)?;
+                    }
+                    Ok(0x0000_0100..=0x0000_ffff) => {
+                        let discriminant = find_enum_discriminant(0u16.., names, discriminant)?;
+                        dst.reserve(3);
+                        Leb128Encoder.encode(discriminant, dst)?;
+                    }
+                    Ok(0x0001_0000..=0x00ff_ffff) => {
+                        let discriminant = find_enum_discriminant(0u32.., names, discriminant)?;
+                        dst.reserve(4);
+                        Leb128Encoder.encode(discriminant, dst)?;
+                    }
+                    Ok(0x0100_0000..=0xffff_ffff) => {
+                        let discriminant = find_enum_discriminant(0u32.., names, discriminant)?;
+                        dst.reserve(5);
+                        Leb128Encoder.encode(discriminant, dst)?;
+                    }
+                    Err(_) => bail!("name count does not fit in u32"),
+                }
+                Ok(())
+            }
+            (Val::Option(None), Type::Option(_)) => {
+                dst.reserve(1);
+                dst.put_u8(0);
+                Ok(())
+            }
+            (Val::Option(Some(v)), Type::Option(ty)) => {
+                dst.reserve(2);
+                dst.put_u8(1);
+                let ty = ty.ty();
+                ValEncoder::new(&ty)
+                    .encode(v, dst)
+                    .context("failed to encode `option::some` value")
+            }
+            (Val::Result(v), Type::Result(ty)) => match v {
+                Ok(v) => match (v, ty.ok()) {
+                    (Some(v), Some(ty)) => {
+                        dst.reserve(2);
+                        dst.put_u8(0);
+                        ValEncoder::new(&ty)
+                            .encode(v, dst)
+                            .context("failed to encode `result::ok` value")
+                    }
+                    (Some(_), None) => bail!("`result::ok` value of unknown type"),
+                    (None, Some(_)) => bail!("`result::ok` value missing"),
+                    (None, None) => {
+                        dst.reserve(1);
+                        dst.put_u8(0);
+                        Ok(())
+                    }
+                },
+                Err(v) => match (v, ty.err()) {
+                    (Some(v), Some(ty)) => {
+                        dst.reserve(2);
+                        dst.put_u8(1);
+                        ValEncoder::new(&ty)
+                            .encode(v, dst)
+                            .context("failed to encode `result::err` value")
+                    }
+                    (Some(_), None) => bail!("`result::err` value of unknown type"),
+                    (None, Some(_)) => bail!("`result::err` value missing"),
+                    (None, None) => {
+                        dst.reserve(1);
+                        dst.put_u8(1);
+                        Ok(())
+                    }
+                },
+            },
+            (Val::Flags(vs), Type::Flags(ty)) => {
+                let names = ty.names();
+                let vs = vs.iter().map(String::as_str);
+                match names.len() {
+                    ..=8 => {
+                        dst.reserve(1);
+                        dst.put_u8(flag_bits(names, vs));
+                    }
+                    9..=16 => {
+                        dst.reserve(2);
+                        dst.put_u16_le(flag_bits(names, vs));
+                    }
+                    17..=24 => {
+                        dst.reserve(3);
+                        dst.put_slice(&u32::to_le_bytes(flag_bits(names, vs))[..3]);
+                    }
+                    25..=32 => {
+                        dst.reserve(4);
+                        dst.put_u32_le(flag_bits(names, vs));
+                    }
+                    33..=40 => {
+                        dst.reserve(5);
+                        dst.put_slice(&u64::to_le_bytes(flag_bits(names, vs))[..5]);
+                    }
+                    41..=48 => {
+                        dst.reserve(6);
+                        dst.put_slice(&u64::to_le_bytes(flag_bits(names, vs))[..6]);
+                    }
+                    49..=56 => {
+                        dst.reserve(7);
+                        dst.put_slice(&u64::to_le_bytes(flag_bits(names, vs))[..7]);
+                    }
+                    57..=64 => {
+                        dst.reserve(8);
+                        dst.put_u64_le(flag_bits(names, vs));
+                    }
+                    65..=72 => {
+                        dst.reserve(9);
+                        dst.put_slice(&u128::to_le_bytes(flag_bits(names, vs))[..9]);
+                    }
+                    73..=80 => {
+                        dst.reserve(10);
+                        dst.put_slice(&u128::to_le_bytes(flag_bits(names, vs))[..10]);
+                    }
+                    81..=88 => {
+                        dst.reserve(11);
+                        dst.put_slice(&u128::to_le_bytes(flag_bits(names, vs))[..11]);
+                    }
+                    89..=96 => {
+                        dst.reserve(12);
+                        dst.put_slice(&u128::to_le_bytes(flag_bits(names, vs))[..12]);
+                    }
+                    97..=104 => {
+                        dst.reserve(13);
+                        dst.put_slice(&u128::to_le_bytes(flag_bits(names, vs))[..13]);
+                    }
+                    105..=112 => {
+                        dst.reserve(14);
+                        dst.put_slice(&u128::to_le_bytes(flag_bits(names, vs))[..14]);
+                    }
+                    113..=120 => {
+                        dst.reserve(15);
+                        dst.put_slice(&u128::to_le_bytes(flag_bits(names, vs))[..15]);
+                    }
+                    121..=128 => {
+                        dst.reserve(16);
+                        dst.put_u128_le(flag_bits(names, vs));
+                    }
+                    bits @ 129.. => {
+                        let mut cap = bits / 8;
+                        if bits % 8 != 0 {
+                            cap = cap.saturating_add(1);
+                        }
+                        let mut buf = vec![0; cap];
+                        let flags: HashSet<&str> = vs.into_iter().collect();
+                        for (i, name) in names.enumerate() {
+                            if flags.contains(name) {
+                                buf[i / 8] |= 1 << (i % 8);
+                            }
+                        }
+                        dst.extend_from_slice(&buf);
+                    }
+                }
+                Ok(())
+            }
+            (_, Type::Map(..)) => bail!("encoding maps not supported by Starstream"),
+            (_, Type::Own(..) | Type::Borrow(..)) => {
+                bail!("encoding resources not supported by Starstream")
+            }
+            (_, Type::Future(..)) => bail!("encoding futures not supported by Starstream"),
+            (_, Type::Stream(..)) => bail!("encoding streams not supported by Starstream"),
+            (_, Type::ErrorContext) => bail!("encoding error contexts not supported by Starstream"),
+            (_, Type::FixedLengthList(..)) => {
+                bail!("encoding fixed length lists not supported by Starstream")
+            }
+            _ => bail!("value type mismatch"),
+        }
+    }
+}
+
+fn unsupported(msg: &'static str) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::Unsupported, msg)
+}
+
+/// Read a wRPC-encoded [`Val`] of type `ty` from `r` into `val`.
+#[allow(clippy::too_many_lines)]
+pub async fn read_value<R: AsyncRead + Unpin>(
+    r: &mut R,
+    val: &mut Val,
+    ty: &Type,
+) -> std::io::Result<()> {
+    match ty {
+        Type::Bool => {
+            *val = Val::Bool(r.read_bool().await?);
+            Ok(())
+        }
+        Type::S8 => {
+            *val = Val::S8(r.read_i8().await?);
+            Ok(())
+        }
+        Type::U8 => {
+            *val = Val::U8(r.read_u8().await?);
+            Ok(())
+        }
+        Type::S16 => {
+            *val = Val::S16(r.read_i16_leb128().await?);
+            Ok(())
+        }
+        Type::U16 => {
+            *val = Val::U16(r.read_u16_leb128().await?);
+            Ok(())
+        }
+        Type::S32 => {
+            *val = Val::S32(r.read_i32_leb128().await?);
+            Ok(())
+        }
+        Type::U32 => {
+            *val = Val::U32(r.read_u32_leb128().await?);
+            Ok(())
+        }
+        Type::S64 => {
+            *val = Val::S64(r.read_i64_leb128().await?);
+            Ok(())
+        }
+        Type::U64 => {
+            *val = Val::U64(r.read_u64_leb128().await?);
+            Ok(())
+        }
+        Type::Float32 => {
+            *val = Val::Float32(r.read_f32_le().await?);
+            Ok(())
+        }
+        Type::Float64 => {
+            *val = Val::Float64(r.read_f64_le().await?);
+            Ok(())
+        }
+        Type::Char => {
+            *val = Val::Char(r.read_char_utf8().await?);
+            Ok(())
+        }
+        Type::String => {
+            let mut s = String::default();
+            r.read_core_name(&mut s).await?;
+            *val = Val::String(s);
+            Ok(())
+        }
+        Type::List(ty) => {
+            let n = r.read_u32_leb128().await?;
+            let n = n.try_into().unwrap_or(usize::MAX);
+            let ty = ty.ty();
+            let mut vs = Vec::with_capacity(n);
+            for _ in 0..n {
+                let mut v = Val::Bool(false);
+                Box::pin(read_value(&mut *r, &mut v, &ty)).await?;
+                vs.push(v);
+            }
+            *val = Val::List(vs);
+            Ok(())
+        }
+        Type::Record(ty) => {
+            let fields = ty.fields();
+            let mut vs = Vec::with_capacity(fields.len());
+            for Field { name, ty } in fields {
+                let mut v = Val::Bool(false);
+                Box::pin(read_value(&mut *r, &mut v, &ty)).await?;
+                vs.push((name.to_string(), v));
+            }
+            *val = Val::Record(vs);
+            Ok(())
+        }
+        Type::Tuple(ty) => {
+            let types = ty.types();
+            let mut vs = Vec::with_capacity(types.len());
+            for ty in types {
+                let mut v = Val::Bool(false);
+                Box::pin(read_value(&mut *r, &mut v, &ty)).await?;
+                vs.push(v);
+            }
+            *val = Val::Tuple(vs);
+            Ok(())
+        }
+        Type::Variant(ty) => {
+            let discriminant = r.read_u32_leb128().await?;
+            let discriminant = discriminant
+                .try_into()
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+            let Case { name, ty } = ty.cases().nth(discriminant).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("unknown variant discriminant `{discriminant}`"),
+                )
+            })?;
+            let name = name.to_string();
+            if let Some(ty) = ty {
+                let mut v = Val::Bool(false);
+                Box::pin(read_value(&mut *r, &mut v, &ty)).await?;
+                *val = Val::Variant(name, Some(Box::new(v)));
+            } else {
+                *val = Val::Variant(name, None);
+            }
+            Ok(())
+        }
+        Type::Enum(ty) => {
+            let discriminant = r.read_u32_leb128().await?;
+            let discriminant = discriminant
+                .try_into()
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+            let name = ty.names().nth(discriminant).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("unknown enum discriminant `{discriminant}`"),
+                )
+            })?;
+            *val = Val::Enum(name.to_string());
+            Ok(())
+        }
+        Type::Option(ty) => {
+            if r.read_option_status().await? {
+                let mut v = Val::Bool(false);
+                Box::pin(read_value(&mut *r, &mut v, &ty.ty())).await?;
+                *val = Val::Option(Some(Box::new(v)));
+            } else {
+                *val = Val::Option(None);
+            }
+            Ok(())
+        }
+        Type::Result(ty) => {
+            if r.read_result_status().await? {
+                if let Some(ty) = ty.ok() {
+                    let mut v = Val::Bool(false);
+                    Box::pin(read_value(&mut *r, &mut v, &ty)).await?;
+                    *val = Val::Result(Ok(Some(Box::new(v))));
+                } else {
+                    *val = Val::Result(Ok(None));
+                }
+            } else if let Some(ty) = ty.err() {
+                let mut v = Val::Bool(false);
+                Box::pin(read_value(&mut *r, &mut v, &ty)).await?;
+                *val = Val::Result(Err(Some(Box::new(v))));
+            } else {
+                *val = Val::Result(Err(None));
+            }
+            Ok(())
+        }
+        Type::Flags(ty) => {
+            let names = ty.names();
+            let mut buf = vec![0u8; names.len().max(1).div_ceil(8)];
+            r.read_exact(&mut buf).await?;
+            let mut vs = Vec::new();
+            for (i, name) in names.enumerate() {
+                if buf[i / 8] & (1 << (i % 8)) != 0 {
+                    vs.push(name.to_string());
+                }
+            }
+            *val = Val::Flags(vs);
+            Ok(())
+        }
+        Type::Map(..) => Err(unsupported("decoding maps not supported by Starstream")),
+        Type::Own(..) | Type::Borrow(..) => Err(unsupported(
+            "decoding resources not supported by Starstream",
+        )),
+        Type::Future(..) => Err(unsupported("decoding futures not supported by Starstream")),
+        Type::Stream(..) => Err(unsupported("decoding streams not supported by Starstream")),
+        Type::ErrorContext => Err(unsupported(
+            "decoding error contexts not supported by Starstream",
+        )),
+        Type::FixedLengthList(..) => Err(unsupported(
+            "decoding fixed length lists not supported by Starstream",
+        )),
+    }
+}

--- a/starstream-ledger/src/wrpc.rs
+++ b/starstream-ledger/src/wrpc.rs
@@ -1,0 +1,7 @@
+//! Starstream ledger wRPC protocol definitions.
+
+/// The package name used for the ledger.
+pub const LEDGER_PACKAGE: &str = "starstream:ledger";
+
+/// The package name used for contracts.
+pub const CONTRACT_PACKAGE: &str = "starstream:contract";

--- a/starstream-ledger/tests/ledger.rs
+++ b/starstream-ledger/tests/ledger.rs
@@ -24,6 +24,7 @@ use starstream_ledger::client::http::{
 use starstream_ledger::encode_digest;
 use starstream_ledger::server::Ledger;
 use starstream_to_wasm::CompileResult;
+use tokio::io::AsyncReadExt as _;
 use tokio::net::TcpListener;
 use wit_component::ComponentEncoder;
 
@@ -231,6 +232,18 @@ async fn http() -> anyhow::Result<()> {
 
     let height = client.block_height().await?;
     assert_eq!(height, 3);
+
+    let mut rx = client
+        .call_coordination_script(&SCORE_WASM_DIGEST, "example", Bytes::default())
+        .await?;
+    let mut buf = [0];
+    let n = rx.read(&mut buf).await?;
+    assert_eq!(n, 0);
+    assert_eq!(buf, [0]);
+
+    () = client
+        .call_coordination_script_typed(&SCORE_WASM_DIGEST, "example", ())
+        .await?;
 
     shutdown.notify_one();
     ledger.await.context("ledger task panicked")

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -1735,9 +1735,9 @@ impl<T> Utxo<T> {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub async fn drop(self, mut store: impl AsContextMut<Data: Send>) -> wasmtime::Result<()> {
+    pub async fn drop(self, mut store: impl AsContextMut<Data: Send>) -> wasmtime::Result<T> {
         self.resource.resource_drop_async(&mut store).await?;
-        Ok(())
+        Ok(self.cx)
     }
 }
 


### PR DESCRIPTION
another PR in the series of ledger PRs

This one adds support for coordination script invocations.

I went back-and-forth on this, but eventually decided to serve the coordination scripts in `starstream:contract/<multibase-multihash>` instance for one simple reason: this makes names unique, which allows ledger's wRPC endpoints to be represented in WIT, which would not be true have we used e.g. an HTTP header.

For example, consider two contracts A and B, both exporting a script `foo`.
If the ledger serves `starstream:contract/scripts.foo`, we could use an HTTP header like `x-starstream-contract: <A_digest>` to select the right contract.

Client side WIT would look like:
```wit
interface scripts {
   @external-id("<A_digest>")
   foo: func();
}
```

however it's not clear what server WIT would like exactly in this situation, maybe something like this?

```wit
interface scripts {
   @external-id("<A_digest>;<B_digest>")
   foo: func();
}
```

It could work better once annotation feature lands, however currently WIT syntax seems insufficient to "unambigiously" represent this and we can always switch and/or add this additional interface support later.

I have also considered using something like `starstream:contract/scripts@0.0.0-<digest>`, but somehow that feels even worse.

This also made me realize that Starstream currently does not support importing coordination scripts with identical names from different contracts, since we use `external-id` to specify the script origin (https://github.com/LFDT-Nightstream/Starstream/blob/main/docs/wit-worlds.mdx#importing-coordination-scripts). In fact, the exact same issue arises with UTXO imports (https://github.com/LFDT-Nightstream/Starstream/blob/main/docs/wit-worlds.mdx#importing-utxos), e.g. we simply cannot import UTXO named `my-utxo` from two different contracts A and B. This may or may not be a concern on the contract side - it does feel less of an issue than for the ledger, but still something to consider. @SpaceManiac WDYT?

To try this out on CLI:

```sh
# terminal 1
$ starstream-ledger-node

# terminal 2
$ ./starstream wasm -c ./starstream-to-wasm/tests/inputs/add.star --output-component add.wasm
$ starstream-ledger-cli key generate > key   # public key is logged to stderr
$ printf admin | sha256sum | cut -d' ' -f1 > admin.key       # default node admin key
$ starstream-ledger-cli account fund --key ./admin.key --nonce 1 <public-key> 1000000
$ starstream-ledger-cli contract publish --key ./key --nonce 1 ./add.wasm
$ starstream-ledger-cli contract script call $(starstream-ledger-cli contract digest ./add.wasm) add 4 2
# (6)
```

Just like `./starstream run`, `starstream-ledger-cli contract script call` takes WAVE-encoded parameters on CLI and writes a WAVE-encoded result tuple to STDOUT on success

blocked on #224