### PR TITLE
rt-next: use nested interface names for contract imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64"
 version = "0.136.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64-meta"
 version = "0.136.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "cranelift-srcgen",
 ]
@@ -1029,7 +1029,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.136.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bitset"
 version = "0.136.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.136.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.136.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1090,12 +1090,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.136.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 
 [[package]]
 name = "cranelift-control"
 version = "0.136.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "arbitrary",
 ]
@@ -1103,7 +1103,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.136.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.136.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -1126,12 +1126,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.136.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 
 [[package]]
 name = "cranelift-native"
 version = "0.136.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "cranelift-srcgen"
 version = "0.136.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 
 [[package]]
 name = "crc32fast"
@@ -3140,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "pulley-interpreter"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "pulley-macros"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3794,6 +3794,8 @@ dependencies = [
  "console 0.16.1",
  "ignore",
  "miette",
+ "multibase",
+ "multihash",
  "serde_json",
  "sha2",
  "similar",
@@ -3932,6 +3934,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "wasm-encoder 0.254.0",
  "wasmtime",
  "wasmtime-wizer",
  "wit-component 0.254.0",
@@ -3988,6 +3991,7 @@ dependencies = [
  "test-log",
  "tokio",
  "tracing",
+ "wasm-encoder 0.254.0",
  "wasmtime",
  "wit-component 0.254.0",
 ]
@@ -4804,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
@@ -4856,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -4886,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-cache"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "base64",
  "directories-next",
@@ -4905,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-macro"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4919,12 +4923,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-util"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 
 [[package]]
 name = "wasmtime-internal-core"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -4935,7 +4939,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-cranelift"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-control",
@@ -4960,7 +4964,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-fiber"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "cc",
  "libc",
@@ -4973,7 +4977,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-debug"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "cc",
  "object 0.40.0",
@@ -4984,7 +4988,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "libc",
  "wasmtime-internal-core",
@@ -4994,7 +4998,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-unwinder"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -5005,7 +5009,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5015,7 +5019,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -5028,7 +5032,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wizer"
 version = "49.0.0-dev"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=56cce8cfef552f458c2044187ad2ba1512e3e2df#56cce8cfef552f458c2044187ad2ba1512e3e2df"
+source = "git+https://github.com/rvolosatovs/wasmtime?rev=6feef10795b32369f75220f241d08d896901cfb2#6feef10795b32369f75220f241d08d896901cfb2"
 dependencies = [
  "log",
  "wasm-encoder 0.258.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,8 @@ tracing-subscriber = { version = "0.3.23", default-features = false }
 wasm-encoder = "0.254.0"
 wasmprinter = "0.254.0"
 wasmparser = "0.254.0"
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "56cce8cfef552f458c2044187ad2ba1512e3e2df", default-features = false }
-wasmtime-wizer = { git = "https://github.com/bytecodealliance/wasmtime", rev = "56cce8cfef552f458c2044187ad2ba1512e3e2df", default-features = false }
+wasmtime = { git = "https://github.com/rvolosatovs/wasmtime", rev = "6feef10795b32369f75220f241d08d896901cfb2", default-features = false }
+wasmtime-wizer = { git = "https://github.com/rvolosatovs/wasmtime", rev = "6feef10795b32369f75220f241d08d896901cfb2", default-features = false }
 wit-component = "0.254.0"
 wit-parser = "0.254.0"
 zeroize = { version = "1.8.2", default-features = false }

--- a/docs/wit-worlds.mdx
+++ b/docs/wit-worlds.mdx
@@ -16,15 +16,21 @@ and coordination scripts defined in the contract.
 The shape of those imports and exports are described here and define the
 interface between the Starstream runtime (host) and Starstream contract (guest).
 
-Imports from other contracts use [`@external-id`][external-id] nodes containing
-the digest of the other contract in a form similar to `"sha256:$HEXDIGEST"`,
-followed by `:` and extra data if needed.
+Imports from other contracts use [nested interface names][nested-names] rooted
+at `starstream:contract/<contract-id>`, where `<contract-id>` is the digest of
+the other contract encoded as the [multibase] base32-lower encoding of its
+sha2-256 [multihash] — a 56-character lowercase alphanumeric label starting
+with `b`.
 
-{/* TODO: use https://multiformats.io/multihash/ ? */}
+Note that nested interface names are only expressible in the component binary
+format — the WIT text format does not support them, so the examples below use
+them in interface names as illustrative notation only.
 
 [raw-wit]: https://github.com/LFDT-Nightstream/Starstream/tree/main/starstream-to-wasm/wit
 [world]: https://component-model.bytecodealliance.org/design/worlds.html
-[external-id]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#import-and-export-definitions
+[nested-names]: https://github.com/WebAssembly/component-model/pull/372
+[multibase]: https://github.com/multiformats/multibase
+[multihash]: https://multiformats.io/multihash/
 
 ## Global builtins
 
@@ -66,8 +72,9 @@ world root {
 
 ## Importing Utxos
 
-Contracts which import Utxos do so by importing interfaces from `starstream:utxo`
-with the Utxo's name containing a `resource utxo`.
+Contracts which import Utxos do so by importing interfaces named
+`starstream:contract/<contract-id>/utxo/<utxo-name>` containing a
+`resource utxo`.
 If needed, the import may also include `downcast` and `upcast` methods, which
 the runtime will provide.
 
@@ -75,21 +82,18 @@ For example:
 
 ```wit
 world root {
-    import starstream:utxo/my-utxo;
+    import starstream:contract/bciqnar…omq/utxo/my-utxo;
 }
 
-package starstream:utxo {
-    @external-id("0123456789abcdef")
-    interface my-utxo {
-        use starstream:std/builtin.{utxo as builtin-utxo};
+interface starstream:contract/bciqnar…omq/utxo/my-utxo {
+    use starstream:std/builtin.{utxo as builtin-utxo};
 
-        resource utxo {
-            my-main-fn: static func() -> utxo;
-        }
-
-        downcast: func(self: borrow<builtin-utxo>) -> option<utxo>;
-        upcast: func(self: borrow<utxo>) -> builtin-utxo;
+    resource utxo {
+        my-main-fn: static func() -> utxo;
     }
+
+    downcast: func(self: borrow<builtin-utxo>) -> option<utxo>;
+    upcast: func(self: borrow<utxo>) -> builtin-utxo;
 }
 ```
 
@@ -99,8 +103,11 @@ will both export and import the Utxo interface.
 Using a Utxo from a coordination script in the same contract imports
 `starstream:self/<utxo-name>`.
 
-Importing a Utxo from another contract imports `starstream:utxo/<utxo-name>` and
-supplies `@external-id` on the `interface` with that contract's digest.
+Importing a Utxo from another contract imports
+`starstream:contract/<contract-id>/utxo/<utxo-name>`, where `<contract-id>` is
+that contract's digest and `<utxo-name>` is the name the Utxo is exported as by
+that contract. Nesting the contract digest in the interface name lets a
+contract import Utxos with the same name from multiple different contracts.
 
 ## Importing ABIs
 
@@ -170,20 +177,22 @@ world root {
 
 ## Importing coordination scripts
 
-Cross-contract coordination scripts are imported from an interface named
-`starstream:contract/scripts` with all coordination script functions needed.
-Each function has an `@external-id` with the digest of the contract it belongs
-to. For example:
+Cross-contract coordination scripts are imported from one interface per
+contract, named `starstream:contract/<contract-id>/scripts` and containing all
+coordination script functions needed from the contract with that digest.
+For example:
 
 ```wit
-interface starstream:contract/scripts {
-    @external-id("0123456789abcdef")
+interface starstream:contract/bciqnar…omq/scripts {
     foobar: func() -> s32;
 }
 world root {
-    import starstream:contract/scripts;
+    import starstream:contract/bciqnar…omq/scripts;
 }
 ```
+
+Nesting the contract digest in the interface name lets a contract import
+coordination scripts with the same name from multiple different contracts.
 
 ## Cardano support
 

--- a/starstream-cli/Cargo.toml
+++ b/starstream-cli/Cargo.toml
@@ -17,6 +17,8 @@ clap = { version = "4.5.32", features = ["derive"] }
 console = "0.16.0"
 ignore = "0.4.24"
 miette = { workspace = true, features = ["fancy"] }
+multibase = { workspace = true, features = ["std"] }
+multihash = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 similar = "2.7.0"

--- a/starstream-cli/src/run.rs
+++ b/starstream-cli/src/run.rs
@@ -46,13 +46,27 @@ struct UtxoCtx {
 struct Imports(HashMap<String, Contract<Ctx>>);
 
 impl ContractLookup<Ctx> for &Imports {
-    fn get_contract(&self, external_id: &str) -> wasmtime::Result<Contract<Ctx>> {
+    fn get_contract(&self, contract_id: &str) -> wasmtime::Result<Contract<Ctx>> {
         let contract = self
             .0
-            .get(external_id)
-            .with_context(|| format!("contract `{external_id}` not found"))?;
+            .get(contract_id)
+            .with_context(|| format!("contract `{contract_id}` not found"))?;
         Ok(contract.clone())
     }
+}
+
+/// The [multihash] code of sha2-256.
+///
+/// [multihash]: https://github.com/multiformats/multihash
+const MULTIHASH_SHA2_256: u64 = 0x12;
+
+/// Encode a raw SHA-256 contract digest in the canonical contract id form: the
+/// multibase base32-lower encoding of its sha2-256 multihash.
+fn contract_id(digest: &[u8; 32]) -> String {
+    let Ok(digest) = multihash::Multihash::<32>::wrap(MULTIHASH_SHA2_256, digest) else {
+        unreachable!();
+    };
+    multibase::encode(multibase::Base::Base32Lower, digest.to_bytes())
 }
 
 impl bindings::starstream::std::cardano::Host for Ctx {
@@ -180,6 +194,7 @@ async fn exec(
 ) -> wasmtime::Result<()> {
     let mut config = wasmtime::Config::new();
     config.wasm_component_model_implements(true);
+    config.wasm_component_model_nested_names(true);
     let engine = wasmtime::Engine::new(&config)?;
 
     let mut lookup = Imports::default();
@@ -191,10 +206,9 @@ async fn exec(
             Component::new(&engine, &wasm).context("failed to compile import contract")?;
         let contract = Contract::new(&component, &lookup)
             .with_context(|| format!("failed to load import contract `{}`", import.display()))?;
-        let digest = Sha256::digest(&wasm);
-        let digest = format!("{digest:02x}");
-        debug!(?digest, path = %import.display(), "imported contract");
-        lookup.0.insert(digest, contract);
+        let contract_id = contract_id(&Sha256::digest(&wasm).into());
+        debug!(?contract_id, path = %import.display(), "imported contract");
+        lookup.0.insert(contract_id, contract);
     }
 
     let wasm = fs::read(&wasm).await.context("failed to read contract")?;

--- a/starstream-ledger-node/src/main.rs
+++ b/starstream-ledger-node/src/main.rs
@@ -76,6 +76,7 @@ async fn main() -> anyhow::Result<()> {
 
     let mut config = wasmtime::Config::default();
     config.wasm_component_model_implements(true);
+    config.wasm_component_model_nested_names(true);
     let engine = wasmtime::Engine::new(&config)?;
 
     let ledger = Ledger::new(engine, max_requests, network, admin);

--- a/starstream-ledger/Cargo.toml
+++ b/starstream-ledger/Cargo.toml
@@ -67,6 +67,7 @@ wasmtime-wizer = { workspace = true, optional = true, features = [
 [dev-dependencies]
 starstream-compiler = { workspace = true }
 starstream-to-wasm = { workspace = true }
+wasm-encoder = { workspace = true }
 tokio = { workspace = true, features = [
     "io-util",
     "macros",

--- a/starstream-ledger/src/server/http/error.rs
+++ b/starstream-ledger/src/server/http/error.rs
@@ -116,9 +116,9 @@ pub enum ContractPutError {
     Http(http::Error),
     #[error("instrumentation failed: {0:#}")]
     Wizer(wasmtime::Error),
-    #[error("failed to parse `external-id` `{0}` as multibase multihash: {1}")]
+    #[error("failed to parse contract id `{0}` as multibase multihash: {1}")]
     ContractImportDigestParsing(Box<str>, DigestParseError),
-    #[error("contract import identified by `external-id` `{0}` not found")]
+    #[error("imported contract `{0}` not found")]
     ContractImportNotFound(Box<str>),
 }
 

--- a/starstream-ledger/src/server/http/mod.rs
+++ b/starstream-ledger/src/server/http/mod.rs
@@ -24,7 +24,7 @@ use hyper_util::server::graceful::GracefulShutdown;
 use mediatype::MediaType;
 use sha2::{Digest as _, Sha256};
 use starstream_runtime_next::{
-    CoordinationScriptImport, UtxoImport, get_coordination_script_instance_import, utxo_imports,
+    CoordinationScriptsImport, UtxoImport, coordination_script_imports, utxo_imports,
 };
 use tokio::net::TcpSocket;
 use tokio::sync::{Notify, TryAcquireError};
@@ -338,7 +338,6 @@ impl Ledger {
         let component = Component::from_binary(&self.engine, &contract_wasm)
             .map_err(ContractPutError::Runtime)?;
         let ty = component.component_type();
-        let script_instance = get_coordination_script_instance_import(&self.engine, &ty);
         let mut imports = HashMap::default();
         {
             let contracts = self.contracts.read().await;
@@ -346,36 +345,22 @@ impl Ledger {
                 return build_text_response(http::StatusCode::OK, "")
                     .map_err(ContractPutError::Http);
             }
-            for import in utxo_imports(&self.engine, &ty) {
-                let UtxoImport { external_id, .. } = import.map_err(ContractPutError::Runtime)?;
-                if imports.contains_key(external_id) {
+            let utxos =
+                utxo_imports(&self.engine, &ty).map(|UtxoImport { contract_id, .. }| contract_id);
+            let scripts = coordination_script_imports(&self.engine, &ty)
+                .map(|CoordinationScriptsImport { contract_id, .. }| contract_id);
+            for contract_id in utxos.chain(scripts) {
+                if imports.contains_key(contract_id) {
                     continue;
                 }
 
-                let digest = parse_digest(external_id).map_err(|err| {
-                    ContractPutError::ContractImportDigestParsing(external_id.into(), err)
+                let digest = parse_digest(contract_id).map_err(|err| {
+                    ContractPutError::ContractImportDigestParsing(contract_id.into(), err)
                 })?;
                 let contract = contracts
                     .get(&digest)
-                    .ok_or_else(|| ContractPutError::ContractImportNotFound(external_id.into()))?;
-                imports.insert(external_id, Arc::clone(contract));
-            }
-            if let Some(script_instance) = &script_instance {
-                for import in script_instance.coordination_scripts() {
-                    let CoordinationScriptImport { external_id, .. } =
-                        import.map_err(ContractPutError::Runtime)?;
-                    if imports.contains_key(external_id) {
-                        continue;
-                    }
-
-                    let digest = parse_digest(external_id).map_err(|err| {
-                        ContractPutError::ContractImportDigestParsing(external_id.into(), err)
-                    })?;
-                    let contract = contracts.get(&digest).ok_or_else(|| {
-                        ContractPutError::ContractImportNotFound(external_id.into())
-                    })?;
-                    imports.insert(external_id, Arc::clone(contract));
-                }
+                    .ok_or_else(|| ContractPutError::ContractImportNotFound(contract_id.into()))?;
+                imports.insert(contract_id, Arc::clone(contract));
             }
         }
 

--- a/starstream-ledger/src/server/lookup.rs
+++ b/starstream-ledger/src/server/lookup.rs
@@ -11,11 +11,11 @@ pub struct ContractLookup<'a>(pub &'a HashMap<&'a str, Arc<Contract>>);
 impl starstream_runtime_next::ContractLookup<Ctx> for ContractLookup<'_> {
     fn get_contract(
         &self,
-        external_id: &str,
+        contract_id: &str,
     ) -> wasmtime::Result<starstream_runtime_next::Contract<Ctx>> {
-        let contract = self.0.get(external_id).with_context(|| {
-            error!(external_id, "unresolved contract import");
-            format!("contract identified by `external-id` `{external_id}` not found")
+        let contract = self.0.get(contract_id).with_context(|| {
+            error!(contract_id, "unresolved contract import");
+            format!("imported contract `{contract_id}` not found")
         })?;
         Ok(contract.contract.clone())
     }

--- a/starstream-ledger/tests/ledger.rs
+++ b/starstream-ledger/tests/ledger.rs
@@ -51,6 +51,42 @@ fn compile_contract(source: &str) -> anyhow::Result<Vec<u8>> {
 
 const NETWORK: &str = "starstream:test";
 
+fn build_importing_component(contract_id: &str) -> Vec<u8> {
+    use wasm_encoder::{
+        ComponentImportSection, ComponentTypeRef, ComponentTypeSection, ComponentValType,
+        InstanceType, TypeBounds,
+    };
+
+    let mut component = wasm_encoder::Component::new();
+
+    let mut types = ComponentTypeSection::new();
+    let mut utxo = InstanceType::new();
+    utxo.export("utxo", ComponentTypeRef::Type(TypeBounds::SubResource));
+    types.instance(&utxo);
+    let mut scripts = InstanceType::new();
+    scripts
+        .ty()
+        .function()
+        .params([] as [(&str, ComponentValType); 0])
+        .result(None);
+    scripts.export("example", ComponentTypeRef::Func(0));
+    types.instance(&scripts);
+    component.section(&types);
+
+    let mut imports = ComponentImportSection::new();
+    imports.import(
+        format!("starstream:contract/{contract_id}/utxo/score-progress"),
+        ComponentTypeRef::Instance(0),
+    );
+    imports.import(
+        format!("starstream:contract/{contract_id}/scripts"),
+        ComponentTypeRef::Instance(1),
+    );
+    component.section(&imports);
+
+    component.finish()
+}
+
 static SCORE_WASM: LazyLock<Vec<u8>> =
     LazyLock::new(|| compile_contract(include_str!("../../examples/score.star")).unwrap());
 static SCORE_WASM_DIGEST: LazyLock<[u8; 32]> =
@@ -86,6 +122,7 @@ async fn http() -> anyhow::Result<()> {
 
     let mut config = wasmtime::Config::default();
     config.wasm_component_model_implements(true);
+    config.wasm_component_model_nested_names(true);
     let engine = wasmtime::Engine::new(&config)?;
 
     let ledger = Ledger::new(engine, 128, NETWORK, ADMIN.verifying_key());
@@ -221,6 +258,36 @@ async fn http() -> anyhow::Result<()> {
         headers.get(X_CONTENT_TYPE_OPTIONS).map(|v| v.as_bytes()),
         Some(b"nosniff".as_slice())
     );
+
+    let importing_wasm = build_importing_component(&encode_digest(&SCORE_WASM_DIGEST));
+    let importing_cost =
+        build_publish_envelope(ADMIN.clone(), NETWORK, 3, importing_wasm.as_slice())?.len();
+    client
+        .fund(
+            ADMIN.clone(),
+            3,
+            &ADMIN.verifying_key(),
+            (importing_cost * 2 + 1024) as _,
+        )
+        .await?;
+    client
+        .publish_contract(ADMIN.clone(), 3, importing_wasm.as_slice())
+        .await
+        .context("failed to publish contract importing score")?;
+
+    let unknown_id = encode_digest(&[0x55; 32]);
+    let missing_import_wasm = build_importing_component(&unknown_id);
+    let req = build_contract_publish_request(
+        &api_base,
+        ADMIN.clone(),
+        NETWORK,
+        4,
+        missing_import_wasm.as_slice(),
+    )?;
+    let (http::response::Parts { status, .. }, body) = http_request(&http, req).await?;
+    let body = String::from_utf8_lossy(&body);
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+    assert_eq!(body, format!("imported contract `{unknown_id}` not found"));
 
     shutdown.notify_one();
     ledger.await.context("ledger task panicked")

--- a/starstream-runtime-next/Cargo.toml
+++ b/starstream-runtime-next/Cargo.toml
@@ -24,6 +24,7 @@ wasmtime = { workspace = true, features = [
 
 [dev-dependencies]
 sha2 = { workspace = true }
+wasm-encoder = { workspace = true }
 starstream-compiler = { workspace = true }
 starstream-to-wasm = { workspace = true }
 test-log = { workspace = true, features = ["color", "trace"] }

--- a/starstream-runtime-next/src/lib.rs
+++ b/starstream-runtime-next/src/lib.rs
@@ -8,7 +8,7 @@ use wasmtime::component::{
     LinkerInstance, Resource, ResourceAny, ResourceTable, ResourceType, Type, Val, types,
 };
 use wasmtime::error::Context as _;
-use wasmtime::{AsContextMut, Engine, StoreContextMut, bail, ensure, format_err};
+use wasmtime::{AsContextMut, Engine, StoreContextMut, bail, ensure};
 
 pub mod bindings {
     // NOTE: `starstream:std/{builtin,utxo-context}` bindings are hand-written
@@ -27,10 +27,48 @@ pub mod bindings {
     });
 }
 
+/// Cross-contract imports use nested interface names rooted at the
+/// `starstream:contract` package:
+///
+/// - `starstream:contract/<contract-id>/utxo/<name>` — the typed UTXO exported
+///   as `<name>` by the dependency contract identified by `<contract-id>`.
+/// - `starstream:contract/<contract-id>/scripts` — the coordination scripts of
+///   the dependency contract identified by `<contract-id>`, exported as plain
+///   functions by the imported instance.
+///
+/// `<contract-id>` is the canonical contract digest label: the multibase
+/// base32-lower encoding of the sha2-256 multihash of the contract Wasm.
+/// The runtime treats it as an opaque string and passes it to
+/// [`ContractLookup::get_contract`] verbatim.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ContractImportName<'a> {
+    Utxo { contract_id: &'a str, name: &'a str },
+    Scripts { contract_id: &'a str },
+}
+
+fn parse_contract_import_name(name: &str) -> Option<ContractImportName<'_>> {
+    let rest = name.strip_prefix("starstream:contract/")?;
+    let mut segments = rest.split('/');
+    match (
+        segments.next(),
+        segments.next(),
+        segments.next(),
+        segments.next(),
+    ) {
+        (Some(contract_id), Some("scripts"), None, None) => {
+            Some(ContractImportName::Scripts { contract_id })
+        }
+        (Some(contract_id), Some("utxo"), Some(name), None) => {
+            Some(ContractImportName::Utxo { contract_id, name })
+        }
+        _ => None,
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct UtxoImport<'a> {
     pub name: &'a str,
-    pub external_id: &'a str,
+    pub contract_id: &'a str,
     pub ty: types::ComponentInstance,
 }
 
@@ -39,94 +77,53 @@ pub struct UtxoImport<'a> {
 pub fn utxo_imports<'a>(
     engine: &'a Engine,
     ty: &'a types::Component,
-) -> impl Iterator<Item = wasmtime::Result<UtxoImport<'a>>> {
-    ty.imports(engine).filter_map(
-        |(
-            name,
-            types::ComponentExtern {
-                ty, external_id, ..
-            },
-        )| {
+) -> impl Iterator<Item = UtxoImport<'a>> {
+    ty.imports(engine)
+        .filter_map(|(name, types::ComponentExtern { ty, .. })| {
             let types::ComponentItem::ComponentInstance(ty) = ty else {
                 return None;
             };
-            let ("starstream:utxo", name) = name.split_once('/')? else {
-                return None;
-            };
-            if let Some(external_id) = external_id {
-                Some(Ok(UtxoImport {
+            match parse_contract_import_name(name)? {
+                ContractImportName::Utxo { contract_id, name } => Some(UtxoImport {
                     name,
-                    external_id,
+                    contract_id,
                     ty,
-                }))
-            } else {
-                Some(Err(format_err!(
-                    "`external-id` missing for UTXO import `{name}`"
-                )))
+                }),
+                ContractImportName::Scripts { .. } => None,
             }
-        },
-    )
+        })
 }
 
 #[derive(Clone, Debug)]
-pub struct CoordinationScriptImport<'a> {
-    pub name: &'a str,
-    pub external_id: &'a str,
-    pub ty: types::ComponentFunc,
+pub struct CoordinationScriptsImport<'a> {
+    pub contract_id: &'a str,
+    pub ty: types::ComponentInstance,
 }
 
-pub struct CoordinationScriptInstanceImport<'a> {
-    engine: &'a Engine,
-    ty: types::ComponentInstance,
-}
-
-impl<'a> CoordinationScriptInstanceImport<'a> {
-    /// Iterate over coordination scripts exported by this [ContractInstanceImport].
-    pub fn coordination_scripts<'b: 'a>(
-        &'b self,
-    ) -> impl Iterator<Item = wasmtime::Result<CoordinationScriptImport<'b>>> {
-        self.ty.exports(self.engine).filter_map(
-            |(
-                name,
-                types::ComponentExtern {
-                    ty, external_id, ..
-                },
-            )| {
-                let types::ComponentItem::ComponentFunc(ty) = ty else {
-                    return None;
-                };
-                if let Some(external_id) = external_id {
-                    Some(Ok(CoordinationScriptImport {
-                        name,
-                        external_id,
-                        ty,
-                    }))
-                } else {
-                    Some(Err(format_err!(
-                        "`external-id` missing for coordination script import `{name}`"
-                    )))
-                }
-            },
-        )
-    }
-}
-
-/// Lookup a `starstream:contract` instance import.
+/// Iterate over per-contract coordination script instances imported by this
+/// [Contract].
 #[instrument(level = "trace", skip_all)]
-pub fn get_coordination_script_instance_import<'a>(
+pub fn coordination_script_imports<'a>(
     engine: &'a Engine,
-    ty: &types::Component,
-) -> Option<CoordinationScriptInstanceImport<'a>> {
-    let types::ComponentExtern { ty, .. } = ty.get_import(engine, "starstream:contract/scripts")?;
-    let types::ComponentItem::ComponentInstance(ty) = ty else {
-        return None;
-    };
-    Some(CoordinationScriptInstanceImport { engine, ty })
+    ty: &'a types::Component,
+) -> impl Iterator<Item = CoordinationScriptsImport<'a>> {
+    ty.imports(engine)
+        .filter_map(|(name, types::ComponentExtern { ty, .. })| {
+            let types::ComponentItem::ComponentInstance(ty) = ty else {
+                return None;
+            };
+            match parse_contract_import_name(name)? {
+                ContractImportName::Scripts { contract_id } => {
+                    Some(CoordinationScriptsImport { contract_id, ty })
+                }
+                ContractImportName::Utxo { .. } => None,
+            }
+        })
 }
 
 pub trait ContractLookup<T> {
-    /// Lookup a contract by `external_id`
-    fn get_contract(&self, external_id: &str) -> wasmtime::Result<Contract<T>>;
+    /// Lookup a contract by `contract_id`
+    fn get_contract(&self, contract_id: &str) -> wasmtime::Result<Contract<T>>;
 }
 
 pub trait Host: bindings::starstream::std::cardano::Host + Send + Sized + 'static {
@@ -618,30 +615,18 @@ fn link_coordination_script_function<T: Host>(
 }
 
 /// Link coordination script instance in a [`LinkerInstance`].
-#[instrument(level = "trace", skip(engine, linker, contracts, ty))]
+#[instrument(level = "trace", skip(engine, linker, contract, ty))]
 fn link_coordination_script_instance<T: Host>(
     engine: &Engine,
     linker: &mut LinkerInstance<T>,
-    contracts: &impl ContractLookup<T>,
+    contract: &Contract<T>,
     ty: &types::ComponentInstance,
 ) -> wasmtime::Result<()> {
-    for (
-        name,
-        types::ComponentExtern {
-            ty, external_id, ..
-        },
-    ) in ty.exports(engine)
-    {
+    for (name, types::ComponentExtern { ty, .. }) in ty.exports(engine) {
         debug!(name, "linking coordination script instance item");
         match ty {
             types::ComponentItem::ComponentFunc(..) => {
-                let external_id = external_id.with_context(|| {
-                    format!("`external-id` missing for coordination script import `{name}`")
-                })?;
-                let contract = contracts.get_contract(external_id).with_context(|| {
-                    format!("failed to get contract for coordination script import `{name}`")
-                })?;
-                link_coordination_script_function(contract, linker, name)?;
+                link_coordination_script_function(contract.clone(), linker, name)?;
             }
             types::ComponentItem::CoreFunc(..) => {
                 bail!("coordination script instance core function imports unsupported")
@@ -673,7 +658,6 @@ fn link_instance<T: Host>(
     contracts: &impl ContractLookup<T>,
     ty: &types::ComponentInstance,
     name: &str,
-    external_id: Option<&str>,
 ) -> wasmtime::Result<()> {
     debug_assert!(!name.starts_with("starstream:std"));
 
@@ -683,15 +667,6 @@ fn link_instance<T: Host>(
         ty.get_export(engine, "utxo"),
         ty.get_export(engine, "token"),
     ) {
-        (Some(("starstream:utxo", name)), ..) => {
-            let external_id = external_id
-                .with_context(|| format!("`external-id` missing for typed UTXO import `{name}`"))?;
-            let contract = contracts.get_contract(external_id).with_context(|| {
-                format!("failed to get contract for typed UTXO import `{name}`")
-            })?;
-            link_typed_utxo_instance(ContractImportTarget::External(contract), linker, ty, name)
-        }
-
         (
             Some(("starstream:self", name)),
             Some(types::ComponentExtern {
@@ -744,9 +719,21 @@ fn link_instance<T: Host>(
             link_dynamic_utxo_instance(engine, linker, ty)
         }
 
-        (Some(("starstream:contract", "scripts")), ..) => {
-            link_coordination_script_instance(engine, linker, contracts, ty)
-        }
+        (Some(("starstream:contract", ..)), ..) => match parse_contract_import_name(name) {
+            Some(ContractImportName::Utxo { contract_id, name }) => {
+                let contract = contracts.get_contract(contract_id).with_context(|| {
+                    format!("failed to get contract `{contract_id}` for typed UTXO import `{name}`")
+                })?;
+                link_typed_utxo_instance(ContractImportTarget::External(contract), linker, ty, name)
+            }
+            Some(ContractImportName::Scripts { contract_id }) => {
+                let contract = contracts.get_contract(contract_id).with_context(|| {
+                    format!("failed to get contract `{contract_id}` for coordination script import")
+                })?;
+                link_coordination_script_instance(engine, linker, &contract, ty)
+            }
+            None => bail!("unexpected `starstream:contract` instance import `{name}`"),
+        },
 
         _ => bail!("unexpected instance import `{name}`"),
     }
@@ -760,12 +747,8 @@ fn link_imports<T: Host>(
     linker: &mut Linker<T>,
     contracts: &impl ContractLookup<T>,
 ) -> wasmtime::Result<()> {
-    for (
-        name,
-        types::ComponentExtern {
-            ty, external_id, ..
-        },
-    ) in component.component_type().imports(component.engine())
+    for (name, types::ComponentExtern { ty, .. }) in
+        component.component_type().imports(component.engine())
     {
         match ty {
             types::ComponentItem::ComponentFunc(..) => {
@@ -785,15 +768,7 @@ fn link_imports<T: Host>(
                     .instance(name)
                     .with_context(|| format!("failed to instantiate `{name}` in the linker"))?;
                 debug!(?name, "linking root instance");
-                link_instance(
-                    contract,
-                    component,
-                    &mut linker,
-                    contracts,
-                    &ty,
-                    name,
-                    external_id,
-                )?;
+                link_instance(contract, component, &mut linker, contracts, &ty, name)?;
             }
             types::ComponentItem::Type(..) => {}
             types::ComponentItem::Resource(..) => {

--- a/starstream-runtime-next/tests/common/mod.rs
+++ b/starstream-runtime-next/tests/common/mod.rs
@@ -15,6 +15,7 @@ use wit_component::ComponentEncoder;
 pub static ENGINE: LazyLock<wasmtime::Engine> = LazyLock::new(|| {
     let mut config = wasmtime::Config::default();
     let config = config.wasm_component_model_implements(true);
+    let config = config.wasm_component_model_nested_names(true);
     wasmtime::Engine::new(config).expect("failed to construct engine")
 });
 
@@ -61,8 +62,8 @@ pub fn method_hash(name: &str) -> (u64, u64, u64, u64) {
 pub struct NoopContractLookup;
 
 impl<T> ContractLookup<T> for NoopContractLookup {
-    fn get_contract(&self, external_id: &str) -> wasmtime::Result<Contract<T>> {
-        bail!("contract with external_id `{external_id}` unknown")
+    fn get_contract(&self, contract_id: &str) -> wasmtime::Result<Contract<T>> {
+        bail!("contract `{contract_id}` unknown")
     }
 }
 

--- a/starstream-runtime-next/tests/contract_imports.rs
+++ b/starstream-runtime-next/tests/contract_imports.rs
@@ -1,0 +1,113 @@
+pub mod common;
+
+use std::sync::LazyLock;
+
+use starstream_runtime_next::{
+    Contract, ContractLookup, CoordinationScriptsImport, UtxoImport, coordination_script_imports,
+    utxo_imports,
+};
+use wasm_encoder::{
+    ComponentImportSection, ComponentTypeRef, ComponentTypeSection, InstanceType, TypeBounds,
+};
+use wasmtime::component::Component;
+use wasmtime::error::Context as _;
+use wasmtime::{bail, ensure};
+
+use crate::common::{Ctx, ENGINE, NoopContractLookup, compile_contract};
+
+static DEP: LazyLock<Component> =
+    LazyLock::new(|| compile_contract(include_str!("../../examples/score.star")).unwrap());
+
+const DEP_A: &str = "bdepa";
+const DEP_B: &str = "bdepb";
+
+struct Lookup(Contract<Ctx>);
+
+impl ContractLookup<Ctx> for Lookup {
+    fn get_contract(&self, contract_id: &str) -> wasmtime::Result<Contract<Ctx>> {
+        ensure!(
+            matches!(contract_id, DEP_A | DEP_B),
+            "unexpected contract id `{contract_id}`"
+        );
+        Ok(self.0.clone())
+    }
+}
+
+fn build_importing_component() -> Vec<u8> {
+    let mut component = wasm_encoder::Component::new();
+
+    let mut types = ComponentTypeSection::new();
+    let mut utxo = InstanceType::new();
+    utxo.export("utxo", ComponentTypeRef::Type(TypeBounds::SubResource));
+    types.instance(&utxo);
+    let mut scripts = InstanceType::new();
+    scripts
+        .ty()
+        .function()
+        .params([] as [(&str, wasm_encoder::ComponentValType); 0])
+        .result(None);
+    scripts.export("example", ComponentTypeRef::Func(0));
+    types.instance(&scripts);
+    component.section(&types);
+
+    let mut imports = ComponentImportSection::new();
+    for dep in [DEP_A, DEP_B] {
+        imports.import(
+            format!("starstream:contract/{dep}/utxo/score-progress"),
+            ComponentTypeRef::Instance(0),
+        );
+        imports.import(
+            format!("starstream:contract/{dep}/scripts"),
+            ComponentTypeRef::Instance(1),
+        );
+    }
+    component.section(&imports);
+
+    component.finish()
+}
+
+#[test_log::test]
+fn contract_imports() -> wasmtime::Result<()> {
+    let dep = Contract::new(&DEP, NoopContractLookup).context("failed to create dep contract")?;
+
+    let wasm = build_importing_component();
+    let component =
+        Component::from_binary(&ENGINE, &wasm).context("failed to compile importing component")?;
+    let ty = component.component_type();
+
+    let mut utxos = utxo_imports(&ENGINE, &ty);
+    match (utxos.next(), utxos.next(), utxos.next()) {
+        (
+            Some(UtxoImport {
+                name: "score-progress",
+                contract_id: DEP_A,
+                ..
+            }),
+            Some(UtxoImport {
+                name: "score-progress",
+                contract_id: DEP_B,
+                ..
+            }),
+            None,
+        ) => {}
+        imports => bail!("unexpected UTXO imports: {imports:?}"),
+    }
+
+    let mut scripts = coordination_script_imports(&ENGINE, &ty);
+    match (scripts.next(), scripts.next(), scripts.next()) {
+        (
+            Some(CoordinationScriptsImport {
+                contract_id: DEP_A, ..
+            }),
+            Some(CoordinationScriptsImport {
+                contract_id: DEP_B, ..
+            }),
+            None,
+        ) => {}
+        imports => bail!("unexpected coordination script imports: {imports:?}"),
+    }
+
+    let _contract =
+        Contract::new(&component, Lookup(dep)).context("failed to link importing component")?;
+    Ok(())
+}

--- a/starstream-runtime-next/tests/score.rs
+++ b/starstream-runtime-next/tests/score.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, LazyLock, Mutex};
 
 use starstream_runtime_next::{
     Contract, CoordinationScriptExport, Host, MethodExport, StorageExport, Utxo, UtxoExport,
-    UtxoMainExport, get_coordination_script_instance_import, utxo_imports,
+    UtxoMainExport, coordination_script_imports, utxo_imports,
 };
 use tracing::{Instrument as _, info_span, instrument};
 use wasmtime::component::{Component, Resource, ResourceTable, Val};
@@ -551,7 +551,7 @@ async fn score_main_new() -> wasmtime::Result<()> {
 #[test_log::test(tokio::test)]
 async fn score_script_example() -> wasmtime::Result<()> {
     let ty = CONTRACT.component_type();
-    assert!(get_coordination_script_instance_import(&ENGINE, &ty).is_none());
+    assert!(coordination_script_imports(&ENGINE, &ty).next().is_none());
     assert!(utxo_imports(&ENGINE, &ty).next().is_none());
 
     let contract =

--- a/starstream-runtime-next/tests/token_mint_burn.rs
+++ b/starstream-runtime-next/tests/token_mint_burn.rs
@@ -4,8 +4,8 @@ use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
 use starstream_runtime_next::{
-    Contract, Host, StorageExport, Token, TokenFunctionExport,
-    get_coordination_script_instance_import, utxo_imports,
+    Contract, Host, StorageExport, Token, TokenFunctionExport, coordination_script_imports,
+    utxo_imports,
 };
 use tracing::{Instrument as _, info_span};
 use wasmtime::component::{Component, ResourceTable, Val};
@@ -98,7 +98,7 @@ async fn get_my_token_storage(
 #[test_log::test(tokio::test)]
 async fn token_mint_burn() -> wasmtime::Result<()> {
     let ty = CONTRACT.component_type();
-    assert!(get_coordination_script_instance_import(&ENGINE, &ty).is_none());
+    assert!(coordination_script_imports(&ENGINE, &ty).next().is_none());
     assert!(utxo_imports(&ENGINE, &ty).next().is_none());
 
     let contract =


### PR DESCRIPTION
This is an LLM-generated PoC of using component model nested interfaces in Starstream.

This is not meant to be merged and/or reviewed. The only purpose of this is for us to evaluate the approach and figure out whether we want to move in this direction.

LLM-generated description below

Identify cross-contract imports by nesting the dependency contract's digest in the import name, per the component-model nested-names extension (WebAssembly/component-model#372), instead of `external-id` name options:

- `starstream:contract/<contract-id>/utxo/<name>` replaces `starstream:utxo/<name>` + `external-id`
- `starstream:contract/<contract-id>/scripts` (one instance per dependency) replaces the single `starstream:contract/scripts` instance with per-function `external-id`s

`<contract-id>` is the canonical contract digest label already used by the ledger: the multibase base32-lower encoding of the sha2-256 multihash of the contract Wasm, which is a valid component-model label.

The previous flat scheme could not represent importing a UTXO or a coordination script with the same name from two different contracts; with the contract digest nested in the interface name such imports get distinct names, and the `external-id` mechanism is no longer needed for contract identity.

Bump the `wasmtime`/`wasmtime-wizer` pin to a rev that allows enabling the `cm-nested-names` validation feature
(`Config::wasm_component_model_nested_names`).

Assisted-by: anthropic:claude-fable-5